### PR TITLE
Add OSGi Metadata Generation

### DIFF
--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -20,6 +20,50 @@
 		<developerConnection>git@github.com/modelcontextprotocol/java-sdk.git</developerConnection>
 	</scm>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<version>${bnd-maven-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>bnd-process</id>
+						<goals>
+							<goal>bnd-process</goal>
+						</goals>
+						<configuration>
+							<bnd><![CDATA[
+								Bundle-Name:            Bundle ${project.groupId} : ${project.artifactId}
+								version:                ${versionmask;===;${version_cleanup;${project.version}}}
+								Bundle-SymbolicName:    ${project.groupId}.${project.artifactId}
+								Bundle-Version:         ${version}
+								Automatic-Module-Name:  ${project.groupId}.${project.artifactId}
+								Import-Package:         jakarta.*;resolution:=optional, \
+								                        *;
+								Export-Package:         io.modelcontextprotocol.*;version="${version}";-noimport:=true
+								-noimportjava:          true;
+								-nouses:                true;
+								-removeheaders:         Private-Package
+								]]>
+							</bnd>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+					</archive>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
 	<dependencies>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
 		<tomcat.version>11.0.2</tomcat.version>
 		<jakarta.servlet.version>6.1.0</jakarta.servlet.version>
 		<awaitility.version>4.2.0</awaitility.version>
+		<bnd-maven-plugin.version>7.1.0</bnd-maven-plugin.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
## Motivation and Context
Added OSGi metadata generation support using the bnd-maven-plugin to enable proper OSGi bundle creation. This change allows the SDK to be used in OSGi environments while maintaining compatibility with regular Java applications. The generated metadata includes:

- Proper bundle naming and versioning
- Explicit package exports with versions
- Optional dependencies for Jakarta
- Version ranges for required dependencies
- Java 17 capability requirement

## How Has This Been Tested?
- Verified MANIFEST.MF generation with Maven build
- Validated package exports and imports with correct versions

## Breaking Changes
No breaking changes. This enhancement is completely backwards compatible:
- Non-OSGi users are unaffected
- Existing Maven builds continue to work as before
- No API changes or runtime behavior modifications

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
The implementation uses bnd-maven-plugin 7.1.0 for metadata generation.

## Example MANIFEST.MF with the current configuration
```text
Manifest-Version: 1.0
Build-Jdk-Spec: 21
Created-By: 21.0.5 (Eclipse Adoptium)
Implementation-Title: mcp
Implementation-Version: 0.8.0-SNAPSHOT
Automatic-Module-Name: io.modelcontextprotocol.sdk.mcp
Bnd-LastModified: 1739627714629
Bundle-Description: Java SDK implementation of the Model Context Protocol, enabling seamless integration with language models and AI tools
Bundle-DocURL: https://github.com/modelcontextprotocol/java-sdk
Bundle-License: "MIT License";link="http://www.opensource.org/licenses/mit-license.php"
Bundle-ManifestVersion: 2
Bundle-Name: Bundle io.modelcontextprotocol.sdk : mcp
Bundle-SCM: url="https://github.com/modelcontextprotocol/java-sdk",connection="git://github.com/modelcontextprotocol/java-sdk.git",developer-connection="git@github.com/modelcontextprotocol/java-sdk.git",tag=HEAD
Bundle-SymbolicName: io.modelcontextprotocol.sdk.mcp
Bundle-Vendor: Anthropic
Bundle-Version: 0.8.0.SNAPSHOT
Export-Package:
 io.modelcontextprotocol.client;version="0.8.0.SNAPSHOT"
 io.modelcontextprotocol.client.transport;version="0.8.0.SNAPSHOT"
 io.modelcontextprotocol.server;version="0.8.0.SNAPSHOT"
 io.modelcontextprotocol.server.transport;version="0.8.0.SNAPSHOT"
 io.modelcontextprotocol.spec;version="0.8.0.SNAPSHOT"
 io.modelcontextprotocol.util;version="0.8.0.SNAPSHOT"
Import-Package:
 org.slf4j;version="[2.0,3)"
 jakarta.servlet;resolution:=optional;version="[6.1,7)"
 jakarta.servlet.annotation;resolution:=optional;version="[6.1,7)"
 jakarta.servlet.http;resolution:=optional;version="[6.1,7)"
 com.fasterxml.jackson.annotation;version="[2.17,3)"
 com.fasterxml.jackson.core.type;version="[2.17,3)"
 com.fasterxml.jackson.databind;version="[2.17,3)"
 org.reactivestreams;version="[1.0,2)"
 reactor.core;version="[3.7,4)"
 reactor.core.publisher;version="[3.7,4)"
 reactor.core.scheduler;version="[3.7,4)"
 reactor.util.annotation;version="[3.7,4)"
 reactor.util.context;version="[3.7,4)"
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
Tool: Bnd-7.1.0.202411251545
```