### PR TITLE
refactor(client): improve validation and remove server methods

### DIFF
--- a/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
@@ -274,9 +274,6 @@ public abstract class AbstractMcpAsyncClientTests {
 
 		assertThatCode(() -> {
 			client.initialize().block();
-			// Trigger notifications
-			client.sendResourcesListChanged().block();
-			client.promptListChangedNotification().block();
 			client.closeGracefully().block();
 		}).doesNotThrowAnyException();
 	}

--- a/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
@@ -258,9 +258,6 @@ public abstract class AbstractMcpSyncClientTests {
 
 		assertThatCode(() -> {
 			client.initialize();
-			// Trigger notifications
-			client.sendResourcesListChanged();
-			client.promptListChangedNotification();
 			client.close();
 		}).doesNotThrowAnyException();
 	}

--- a/mcp/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
@@ -297,6 +297,14 @@ public class McpAsyncClient {
 	}
 
 	/**
+	 * Check if the client-server connection is initialized.
+	 * @return true if the client-server connection is initialized
+	 */
+	public boolean isInitialized() {
+		return this.serverCapabilities != null;
+	}
+
+	/**
 	 * Get the client capabilities that define the supported features and functionality.
 	 * @return The client capabilities
 	 */
@@ -456,6 +464,12 @@ public class McpAsyncClient {
 	 * (false/absent)
 	 */
 	public Mono<McpSchema.CallToolResult> callTool(McpSchema.CallToolRequest callToolRequest) {
+		if (!this.isInitialized()) {
+			return Mono.error(new McpError("Client must be initialized before calling tools"));
+		}
+		if (this.serverCapabilities.tools() == null) {
+			return Mono.error(new McpError("Server does not provide tools capability"));
+		}
 		return this.mcpSession.sendRequest(McpSchema.METHOD_TOOLS_CALL, callToolRequest, CALL_TOOL_RESULT_TYPE_REF);
 	}
 
@@ -477,6 +491,12 @@ public class McpAsyncClient {
 	 * Optional cursor for pagination if more tools are available
 	 */
 	public Mono<McpSchema.ListToolsResult> listTools(String cursor) {
+		if (!this.isInitialized()) {
+			return Mono.error(new McpError("Client must be initialized before calling tools"));
+		}
+		if (this.serverCapabilities.tools() == null) {
+			return Mono.error(new McpError("Server does not provide tools capability"));
+		}
 		return this.mcpSession.sendRequest(McpSchema.METHOD_TOOLS_LIST, new McpSchema.PaginatedRequest(cursor),
 				LIST_TOOLS_RESULT_TYPE_REF);
 	}
@@ -532,6 +552,12 @@ public class McpAsyncClient {
 	 * @return A Mono that completes with the list of resources result
 	 */
 	public Mono<McpSchema.ListResourcesResult> listResources(String cursor) {
+		if (!this.isInitialized()) {
+			return Mono.error(new McpError("Client must be initialized before calling tools"));
+		}
+		if (this.serverCapabilities.resources() == null) {
+			return Mono.error(new McpError("Server does not provide the resources capability"));
+		}
 		return this.mcpSession.sendRequest(McpSchema.METHOD_RESOURCES_LIST, new McpSchema.PaginatedRequest(cursor),
 				LIST_RESOURCES_RESULT_TYPE_REF);
 	}
@@ -551,6 +577,12 @@ public class McpAsyncClient {
 	 * @return A Mono that completes with the resource content
 	 */
 	public Mono<McpSchema.ReadResourceResult> readResource(McpSchema.ReadResourceRequest readResourceRequest) {
+		if (!this.isInitialized()) {
+			return Mono.error(new McpError("Client must be initialized before calling tools"));
+		}
+		if (this.serverCapabilities.resources() == null) {
+			return Mono.error(new McpError("Server does not provide the resources capability"));
+		}
 		return this.mcpSession.sendRequest(McpSchema.METHOD_RESOURCES_READ, readResourceRequest,
 				READ_RESOURCE_RESULT_TYPE_REF);
 	}
@@ -575,17 +607,14 @@ public class McpAsyncClient {
 	 * @return A Mono that completes with the list of resource templates result
 	 */
 	public Mono<McpSchema.ListResourceTemplatesResult> listResourceTemplates(String cursor) {
+		if (!this.isInitialized()) {
+			return Mono.error(new McpError("Client must be initialized before calling tools"));
+		}
+		if (this.serverCapabilities.resources() == null) {
+			return Mono.error(new McpError("Server does not provide the resources capability"));
+		}
 		return this.mcpSession.sendRequest(McpSchema.METHOD_RESOURCES_TEMPLATES_LIST,
 				new McpSchema.PaginatedRequest(cursor), LIST_RESOURCE_TEMPLATES_RESULT_TYPE_REF);
-	}
-
-	/**
-	 * List Changed Notification. When the list of available resources changes, servers
-	 * that declared the listChanged capability SHOULD send a notification.
-	 * @return A Mono that completes when the notification is sent
-	 */
-	public Mono<Void> sendResourcesListChanged() {
-		return this.mcpSession.sendNotification(McpSchema.METHOD_NOTIFICATION_RESOURCES_LIST_CHANGED);
 	}
 
 	/**
@@ -658,16 +687,6 @@ public class McpAsyncClient {
 	 */
 	public Mono<GetPromptResult> getPrompt(GetPromptRequest getPromptRequest) {
 		return this.mcpSession.sendRequest(McpSchema.METHOD_PROMPT_GET, getPromptRequest, GET_PROMPT_RESULT_TYPE_REF);
-	}
-
-	/**
-	 * (Server) An optional notification from the server to the client, informing it that
-	 * the list of prompts it offers has changed. This may be issued by servers without
-	 * any previous subscription from the client.
-	 * @return A Mono that completes when the notification is sent
-	 */
-	public Mono<Void> promptListChangedNotification() {
-		return this.mcpSession.sendNotification(McpSchema.METHOD_NOTIFICATION_PROMPTS_LIST_CHANGED);
 	}
 
 	private NotificationHandler asyncPromptsChangeNotificationHandler(

--- a/mcp/src/main/java/io/modelcontextprotocol/client/McpSyncClient.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/McpSyncClient.java
@@ -285,14 +285,6 @@ public class McpSyncClient implements AutoCloseable {
 	}
 
 	/**
-	 * List Changed Notification. When the list of available resources changes, servers
-	 * that declared the listChanged capability SHOULD send a notification:
-	 */
-	public void sendResourcesListChanged() {
-		this.delegate.sendResourcesListChanged().block();
-	}
-
-	/**
 	 * Subscriptions. The protocol supports optional subscriptions to resource changes.
 	 * Clients can subscribe to specific resources and receive notifications when they
 	 * change.
@@ -327,15 +319,6 @@ public class McpSyncClient implements AutoCloseable {
 
 	public GetPromptResult getPrompt(GetPromptRequest getPromptRequest) {
 		return this.delegate.getPrompt(getPromptRequest).block();
-	}
-
-	/**
-	 * (Server) An optional notification from the server to the client, informing it that
-	 * the list of prompts it offers has changed. This may be issued by servers without
-	 * any previous subscription from the client.
-	 */
-	public void promptListChangedNotification() {
-		this.delegate.promptListChangedNotification().block();
 	}
 
 	/**

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -192,9 +192,13 @@ public class McpAsyncServer {
 					initializeRequest.protocolVersion(), initializeRequest.capabilities(),
 					initializeRequest.clientInfo());
 
+			// The server MUST respond with the highest protocol version it supports if
+			// it does not support the requested (e.g. Client) version.
 			String serverProtocolVersion = this.protocolVersions.get(this.protocolVersions.size() - 1);
 
 			if (this.protocolVersions.contains(initializeRequest.protocolVersion())) {
+				// If the server supports the requested protocol version, it MUST respond
+				// with the same version.
 				serverProtocolVersion = initializeRequest.protocolVersion();
 			}
 			else {

--- a/mcp/src/test/java/io/modelcontextprotocol/MockMcpTransport.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/MockMcpTransport.java
@@ -38,6 +38,13 @@ public class MockMcpTransport implements ClientMcpTransport, ServerMcpTransport 
 			throw new RuntimeException("Failed to emit message " + message);
 		}
 		inboundMessageCount.incrementAndGet();
+
+		try {
+			Thread.sleep(200);
+		}
+		catch (InterruptedException e) {
+			e.printStackTrace();
+		}
 	}
 
 	@Override

--- a/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
@@ -275,9 +275,6 @@ public abstract class AbstractMcpAsyncClientTests {
 
 		assertThatCode(() -> {
 			client.initialize().block();
-			// Trigger notifications
-			client.sendResourcesListChanged().block();
-			client.promptListChangedNotification().block();
 			client.closeGracefully().block();
 		}).doesNotThrowAnyException();
 	}

--- a/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
@@ -259,9 +259,6 @@ public abstract class AbstractMcpSyncClientTests {
 
 		assertThatCode(() -> {
 			client.initialize();
-			// Trigger notifications
-			client.sendResourcesListChanged();
-			client.promptListChangedNotification();
 			client.close();
 		}).doesNotThrowAnyException();
 	}


### PR DESCRIPTION
Add client initialization and capability validation checks

- New isInitialized() method to check client state
- Validate server capabilities before tool/resource operations
- Add clear error messages for common failure cases
- Remove server-side notification methods from client: sendResourcesListChanged(), promptListChangedNotification()
- Improve protocol version handling
- Testing improvements and new initialization tests

Resolves #13