### PR TITLE
Remove closed sessions from list in WebMvcSseServerTransport

### DIFF
--- a/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransport.java
+++ b/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransport.java
@@ -217,6 +217,14 @@ public class WebMvcSseServerTransport implements ServerMcpTransport {
 		// Send initial endpoint event
 		try {
 			return ServerResponse.sse(sseBuilder -> {
+				sseBuilder.onComplete(() -> {
+					logger.debug("SSE connection completed for session: {}", sessionId);
+					sessions.remove(sessionId);
+				});
+				sseBuilder.onTimeout(() -> {
+					logger.debug("SSE connection timed out for session: {}", sessionId);
+					sessions.remove(sessionId);
+				});
 
 				ClientSession session = new ClientSession(sessionId, sseBuilder);
 				this.sessions.put(sessionId, session);


### PR DESCRIPTION
Remove a session from the session list in `WebMvcSseServerTransport` when it times out or closes.

## Motivation and Context
This is related to: https://github.com/spring-projects/spring-ai/issues/2267

When a client closes its connection then the session is still kept in the list of sessions. The transport then tries to broadcast messages to the outdated sessions and it fails with exception:

```sh
Failed to send message to session 6b973076-58fe-4613-95ba-3f39440f6ed0: Cannot invoke "org.apache.catalina.connector.OutputBuffer.isBlocking()" because "this.ob" is null
```

## How Has This Been Tested?

Unfortunately the active sessions can't be retrieved from within a test, so manual testing was done.

I created a client - server application where 100 clients connect to a server and close their connection after doing a tool request.

```sh
2025-02-22T15:23:14.835+01:00 DEBUG 396597 --- [mcp-server-basic] [io-8080-exec-10] i.m.s.t.WebMvcSseServerTransport         : Attempting to broadcast message to 100 active sessions
```

After that another 100 clients do the same and the number of active sessions grows (although it should be 100):

```sh
2025-02-22T15:24:09.244+01:00 DEBUG 396597 --- [mcp-server-basic] [io-8080-exec-26] i.m.s.t.WebMvcSseServerTransport         : Attempting to broadcast message to 200 active sessions
```

Also, the following exception is thrown for each old, inactive session.

```sh
2025-02-22T15:24:09.244+01:00 ERROR 396597 --- [mcp-server-basic] [io-8080-exec-22] i.m.s.t.WebMvcSseServerTransport         : Failed to send message to session 6b973076-58fe-4613-95ba-3f39440f6ed0: Cannot invoke "org.apache.catalina.connector.OutputBuffer.isBlocking()" because "this.ob" is null
```

With the provided fix the sessions are removed from the list via callbacks on timeout and on complete.
The exception doesn't appear anymore.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
