### PR TITLE
Fix issue, SSE connection will terminate after 30 seconds (DEFAULT).

### DIFF
--- a/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransport.java
+++ b/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransport.java
@@ -5,6 +5,7 @@
 package io.modelcontextprotocol.server.transport;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -228,7 +229,7 @@ public class WebMvcSseServerTransport implements ServerMcpTransport {
 					logger.error("Failed to poll event from session queue: {}", e.getMessage());
 					sseBuilder.error(e);
 				}
-			});
+			}, Duration.ZERO);
 		}
 		catch (Exception e) {
 			logger.error("Failed to send initial endpoint event to session {}: {}", sessionId, e.getMessage());


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
Base on: https://github.com/spring-projects/spring-ai/issues/2267

The SSE connection will automatically disconnect 30 seconds after being established.

```
2025-02-24 18:13:39.403 [http-nio-8822-exec-2] INFO  i.m.server.McpAsyncServer - Client initialize request - Protocol: 2024-11-05, Capabilities: ClientCapabilities[experimental=null, roots=null, sampling=null], Info: Implementation[name=Spring AI MCP Client, version=1.0.0]
2025-02-24 18:14:09.564 [http-nio-8822-exec-5] WARN  o.s.w.s.m.s.DefaultHandlerExceptionResolver - Ignoring exception, response committed already: org.springframework.web.context.request.async.AsyncRequestTimeoutException
2025-02-24 18:14:09.564 [http-nio-8822-exec-5] WARN  o.s.w.s.m.s.DefaultHandlerExceptionResolver - Resolved [org.springframework.web.context.request.async.AsyncRequestTimeoutException]
```

## How Has This Been Tested?
### Step1:
Create a MCP server with `spring-ai-mcp-server-webmvc-spring-boot-starter` like https://github.com/spring-projects/spring-ai/issues/2267

### Step2:
Connect mcp server with any MCP client.

### Step3:
Wait for 30 seconds, get logs
 ```
2025-02-24 18:13:39.403 [http-nio-8822-exec-2] INFO  i.m.server.McpAsyncServer - Client initialize request - Protocol: 2024-11-05, Capabilities: ClientCapabilities[experimental=null, roots=null, sampling=null], Info: Implementation[name=Spring AI MCP Client, version=1.0.0]
2025-02-24 18:14:09.564 [http-nio-8822-exec-5] WARN  o.s.w.s.m.s.DefaultHandlerExceptionResolver - Ignoring exception, response committed already: org.springframework.web.context.request.async.AsyncRequestTimeoutException
2025-02-24 18:14:09.564 [http-nio-8822-exec-5] WARN  o.s.w.s.m.s.DefaultHandlerExceptionResolver - Resolved [org.springframework.web.context.request.async.AsyncRequestTimeoutException]
```


## Breaking Changes
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
N/A
