### PR TITLE
Mention Quarkus MCP servers, along side Spring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This SDK enables Java applications to interact with AI models and tools through 
 For comprehensive guides and SDK API documentation, visit the [MCP Java SDK Reference Documentation](https://modelcontextprotocol.io/sdk/java/mcp-overview).
 
 #### Quarkus MCP servers documentation
-[Quarkus MCP Servers](https://github.com/quarkiverse/quarkus-mcp-servers) provides Quarkus integration with several servers implemented as Quarkus extensions.
+[Quarkus MCP Servers](https://github.com/quarkiverse/quarkus-mcp-servers) provides Quarkus integration with several servers implemented as Quarkus extensions. Bootstrap your AI applications with MCP support using [Quarkus code](https://code.quarkus.io).
 
 #### Spring AI MCP documentation
 [Spring AI MCP](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-overview.html) extends the MCP Java SDK with Spring Boot integration, providing both [client](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-client-boot-starter-docs.html) and [server](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-server-boot-starter-docs.html) starters. Bootstrap your AI applications with MCP support using [Spring Initializer](https://start.spring.io).

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ This SDK enables Java applications to interact with AI models and tools through 
 #### MCP Java SDK documentation
 For comprehensive guides and SDK API documentation, visit the [MCP Java SDK Reference Documentation](https://modelcontextprotocol.io/sdk/java/mcp-overview).
 
+#### Quarkus MCP servers documentation
+[Quarkus MCP Servers](https://github.com/quarkiverse/quarkus-mcp-servers) provides Quarkus integration with several servers implemented as Quarkus extensions.
+
 #### Spring AI MCP documentation
 [Spring AI MCP](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-overview.html) extends the MCP Java SDK with Spring Boot integration, providing both [client](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-client-boot-starter-docs.html) and [server](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-server-boot-starter-docs.html) starters. Bootstrap your AI applications with MCP support using [Spring Initializer](https://start.spring.io).
 


### PR DESCRIPTION
modified:   README.md

Mention the existence of Quarkus MCP servers, to supplement Spring.

## Motivation and Context
Reduce 2nd order ignorance about Quarkus support for MCP.

## How Has This Been Tested?
This change is documentation only.

## Breaking Changes
This change is documentation only.

## Types of changes

- [ X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [NA ] My code follows the repository's style guidelines
- [NA ] New and existing tests pass locally
- [NA ] I have added appropriate error handling
- [NA ] I have added or updated documentation as needed


See also https://github.com/modelcontextprotocol/servers/pull/758 .
