### PR TITLE
feat(client): Improve initialization state handling in McpAsyncClient

### DIFF
--- a/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/WebFluxSseMcpAsyncClientTests.java
+++ b/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/WebFluxSseMcpAsyncClientTests.java
@@ -4,6 +4,8 @@
 
 package io.modelcontextprotocol.client;
 
+import java.time.Duration;
+
 import io.modelcontextprotocol.client.transport.WebFluxSseClientTransport;
 import io.modelcontextprotocol.spec.ClientMcpTransport;
 import org.junit.jupiter.api.Timeout;
@@ -44,6 +46,11 @@ class WebFluxSseMcpAsyncClientTests extends AbstractMcpAsyncClientTests {
 	@Override
 	public void onClose() {
 		container.stop();
+	}
+
+	@Override
+	protected Duration getTimeoutDuration() {
+		return Duration.ofMillis(300);
 	}
 
 }

--- a/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/WebFluxSseMcpSyncClientTests.java
+++ b/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/WebFluxSseMcpSyncClientTests.java
@@ -4,6 +4,8 @@
 
 package io.modelcontextprotocol.client;
 
+import java.time.Duration;
+
 import io.modelcontextprotocol.client.transport.WebFluxSseClientTransport;
 import io.modelcontextprotocol.spec.ClientMcpTransport;
 import org.junit.jupiter.api.Timeout;
@@ -44,6 +46,11 @@ class WebFluxSseMcpSyncClientTests extends AbstractMcpSyncClientTests {
 	@Override
 	protected void onClose() {
 		container.stop();
+	}
+
+	@Override
+	protected Duration getTimeoutDuration() {
+		return Duration.ofMillis(300);
 	}
 
 }

--- a/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 import io.modelcontextprotocol.spec.ClientMcpTransport;
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.ClientCapabilities;
@@ -47,7 +48,7 @@ public abstract class AbstractMcpAsyncClientTests {
 
 	protected ClientMcpTransport mcpTransport;
 
-	private static final Duration TIMEOUT = Duration.ofSeconds(20);
+	// private static final Duration TIMEOUT = Duration.ofMillis(1000);
 
 	private static final String ECHO_TEST_MESSAGE = "Hello MCP Spring AI!";
 
@@ -59,6 +60,10 @@ public abstract class AbstractMcpAsyncClientTests {
 	protected void onClose() {
 	}
 
+	protected Duration getTimeoutDuration() {
+		return Duration.ofSeconds(2);
+	}
+
 	@BeforeEach
 	void setUp() {
 		onStart();
@@ -66,10 +71,9 @@ public abstract class AbstractMcpAsyncClientTests {
 
 		assertThatCode(() -> {
 			mcpAsyncClient = McpClient.async(mcpTransport)
-				.requestTimeout(TIMEOUT)
+				.requestTimeout(getTimeoutDuration())
 				.capabilities(ClientCapabilities.builder().roots(true).build())
 				.build();
-			mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
 		}).doesNotThrowAnyException();
 	}
 
@@ -93,7 +97,15 @@ public abstract class AbstractMcpAsyncClientTests {
 	}
 
 	@Test
+	void testListToolsWithoutInitialization() {
+		assertThatThrownBy(() -> mcpAsyncClient.listTools(null).block()).isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before listing tools");
+	}
+
+	@Test
 	void testListTools() {
+		mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
+
 		StepVerifier.create(mcpAsyncClient.listTools(null)).consumeNextWith(result -> {
 			assertThat(result.tools()).isNotNull().isNotEmpty();
 
@@ -104,12 +116,29 @@ public abstract class AbstractMcpAsyncClientTests {
 	}
 
 	@Test
+	void testPingWithoutInitialization() {
+		assertThatThrownBy(() -> mcpAsyncClient.ping().block()).isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before pinging the server");
+	}
+
+	@Test
 	void testPing() {
+		mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
 		assertThatCode(() -> mcpAsyncClient.ping().block()).doesNotThrowAnyException();
 	}
 
 	@Test
+	void testCallToolWithoutInitialization() {
+		CallToolRequest callToolRequest = new CallToolRequest("echo", Map.of("message", ECHO_TEST_MESSAGE));
+
+		assertThatThrownBy(() -> mcpAsyncClient.callTool(callToolRequest).block()).isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before calling tools");
+	}
+
+	@Test
 	void testCallTool() {
+		mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
+
 		CallToolRequest callToolRequest = new CallToolRequest("echo", Map.of("message", ECHO_TEST_MESSAGE));
 
 		StepVerifier.create(mcpAsyncClient.callTool(callToolRequest)).consumeNextWith(callToolResult -> {
@@ -122,13 +151,23 @@ public abstract class AbstractMcpAsyncClientTests {
 
 	@Test
 	void testCallToolWithInvalidTool() {
+		mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
+
 		CallToolRequest invalidRequest = new CallToolRequest("nonexistent_tool", Map.of("message", ECHO_TEST_MESSAGE));
 
 		assertThatThrownBy(() -> mcpAsyncClient.callTool(invalidRequest).block()).isInstanceOf(Exception.class);
 	}
 
 	@Test
+	void testListResourcesWithoutInitialization() {
+		assertThatThrownBy(() -> mcpAsyncClient.listResources(null).block()).isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before listing resources");
+	}
+
+	@Test
 	void testListResources() {
+		mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
+
 		StepVerifier.create(mcpAsyncClient.listResources(null)).consumeNextWith(resources -> {
 			assertThat(resources).isNotNull().satisfies(result -> {
 				assertThat(result.resources()).isNotNull();
@@ -148,7 +187,15 @@ public abstract class AbstractMcpAsyncClientTests {
 	}
 
 	@Test
+	void testListPromptsWithoutInitialization() {
+		assertThatThrownBy(() -> mcpAsyncClient.listPrompts(null).block()).isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before listing prompts");
+	}
+
+	@Test
 	void testListPrompts() {
+		mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
+
 		StepVerifier.create(mcpAsyncClient.listPrompts(null)).consumeNextWith(prompts -> {
 			assertThat(prompts).isNotNull().satisfies(result -> {
 				assertThat(result.prompts()).isNotNull();
@@ -163,7 +210,17 @@ public abstract class AbstractMcpAsyncClientTests {
 	}
 
 	@Test
+	void testGetPromptWithoutInitialization() {
+		GetPromptRequest request = new GetPromptRequest("simple_prompt", Map.of());
+
+		assertThatThrownBy(() -> mcpAsyncClient.getPrompt(request).block()).isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before getting prompts");
+	}
+
+	@Test
 	void testGetPrompt() {
+		mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
+
 		StepVerifier.create(mcpAsyncClient.getPrompt(new GetPromptRequest("simple_prompt", Map.of())))
 			.consumeNextWith(prompt -> {
 				assertThat(prompt).isNotNull().satisfies(result -> {
@@ -175,7 +232,15 @@ public abstract class AbstractMcpAsyncClientTests {
 	}
 
 	@Test
+	void testRootsListChangedWithoutInitialization() {
+		assertThatThrownBy(() -> mcpAsyncClient.rootsListChangedNotification().block()).isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before sending roots list changed notification");
+	}
+
+	@Test
 	void testRootsListChanged() {
+		mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
+
 		assertThatCode(() -> mcpAsyncClient.rootsListChangedNotification().block()).doesNotThrowAnyException();
 	}
 
@@ -184,7 +249,7 @@ public abstract class AbstractMcpAsyncClientTests {
 		var transport = createMcpTransport();
 
 		var client = McpClient.async(transport)
-			.requestTimeout(TIMEOUT)
+			.requestTimeout(getTimeoutDuration())
 			.roots(new Root("file:///test/path", "test-root"))
 			.build();
 
@@ -234,7 +299,15 @@ public abstract class AbstractMcpAsyncClientTests {
 	}
 
 	@Test
+	void testListResourceTemplatesWithoutInitialization() {
+		assertThatThrownBy(() -> mcpAsyncClient.listResourceTemplates().block()).isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before listing resource templates");
+	}
+
+	@Test
 	void testListResourceTemplates() {
+		mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
+
 		StepVerifier.create(mcpAsyncClient.listResourceTemplates()).consumeNextWith(result -> {
 			assertThat(result).isNotNull();
 			assertThat(result.resourceTemplates()).isNotNull();
@@ -266,7 +339,7 @@ public abstract class AbstractMcpAsyncClientTests {
 
 		var transport = createMcpTransport();
 		var client = McpClient.async(transport)
-			.requestTimeout(TIMEOUT)
+			.requestTimeout(getTimeoutDuration())
 			.toolsChangeConsumer(tools -> Mono.fromRunnable(() -> toolsNotificationReceived.set(true)))
 			.resourcesChangeConsumer(resources -> Mono.fromRunnable(() -> resourcesNotificationReceived.set(true)))
 			.promptsChangeConsumer(prompts -> Mono.fromRunnable(() -> promptsNotificationReceived.set(true)))
@@ -285,7 +358,7 @@ public abstract class AbstractMcpAsyncClientTests {
 		var capabilities = ClientCapabilities.builder().sampling().build();
 
 		var client = McpClient.async(transport)
-			.requestTimeout(TIMEOUT)
+			.requestTimeout(getTimeoutDuration())
 			.capabilities(capabilities)
 			.sampling(request -> Mono.just(CreateMessageResult.builder().message("test").model("test-model").build()))
 			.build();
@@ -309,7 +382,7 @@ public abstract class AbstractMcpAsyncClientTests {
 		Function<CreateMessageRequest, Mono<CreateMessageResult>> samplingHandler = request -> Mono
 			.just(CreateMessageResult.builder().message("test").model("test-model").build());
 		var client = McpClient.async(transport)
-			.requestTimeout(TIMEOUT)
+			.requestTimeout(getTimeoutDuration())
 			.capabilities(capabilities)
 			.sampling(samplingHandler)
 			.build();
@@ -327,7 +400,16 @@ public abstract class AbstractMcpAsyncClientTests {
 	// ---------------------------------------
 
 	@Test
+	void testLoggingLevelsWithoutInitialization() {
+		assertThatThrownBy(() -> mcpAsyncClient.setLoggingLevel(McpSchema.LoggingLevel.DEBUG).block())
+			.isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before setting logging level");
+	}
+
+	@Test
 	void testLoggingLevels() {
+		mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
+
 		// Test all logging levels
 		for (McpSchema.LoggingLevel level : McpSchema.LoggingLevel.values()) {
 			StepVerifier.create(mcpAsyncClient.setLoggingLevel(level)).verifyComplete();
@@ -340,7 +422,7 @@ public abstract class AbstractMcpAsyncClientTests {
 		var transport = createMcpTransport();
 
 		var client = McpClient.async(transport)
-			.requestTimeout(TIMEOUT)
+			.requestTimeout(getTimeoutDuration())
 			.loggingConsumer(notification -> Mono.fromRunnable(() -> logReceived.set(true)))
 			.build();
 

--- a/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
@@ -48,8 +48,6 @@ public abstract class AbstractMcpAsyncClientTests {
 
 	protected ClientMcpTransport mcpTransport;
 
-	// private static final Duration TIMEOUT = Duration.ofMillis(1000);
-
 	private static final String ECHO_TEST_MESSAGE = "Hello MCP Spring AI!";
 
 	abstract protected ClientMcpTransport createMcpTransport();

--- a/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.modelcontextprotocol.spec.ClientMcpTransport;
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -41,8 +42,6 @@ public abstract class AbstractMcpSyncClientTests {
 
 	private McpSyncClient mcpSyncClient;
 
-	private static final Duration TIMEOUT = Duration.ofSeconds(10);
-
 	private static final String TEST_MESSAGE = "Hello MCP Spring AI!";
 
 	protected ClientMcpTransport mcpTransport;
@@ -53,6 +52,10 @@ public abstract class AbstractMcpSyncClientTests {
 
 	abstract protected void onClose();
 
+	protected Duration getTimeoutDuration() {
+		return Duration.ofSeconds(2);
+	}
+
 	@BeforeEach
 	void setUp() {
 		onStart();
@@ -60,10 +63,9 @@ public abstract class AbstractMcpSyncClientTests {
 
 		assertThatCode(() -> {
 			mcpSyncClient = McpClient.sync(mcpTransport)
-				.requestTimeout(TIMEOUT)
+				.requestTimeout(getTimeoutDuration())
 				.capabilities(ClientCapabilities.builder().roots(true).build())
 				.build();
-			mcpSyncClient.initialize();
 		}).doesNotThrowAnyException();
 	}
 
@@ -86,7 +88,14 @@ public abstract class AbstractMcpSyncClientTests {
 	}
 
 	@Test
+	void testListToolsWithoutInitialization() {
+		assertThatThrownBy(() -> mcpSyncClient.listTools(null)).isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before listing tools");
+	}
+
+	@Test
 	void testListTools() {
+		mcpSyncClient.initialize();
 		ListToolsResult tools = mcpSyncClient.listTools(null);
 
 		assertThat(tools).isNotNull().satisfies(result -> {
@@ -99,7 +108,15 @@ public abstract class AbstractMcpSyncClientTests {
 	}
 
 	@Test
+	void testCallToolsWithoutInitialization() {
+		assertThatThrownBy(() -> mcpSyncClient.callTool(new CallToolRequest("add", Map.of("a", 3, "b", 4))))
+			.isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before calling tools");
+	}
+
+	@Test
 	void testCallTools() {
+		mcpSyncClient.initialize();
 		CallToolResult toolResult = mcpSyncClient.callTool(new CallToolRequest("add", Map.of("a", 3, "b", 4)));
 
 		assertThat(toolResult).isNotNull().satisfies(result -> {
@@ -115,12 +132,28 @@ public abstract class AbstractMcpSyncClientTests {
 	}
 
 	@Test
+	void testPingWithoutInitialization() {
+		assertThatThrownBy(() -> mcpSyncClient.ping()).isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before pinging the server");
+	}
+
+	@Test
 	void testPing() {
+		mcpSyncClient.initialize();
 		assertThatCode(() -> mcpSyncClient.ping()).doesNotThrowAnyException();
 	}
 
 	@Test
+	void testCallToolWithoutInitialization() {
+		CallToolRequest callToolRequest = new CallToolRequest("echo", Map.of("message", TEST_MESSAGE));
+
+		assertThatThrownBy(() -> mcpSyncClient.callTool(callToolRequest)).isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before calling tools");
+	}
+
+	@Test
 	void testCallTool() {
+		mcpSyncClient.initialize();
 		CallToolRequest callToolRequest = new CallToolRequest("echo", Map.of("message", TEST_MESSAGE));
 
 		CallToolResult callToolResult = mcpSyncClient.callTool(callToolRequest);
@@ -139,12 +172,26 @@ public abstract class AbstractMcpSyncClientTests {
 	}
 
 	@Test
+	void testRootsListChangedWithoutInitialization() {
+		assertThatThrownBy(() -> mcpSyncClient.rootsListChangedNotification()).isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before sending roots list changed notification");
+	}
+
+	@Test
 	void testRootsListChanged() {
+		mcpSyncClient.initialize();
 		assertThatCode(() -> mcpSyncClient.rootsListChangedNotification()).doesNotThrowAnyException();
 	}
 
 	@Test
+	void testListResourcesWithoutInitialization() {
+		assertThatThrownBy(() -> mcpSyncClient.listResources(null)).isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before listing resources");
+	}
+
+	@Test
 	void testListResources() {
+		mcpSyncClient.initialize();
 		ListResourcesResult resources = mcpSyncClient.listResources(null);
 
 		assertThat(resources).isNotNull().satisfies(result -> {
@@ -168,7 +215,7 @@ public abstract class AbstractMcpSyncClientTests {
 		var transport = createMcpTransport();
 
 		var client = McpClient.sync(transport)
-			.requestTimeout(TIMEOUT)
+			.requestTimeout(getTimeoutDuration())
 			.roots(new Root("file:///test/path", "test-root"))
 			.build();
 
@@ -205,7 +252,16 @@ public abstract class AbstractMcpSyncClientTests {
 	}
 
 	@Test
+	void testReadResourceWithoutInitialization() {
+		assertThatThrownBy(() -> {
+			Resource resource = new Resource("test://uri", "Test Resource", null, null, null);
+			mcpSyncClient.readResource(resource);
+		}).isInstanceOf(McpError.class).hasMessage("Client must be initialized before reading resources");
+	}
+
+	@Test
 	void testReadResource() {
+		mcpSyncClient.initialize();
 		ListResourcesResult resources = mcpSyncClient.listResources(null);
 
 		if (!resources.resources().isEmpty()) {
@@ -218,7 +274,14 @@ public abstract class AbstractMcpSyncClientTests {
 	}
 
 	@Test
+	void testListResourceTemplatesWithoutInitialization() {
+		assertThatThrownBy(() -> mcpSyncClient.listResourceTemplates(null)).isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before listing resource templates");
+	}
+
+	@Test
 	void testListResourceTemplates() {
+		mcpSyncClient.initialize();
 		ListResourceTemplatesResult result = mcpSyncClient.listResourceTemplates(null);
 
 		assertThat(result).isNotNull();
@@ -250,7 +313,7 @@ public abstract class AbstractMcpSyncClientTests {
 
 		var transport = createMcpTransport();
 		var client = McpClient.sync(transport)
-			.requestTimeout(TIMEOUT)
+			.requestTimeout(getTimeoutDuration())
 			.toolsChangeConsumer(tools -> toolsNotificationReceived.set(true))
 			.resourcesChangeConsumer(resources -> resourcesNotificationReceived.set(true))
 			.promptsChangeConsumer(prompts -> promptsNotificationReceived.set(true))
@@ -267,7 +330,15 @@ public abstract class AbstractMcpSyncClientTests {
 	// ---------------------------------------
 
 	@Test
+	void testLoggingLevelsWithoutInitialization() {
+		assertThatThrownBy(() -> mcpSyncClient.setLoggingLevel(McpSchema.LoggingLevel.DEBUG))
+			.isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before setting logging level");
+	}
+
+	@Test
 	void testLoggingLevels() {
+		mcpSyncClient.initialize();
 		// Test all logging levels
 		for (McpSchema.LoggingLevel level : McpSchema.LoggingLevel.values()) {
 			assertThatCode(() -> mcpSyncClient.setLoggingLevel(level)).doesNotThrowAnyException();
@@ -280,7 +351,7 @@ public abstract class AbstractMcpSyncClientTests {
 		var transport = createMcpTransport();
 
 		var client = McpClient.sync(transport)
-			.requestTimeout(TIMEOUT)
+			.requestTimeout(getTimeoutDuration())
 			.loggingConsumer(notification -> logReceived.set(true))
 			.build();
 

--- a/mcp/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
@@ -495,9 +495,9 @@ public class McpAsyncClient {
 	 * Calls a tool provided by the server. Tools enable servers to expose executable
 	 * functionality that can interact with external systems, perform computations, and
 	 * take actions in the real world.
-	 * @param callToolRequest The request containing the tool name and input parameters
+	 * @param callToolRequest The request containing the tool name and input parameters.
 	 * @return A Mono that emits the result of the tool call, including the output and any
-	 * errors
+	 * errors.
 	 * @see McpSchema.CallToolRequest
 	 * @see McpSchema.CallToolResult
 	 * @see #listTools()
@@ -626,10 +626,6 @@ public class McpAsyncClient {
 	 * Retrieves the list of all resource templates provided by the server. Resource
 	 * templates allow servers to expose parameterized resources using URI templates,
 	 * enabling dynamic resource access based on variable parameters.
-	 *
-	 * <p>
-	 * For example, a template like "weather://{city}/forecast" allows clients to access
-	 * weather forecasts for different cities by substituting the {city} parameter.
 	 * @return A Mono that completes with the list of resource templates result.
 	 * @see McpSchema.ListResourceTemplatesResult
 	 */
@@ -641,10 +637,6 @@ public class McpAsyncClient {
 	 * Retrieves a paginated list of resource templates provided by the server. Resource
 	 * templates allow servers to expose parameterized resources using URI templates,
 	 * enabling dynamic resource access based on variable parameters.
-	 *
-	 * <p>
-	 * For example, a template like "weather://{city}/forecast" allows clients to access
-	 * weather forecasts for different cities by substituting the {city} parameter.
 	 * @param cursor Optional pagination cursor from a previous list request.
 	 * @return A Mono that completes with the list of resource templates result.
 	 * @see McpSchema.ListResourceTemplatesResult
@@ -663,11 +655,6 @@ public class McpAsyncClient {
 	 * Subscribes to changes in a specific resource. When the resource changes on the
 	 * server, the client will receive notifications through the resources change
 	 * notification handler.
-	 *
-	 * <p>
-	 * Resource subscriptions enable real-time updates for dynamic resources that may
-	 * change over time, such as system status information, live data feeds, or
-	 * collaborative documents.
 	 * @param subscribeRequest The subscribe request containing the URI of the resource.
 	 * @return A Mono that completes when the subscription is complete.
 	 * @see McpSchema.SubscribeRequest
@@ -681,11 +668,6 @@ public class McpAsyncClient {
 	/**
 	 * Cancels an existing subscription to a resource. After unsubscribing, the client
 	 * will no longer receive notifications when the resource changes.
-	 *
-	 * <p>
-	 * This method should be called when the client is no longer interested in receiving
-	 * updates for a particular resource, to reduce unnecessary network traffic and
-	 * processing.
 	 * @param unsubscribeRequest The unsubscribe request containing the URI of the
 	 * resource.
 	 * @return A Mono that completes when the unsubscription is complete.
@@ -742,12 +724,7 @@ public class McpAsyncClient {
 	/**
 	 * Retrieves a specific prompt by its ID. This provides the complete prompt template
 	 * including all parameters and instructions for generating AI content.
-	 *
-	 * <p>
-	 * Prompts define structured interactions with language models, allowing servers to
-	 * request specific types of AI-generated content with consistent formatting and
-	 * behavior.
-	 * @param getPromptRequest The request containing the ID of the prompt to retrieve
+	 * @param getPromptRequest The request containing the ID of the prompt to retrieve.
 	 * @return A Mono that completes with the prompt result.
 	 * @see McpSchema.GetPromptRequest
 	 * @see McpSchema.GetPromptResult
@@ -789,18 +766,8 @@ public class McpAsyncClient {
 	/**
 	 * Sets the minimum logging level for messages received from the server. The client
 	 * will only receive log messages at or above the specified severity level.
-	 *
-	 * <p>
-	 * This allows clients to control the verbosity of server logging, filtering out less
-	 * important messages while still receiving critical information.
-	 * @param loggingLevel The minimum logging level to receive, one of:
-	 * <ul>
-	 * <li><b>DEBUG</b>: Detailed information for debugging purposes</li>
-	 * <li><b>INFO</b>: General information about normal operation</li>
-	 * <li><b>WARN</b>: Potential issues that don't prevent normal operation</li>
-	 * <li><b>ERROR</b>: Errors that prevent normal operation</li>
-	 * </ul>
-	 * @return A Mono that completes when the logging level is set
+	 * @param loggingLevel The minimum logging level to receive.
+	 * @return A Mono that completes when the logging level is set.
 	 * @see McpSchema.LoggingLevel
 	 */
 	public Mono<Void> setLoggingLevel(LoggingLevel loggingLevel) {

--- a/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 import io.modelcontextprotocol.spec.ClientMcpTransport;
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.ClientCapabilities;
@@ -48,7 +49,7 @@ public abstract class AbstractMcpAsyncClientTests {
 
 	protected ClientMcpTransport mcpTransport;
 
-	private static final Duration TIMEOUT = Duration.ofSeconds(20);
+	// private static final Duration TIMEOUT = Duration.ofMillis(1000);
 
 	private static final String ECHO_TEST_MESSAGE = "Hello MCP Spring AI!";
 
@@ -60,6 +61,10 @@ public abstract class AbstractMcpAsyncClientTests {
 	protected void onClose() {
 	}
 
+	protected Duration getTimeoutDuration() {
+		return Duration.ofSeconds(2);
+	}
+
 	@BeforeEach
 	void setUp() {
 		onStart();
@@ -67,10 +72,9 @@ public abstract class AbstractMcpAsyncClientTests {
 
 		assertThatCode(() -> {
 			mcpAsyncClient = McpClient.async(mcpTransport)
-				.requestTimeout(TIMEOUT)
+				.requestTimeout(getTimeoutDuration())
 				.capabilities(ClientCapabilities.builder().roots(true).build())
 				.build();
-			mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
 		}).doesNotThrowAnyException();
 	}
 
@@ -94,7 +98,15 @@ public abstract class AbstractMcpAsyncClientTests {
 	}
 
 	@Test
+	void testListToolsWithoutInitialization() {
+		assertThatThrownBy(() -> mcpAsyncClient.listTools(null).block()).isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before listing tools");
+	}
+
+	@Test
 	void testListTools() {
+		mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
+
 		StepVerifier.create(mcpAsyncClient.listTools(null)).consumeNextWith(result -> {
 			assertThat(result.tools()).isNotNull().isNotEmpty();
 
@@ -105,12 +117,29 @@ public abstract class AbstractMcpAsyncClientTests {
 	}
 
 	@Test
+	void testPingWithoutInitialization() {
+		assertThatThrownBy(() -> mcpAsyncClient.ping().block()).isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before pinging the server");
+	}
+
+	@Test
 	void testPing() {
+		mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
 		assertThatCode(() -> mcpAsyncClient.ping().block()).doesNotThrowAnyException();
 	}
 
 	@Test
+	void testCallToolWithoutInitialization() {
+		CallToolRequest callToolRequest = new CallToolRequest("echo", Map.of("message", ECHO_TEST_MESSAGE));
+
+		assertThatThrownBy(() -> mcpAsyncClient.callTool(callToolRequest).block()).isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before calling tools");
+	}
+
+	@Test
 	void testCallTool() {
+		mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
+
 		CallToolRequest callToolRequest = new CallToolRequest("echo", Map.of("message", ECHO_TEST_MESSAGE));
 
 		StepVerifier.create(mcpAsyncClient.callTool(callToolRequest)).consumeNextWith(callToolResult -> {
@@ -123,13 +152,23 @@ public abstract class AbstractMcpAsyncClientTests {
 
 	@Test
 	void testCallToolWithInvalidTool() {
+		mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
+
 		CallToolRequest invalidRequest = new CallToolRequest("nonexistent_tool", Map.of("message", ECHO_TEST_MESSAGE));
 
 		assertThatThrownBy(() -> mcpAsyncClient.callTool(invalidRequest).block()).isInstanceOf(Exception.class);
 	}
 
 	@Test
+	void testListResourcesWithoutInitialization() {
+		assertThatThrownBy(() -> mcpAsyncClient.listResources(null).block()).isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before listing resources");
+	}
+
+	@Test
 	void testListResources() {
+		mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
+
 		StepVerifier.create(mcpAsyncClient.listResources(null)).consumeNextWith(resources -> {
 			assertThat(resources).isNotNull().satisfies(result -> {
 				assertThat(result.resources()).isNotNull();
@@ -149,7 +188,15 @@ public abstract class AbstractMcpAsyncClientTests {
 	}
 
 	@Test
+	void testListPromptsWithoutInitialization() {
+		assertThatThrownBy(() -> mcpAsyncClient.listPrompts(null).block()).isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before listing prompts");
+	}
+
+	@Test
 	void testListPrompts() {
+		mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
+
 		StepVerifier.create(mcpAsyncClient.listPrompts(null)).consumeNextWith(prompts -> {
 			assertThat(prompts).isNotNull().satisfies(result -> {
 				assertThat(result.prompts()).isNotNull();
@@ -164,7 +211,17 @@ public abstract class AbstractMcpAsyncClientTests {
 	}
 
 	@Test
+	void testGetPromptWithoutInitialization() {
+		GetPromptRequest request = new GetPromptRequest("simple_prompt", Map.of());
+
+		assertThatThrownBy(() -> mcpAsyncClient.getPrompt(request).block()).isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before getting prompts");
+	}
+
+	@Test
 	void testGetPrompt() {
+		mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
+
 		StepVerifier.create(mcpAsyncClient.getPrompt(new GetPromptRequest("simple_prompt", Map.of())))
 			.consumeNextWith(prompt -> {
 				assertThat(prompt).isNotNull().satisfies(result -> {
@@ -176,7 +233,15 @@ public abstract class AbstractMcpAsyncClientTests {
 	}
 
 	@Test
+	void testRootsListChangedWithoutInitialization() {
+		assertThatThrownBy(() -> mcpAsyncClient.rootsListChangedNotification().block()).isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before sending roots list changed notification");
+	}
+
+	@Test
 	void testRootsListChanged() {
+		mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
+
 		assertThatCode(() -> mcpAsyncClient.rootsListChangedNotification().block()).doesNotThrowAnyException();
 	}
 
@@ -185,7 +250,7 @@ public abstract class AbstractMcpAsyncClientTests {
 		var transport = createMcpTransport();
 
 		var client = McpClient.async(transport)
-			.requestTimeout(TIMEOUT)
+			.requestTimeout(getTimeoutDuration())
 			.roots(new Root("file:///test/path", "test-root"))
 			.build();
 
@@ -235,7 +300,15 @@ public abstract class AbstractMcpAsyncClientTests {
 	}
 
 	@Test
+	void testListResourceTemplatesWithoutInitialization() {
+		assertThatThrownBy(() -> mcpAsyncClient.listResourceTemplates().block()).isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before listing resource templates");
+	}
+
+	@Test
 	void testListResourceTemplates() {
+		mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
+
 		StepVerifier.create(mcpAsyncClient.listResourceTemplates()).consumeNextWith(result -> {
 			assertThat(result).isNotNull();
 			assertThat(result.resourceTemplates()).isNotNull();
@@ -267,7 +340,7 @@ public abstract class AbstractMcpAsyncClientTests {
 
 		var transport = createMcpTransport();
 		var client = McpClient.async(transport)
-			.requestTimeout(TIMEOUT)
+			.requestTimeout(getTimeoutDuration())
 			.toolsChangeConsumer(tools -> Mono.fromRunnable(() -> toolsNotificationReceived.set(true)))
 			.resourcesChangeConsumer(resources -> Mono.fromRunnable(() -> resourcesNotificationReceived.set(true)))
 			.promptsChangeConsumer(prompts -> Mono.fromRunnable(() -> promptsNotificationReceived.set(true)))
@@ -286,7 +359,7 @@ public abstract class AbstractMcpAsyncClientTests {
 		var capabilities = ClientCapabilities.builder().sampling().build();
 
 		var client = McpClient.async(transport)
-			.requestTimeout(TIMEOUT)
+			.requestTimeout(getTimeoutDuration())
 			.capabilities(capabilities)
 			.sampling(request -> Mono.just(CreateMessageResult.builder().message("test").model("test-model").build()))
 			.build();
@@ -310,7 +383,7 @@ public abstract class AbstractMcpAsyncClientTests {
 		Function<CreateMessageRequest, Mono<CreateMessageResult>> samplingHandler = request -> Mono
 			.just(CreateMessageResult.builder().message("test").model("test-model").build());
 		var client = McpClient.async(transport)
-			.requestTimeout(TIMEOUT)
+			.requestTimeout(getTimeoutDuration())
 			.capabilities(capabilities)
 			.sampling(samplingHandler)
 			.build();
@@ -328,7 +401,16 @@ public abstract class AbstractMcpAsyncClientTests {
 	// ---------------------------------------
 
 	@Test
+	void testLoggingLevelsWithoutInitialization() {
+		assertThatThrownBy(() -> mcpAsyncClient.setLoggingLevel(McpSchema.LoggingLevel.DEBUG).block())
+			.isInstanceOf(McpError.class)
+			.hasMessage("Client must be initialized before setting logging level");
+	}
+
+	@Test
 	void testLoggingLevels() {
+		mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
+
 		// Test all logging levels
 		for (McpSchema.LoggingLevel level : McpSchema.LoggingLevel.values()) {
 			StepVerifier.create(mcpAsyncClient.setLoggingLevel(level)).verifyComplete();
@@ -341,7 +423,7 @@ public abstract class AbstractMcpAsyncClientTests {
 		var transport = createMcpTransport();
 
 		var client = McpClient.async(transport)
-			.requestTimeout(TIMEOUT)
+			.requestTimeout(getTimeoutDuration())
 			.loggingConsumer(notification -> Mono.fromRunnable(() -> logReceived.set(true)))
 			.build();
 

--- a/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
@@ -49,8 +49,6 @@ public abstract class AbstractMcpAsyncClientTests {
 
 	protected ClientMcpTransport mcpTransport;
 
-	// private static final Duration TIMEOUT = Duration.ofMillis(1000);
-
 	private static final String ECHO_TEST_MESSAGE = "Hello MCP Spring AI!";
 
 	abstract protected ClientMcpTransport createMcpTransport();

--- a/mcp/src/test/java/io/modelcontextprotocol/client/ServletSseMcpAsyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/ServletSseMcpAsyncClientTests.java
@@ -4,6 +4,8 @@
 
 package io.modelcontextprotocol.client;
 
+import java.time.Duration;
+
 import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
 import io.modelcontextprotocol.spec.ClientMcpTransport;
 import org.junit.jupiter.api.Timeout;
@@ -42,6 +44,11 @@ class ServletSseMcpAsyncClientTests extends AbstractMcpAsyncClientTests {
 	@Override
 	protected void onClose() {
 		container.stop();
+	}
+
+	@Override
+	protected Duration getTimeoutDuration() {
+		return Duration.ofMillis(300);
 	}
 
 }

--- a/mcp/src/test/java/io/modelcontextprotocol/client/ServletSseMcpSyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/ServletSseMcpSyncClientTests.java
@@ -4,6 +4,8 @@
 
 package io.modelcontextprotocol.client;
 
+import java.time.Duration;
+
 import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
 import io.modelcontextprotocol.spec.ClientMcpTransport;
 import org.junit.jupiter.api.Timeout;
@@ -42,6 +44,11 @@ class ServletSseMcpSyncClientTests extends AbstractMcpSyncClientTests {
 	@Override
 	protected void onClose() {
 		container.stop();
+	}
+
+	@Override
+	protected Duration getTimeoutDuration() {
+		return Duration.ofMillis(300);
 	}
 
 }


### PR DESCRIPTION
- Add proper initialization state tracking using AtomicBoolean and Sinks
- Implement timeout handling for requests requiring initialization
- Ensure all client methods verify initialization state before proceeding
- Fix rootsListChangedNotification to check initialization state
- Improve error messages for uninitialized client operations

