### PR TITLE
Update PING request handler, return empty map instead of empty string

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -6,6 +6,7 @@ package io.modelcontextprotocol.server;
 
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -129,7 +130,7 @@ public class McpAsyncServer {
 		requestHandlers.put(McpSchema.METHOD_INITIALIZE, asyncInitializeRequestHandler());
 
 		// Ping MUST respond with an empty data, but not NULL response.
-		requestHandlers.put(McpSchema.METHOD_PING, (params) -> Mono.just(""));
+		requestHandlers.put(McpSchema.METHOD_PING, (params) -> Mono.just(Collections.emptyMap()));
 
 		// Add tools API handlers if the tool capability is enabled
 		if (this.serverCapabilities.tools() != null) {


### PR DESCRIPTION
change ping request handler, response empty map instead of empty string.

## Motivation and Context
[MCP Ping Specification](https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/utilities/ping/)
the ping response result field should be empty object: 
```json 
{
  "jsonrpc": "2.0",
  "id": "123",
  "result": {}
}
```

## How Has This Been Tested?
use mcp official tool `npx @modelcontextprotocol/inspector`, connect to mcp server and use `ping` for test.

## Breaking Changes
no

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
