### PR TITLE
Fix CreateMessageRequest includeContext enum values to match MCP specification

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -796,8 +796,8 @@ public final class McpSchema {
 
 		public enum ContextInclusionStrategy {
 			@JsonProperty("none") NONE,
-			@JsonProperty("this_server") THIS_SERVER,
-			@JsonProperty("all_server") ALL_SERVERS
+			@JsonProperty("thisServer") THIS_SERVER,
+			@JsonProperty("allServers") ALL_SERVERS
 		}
 	}// @formatter:on
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context


[MCP specification](https://github.com/modelcontextprotocol/specification/blob/bb8f4b7323693910328f72f244352cd71a0689e6/schema/draft/schema.json#L389-L391) defines `includeContext` enum values as `none`, `allServers` and `thisServer`, while `java-sdk` used `none`, `all_server` and `this_server`. This mismatch caused tool calls with sampling (e.g. [server-everything's `sampleLLM`](https://github.com/modelcontextprotocol/servers/blob/main/src/everything/everything.ts#L135)) to fail with:
````
; Execution error (McpError) at io.modelcontextprotocol.spec.DefaultMcpSession/lambda$sendRequest$12 (DefaultMcpSession.java:241).
; MCP error -32603: Cannot deserialize value of type `io.modelcontextprotocol.spec.McpSchema$CreateMessageRequest$ContextInclusionStrategy` from String "thisServer": not one of the values accepted for Enum class: [none, all_server, this_server]
;  at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: io.modelcontextprotocol.spec.McpSchema$CreateMessageRequest["includeContext"])
````

Other sdks ([python-sdk](https://github.com/modelcontextprotocol/python-sdk/blob/c8978681f6b4903163325237dae2cb43ab2fbdf5/src/mcp/types.py#L770), [typescript-sdk](https://github.com/modelcontextprotocol/typescript-sdk/blob/0fa2397174eba309b54575294d56754c52b13a65/src/types.ts#L898)) also use camelCased values so it looks like `sdk-java` is in the wrong.

## How Has This Been Tested?
I used java-sdk through clojure interop:

<details>
  <summary>`->client` and `call-tool` implementation</summary>
  
````clojure

(ns example
  (:require [jsonista.core :as j])
  (:import
   [io.modelcontextprotocol.spec
    McpTransport
    McpSchema$ClientCapabilities
    McpSchema$CallToolRequest
    McpSchema$CreateMessageResult]
   [io.modelcontextprotocol.client.transport ServerParameters StdioClientTransport]
   [io.modelcontextprotocol.client McpClient McpSyncClient]
   com.fasterxml.jackson.databind.ObjectMapper
   java.time.Duration))

(def McpClientSchema
  [:fn
   {:error/message "should be an instance of McpSyncClient"}
   #(instance? McpSyncClient %)])

(defn obj->clj
  [obj]
  (-> (.writeValueAsString (ObjectMapper.) obj)
      (j/read-value j/keyword-keys-object-mapper)))

(defn stringify-keywords
  [m]
  (->> m
       (j/write-value-as-bytes)
       j/read-value))

(defn ->client
  {:malli/schema [:=>
                  [:cat
                   [:map
                    [:command :string]
                    [:args [:vector :string]]]]
                  McpClientSchema]}
  ^McpSyncClient
  [{:keys [command args]}]
  (let [^ServerParameters params (-> (ServerParameters/builder command)
                                     (.args args)
                                     (.build))
        ^McpTransport transport (StdioClientTransport. params)
        ^McpSyncClient client (-> (McpClient/sync transport)
                                  (.requestTimeout (Duration/ofSeconds 10))
                                  (.capabilities (-> (McpSchema$ClientCapabilities/builder)
                                                     (.roots true)
                                                     (.sampling)
                                                     (.build)))
                                  (.sampling (fn [request]
                                               (tap> request)
                                               (-> (McpSchema$CreateMessageResult/builder)
                                                   (.model "claude")
                                                   (.message "test")
                                                   .build)))
                                  (.build))]
    (doto client
      .initialize)))

(defn call-tool
  [client tool-name & [args]]
  (->> args
       stringify-keywords
       (McpSchema$CallToolRequest. tool-name)
       (.callTool client)
       obj->clj))
````

</details>

````clojure

  ;; BEFORE THE FIX:
  (-> (->client {:command "npx"
                 :args ["-y" "@modelcontextprotocol/server-everything"]})
      (call-tool "sampleLLM" {:prompt "hello"}))
  ;;=> Execution error (McpError) at io.modelcontextprotocol.spec.DefaultMcpSession/lambda$sendRequest$12 (DefaultMcpSession.java:241).
  ;;   MCP error -32603: Cannot deserialize value of type `io.modelcontextprotocol.spec.McpSchema$CreateMessageRequest$ContextInclusionStrategy` from String "thisServer": not one of the values accepted for Enum class: [none, all_server, this_server]
  ;;    at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: io.modelcontextprotocol.spec.McpSchema$CreateMessageRequest["includeContext"])
  ;;

  ;; AFTER THE FIX:
  (-> (->client {:command "npx"
                 :args ["-y" "@modelcontextprotocol/server-everything"]})
      (call-tool "sampleLLM" {:prompt "hello"}))
  ;;=> {:content [{:type "text", :text "LLM sampling result: test"}]}
  
````

## Breaking Changes
It might break server implementations (if there're any) relying on java-sdk enum values, but nevertheless, those would be incompatible with specification, [server-everything](https://github.com/modelcontextprotocol/servers/tree/main/src/everything) and other sdks.
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
