### PR TITLE
refactor(McpSchema): convert StopReason enum values to camelCase

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -810,9 +810,9 @@ public final class McpSchema {
 		@JsonProperty("stopReason") StopReason stopReason) {
 		
 		public enum StopReason {
-			@JsonProperty("end_turn") END_TURN,
-			@JsonProperty("stop_sequence") STOP_SEQUENCE,
-			@JsonProperty("max_tokens") MAX_TOKENS
+			@JsonProperty("endTurn") END_TURN,
+			@JsonProperty("stopSequence") STOP_SEQUENCE,
+			@JsonProperty("maxTokens") MAX_TOKENS
 		}
 
 		public static Builder builder() {

--- a/mcp/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
@@ -553,7 +553,7 @@ public class McpSchemaTests {
 			.isObject()
 			.isEqualTo(
 					json("""
-							{"role":"assistant","content":{"type":"text","text":"Assistant response"},"model":"gpt-4","stopReason":"end_turn"}"""));
+							{"role":"assistant","content":{"type":"text","text":"Assistant response"},"model":"gpt-4","stopReason":"endTurn"}"""));
 	}
 
 	// Roots Tests


### PR DESCRIPTION
Change format from snake_case to camelCase:
- end_turn → endTurn
- stop_sequence → stopSequence
- max_tokens → maxTokens
