### PR TITLE
(pom) Enable automatic publishing to Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
 						<extensions>true</extensions>
 						<configuration>
 							<publishingServerId>central</publishingServerId>
-							<!-- <autoPublish>false</autoPublish> -->
+							<autoPublish>true</autoPublish>
 						</configuration>
 					</plugin>
 					<plugin>


### PR DESCRIPTION
Set autoPublish to true in the Maven configuration to automatically publish artifacts to the Central repository when the release is performed.
