### PR TITLE
A constructor in HttpClientSseClientTransport overloading

### DIFF
--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransport.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransport.java
@@ -80,7 +80,10 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 	 * endpoint is used to establish the SSE connection with the server.
 	 */
 	private static final String SSE_ENDPOINT = "/sse";
-
+	/**
+	 * Custom sseEndpoint
+	 */
+	private final String sseEndpoint;
 	/**
 	 * Type reference for parsing SSE events containing string data.
 	 */
@@ -137,13 +140,17 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 	 * @throws IllegalArgumentException if either parameter is null
 	 */
 	public WebFluxSseClientTransport(WebClient.Builder webClientBuilder, ObjectMapper objectMapper) {
+	    this(webClientBuilder,objectMapper,SSE_ENDPOINT);
+	}
+	public WebFluxSseClientTransport(WebClient.Builder webClientBuilder, ObjectMapper objectMapper,String sseEndpoint) {
 		Assert.notNull(objectMapper, "ObjectMapper must not be null");
 		Assert.notNull(webClientBuilder, "WebClient.Builder must not be null");
+		Assert.notNull(sseEndpoint, "sseEndpoint must not be null");
 
 		this.objectMapper = objectMapper;
 		this.webClient = webClientBuilder.build();
+		this.sseEndpoint=sseEndpoint;
 	}
-
 	/**
 	 * Establishes a connection to the MCP server using Server-Sent Events (SSE). This
 	 * method initiates the SSE connection and sets up the message processing pipeline.
@@ -254,7 +261,7 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 	protected Flux<ServerSentEvent<String>> eventStream() {// @formatter:off
 		return this.webClient
 			.get()
-			.uri(SSE_ENDPOINT)
+			.uri(this.sseEndpoint)
 			.accept(MediaType.TEXT_EVENT_STREAM)
 			.retrieve()
 			.bodyToFlux(SSE_TYPE)

--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
@@ -66,7 +66,10 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 
 	/** Default SSE endpoint path */
 	private static final String SSE_ENDPOINT = "/sse";
-
+	/**
+	 * Custom sseEndPoint
+	 */
+        private final String sseEndPoint;
 	/** Base URI for the MCP server */
 	private final String baseUri;
 
@@ -110,15 +113,32 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 	 * @throws IllegalArgumentException if objectMapper or clientBuilder is null
 	 */
 	public HttpClientSseClientTransport(HttpClient.Builder clientBuilder, String baseUri, ObjectMapper objectMapper) {
-		Assert.notNull(objectMapper, "ObjectMapper must not be null");
-		Assert.hasText(baseUri, "baseUri must not be empty");
-		Assert.notNull(clientBuilder, "clientBuilder must not be null");
-		this.baseUri = baseUri;
-		this.objectMapper = objectMapper;
-		this.httpClient = clientBuilder.connectTimeout(Duration.ofSeconds(10)).build();
-		this.sseClient = new FlowSseClient(this.httpClient);
+	    this(clientBuilder, baseUri, SSE_ENDPOINT, objectMapper);
 	}
 
+	 /**
+     * Creates a new transport instance with custom HTTP client builder and object mapper.
+     *
+     * @param clientBuilder the HTTP client builder to use
+     * @param baseUri       the base URI of the MCP server
+     * @param objectMapper  the object mapper for JSON serialization/deserialization
+     * @param clientBuilder the HTTP client builder to use
+     * @param baseUri the base URI of the MCP server
+     * @param sseEndPoint Custom sseEndPoint
+     * @param objectMapper the object mapper for JSON serialization/deserialization
+     * @throws IllegalArgumentException if objectMapper or clientBuilder is null
+     */
+    public HttpClientSseClientTransport(HttpClient.Builder clientBuilder, String baseUri, String sseEndPoint, ObjectMapper objectMapper) {
+        Assert.notNull(objectMapper, "ObjectMapper must not be null");
+        Assert.hasText(baseUri, "baseUri must not be empty");
+        Assert.notNull(clientBuilder, "clientBuilder must not be null");
+        Assert.notNull(sseEndPoint, "sseEndPoint must not be null");
+        this.baseUri = baseUri;
+        this.objectMapper = objectMapper;
+        this.httpClient = clientBuilder.connectTimeout(Duration.ofSeconds(10)).build();
+        this.sseClient = new FlowSseClient(this.httpClient);
+        this.sseEndPoint = sseEndPoint;
+    }
 	/**
 	 * Establishes the SSE connection with the server and sets up message handling.
 	 *

--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
@@ -69,7 +69,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 	/**
 	 * Custom sseEndPoint
 	 */
-        private final String sseEndPoint;
+        private final String sseEndpoint;
 	/** Base URI for the MCP server */
 	private final String baseUri;
 
@@ -124,20 +124,20 @@ public class HttpClientSseClientTransport implements McpClientTransport {
      * @param objectMapper  the object mapper for JSON serialization/deserialization
      * @param clientBuilder the HTTP client builder to use
      * @param baseUri the base URI of the MCP server
-     * @param sseEndPoint Custom sseEndPoint
+     * @param sseEndpoint Custom sseEndPoint
      * @param objectMapper the object mapper for JSON serialization/deserialization
      * @throws IllegalArgumentException if objectMapper or clientBuilder is null
      */
-    public HttpClientSseClientTransport(HttpClient.Builder clientBuilder, String baseUri, String sseEndPoint, ObjectMapper objectMapper) {
+    public HttpClientSseClientTransport(HttpClient.Builder clientBuilder, String baseUri, String sseEndpoint, ObjectMapper objectMapper) {
         Assert.notNull(objectMapper, "ObjectMapper must not be null");
         Assert.hasText(baseUri, "baseUri must not be empty");
         Assert.notNull(clientBuilder, "clientBuilder must not be null");
-        Assert.notNull(sseEndPoint, "sseEndPoint must not be null");
+        Assert.notNull(sseEndpoint, "sseEndPoint must not be null");
         this.baseUri = baseUri;
         this.objectMapper = objectMapper;
         this.httpClient = clientBuilder.connectTimeout(Duration.ofSeconds(10)).build();
         this.sseClient = new FlowSseClient(this.httpClient);
-        this.sseEndPoint = sseEndPoint;
+        this.sseEndpoint = sseEndpoint;
     }
 	/**
 	 * Establishes the SSE connection with the server and sets up message handling.
@@ -157,7 +157,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 		CompletableFuture<Void> future = new CompletableFuture<>();
 		connectionFuture.set(future);
 
-		sseClient.subscribe(this.baseUri + SSE_ENDPOINT, new FlowSseClient.SseEventHandler() {
+		sseClient.subscribe(this.baseUri + this.sseEndpoint, new FlowSseClient.SseEventHandler() {
 			@Override
 			public void onEvent(SseEvent event) {
 				if (isClosing) {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
A constructor in HttpClientSseClientTransport overloading

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Repair WebMvcSseServerTransport specifies the sseEndpoint, while HttpClientSseClientTransport SSE_ENDPOINT or/sse, finally an error. Below is a screenshot.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
There are tests. The test steps are as follows:

Step 1. Create a WebMvcSseServerTransport and specify sseEndpoint.

Step 2. Create HttpClientSseClientTransport will find when creating McpSyncClient afferent sseEndpoint.

Step 3. There is `"Java. Lang. RuntimeException: Failed to connect to SSE stream. Unexpected status code: 404"`  error.
If McpClient use WebFluxSseClientTransport will quote `"under Caused by: org.springframework.web.reactive.function.client.WebClientResponseException$NotFound:  404 Not Found from the GET http://localhost:18080/sse "` error.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
It isn't necessary

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
