### PR TITLE
HttpServletSseServerTransportProvider - replace path matching from `getPathInfo` to `getRequestURI`.

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
@@ -170,8 +170,8 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 	protected void doGet(HttpServletRequest request, HttpServletResponse response)
 			throws ServletException, IOException {
 
-		String pathInfo = request.getPathInfo();
-		if (!sseEndpoint.equals(pathInfo)) {
+		String requestURI = request.getRequestURI();
+		if (!sseEndpoint.equals(requestURI)) {
 			response.sendError(HttpServletResponse.SC_NOT_FOUND);
 			return;
 		}
@@ -225,8 +225,8 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 			return;
 		}
 
-		String pathInfo = request.getPathInfo();
-		if (!messageEndpoint.equals(pathInfo)) {
+		String requestURI = request.getRequestURI();
+		if (!messageEndpoint.equals(requestURI)) {
 			response.sendError(HttpServletResponse.SC_NOT_FOUND);
 			return;
 		}


### PR DESCRIPTION
# Fix path matching in HttpServletSseServerTransport

## Problem
When configuring a Servlet mapped to `/somePath/*` and initializing `HttpServletSseServerTransport` with:
```java
new HttpServletSseServerTransport(new ObjectMapper(), "/somePath/message", "/somePath/sse")
```
The handshake phase fails because the current implementation uses `getPathInfo()` which only returns the path after the servlet mapping (e.g., "/message" and "/sse"), not the full configured path.

Using `getRequestURI()` instead will correctly return "/somePath/message" and "/somePath/sse", allowing proper validation.

## Motivation and Context
I need to map my Servlet to a custom URI pattern like `/somePath/*` using web.xml configuration. Currently, path validation in `doPost()` fails because `getPathInfo()` only returns the part of the path after the servlet mapping, rather than the complete path specified during initialization.

## How Has This Been Tested?
Existing tests continue to pass. Note that the current MCP client doesn't support custom SSE endpoints, so additional testing may be needed.

## Breaking Changes
None identified.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
