### PR TITLE
Add unit tests for Assert and Utils classes

### DIFF
--- a/mcp/src/test/java/io/modelcontextprotocol/util/AssertTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/util/AssertTests.java
@@ -1,0 +1,42 @@
+package io.modelcontextprotocol.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AssertTests {
+
+	@Test
+	void testCollectionNotEmpty() {
+		IllegalArgumentException e1 = assertThrows(IllegalArgumentException.class,
+				() -> Assert.notEmpty(null, "collection is null"));
+		assertEquals("collection is null", e1.getMessage());
+
+		IllegalArgumentException e2 = assertThrows(IllegalArgumentException.class,
+				() -> Assert.notEmpty(List.of(), "collection is empty"));
+		assertEquals("collection is empty", e2.getMessage());
+
+		assertDoesNotThrow(() -> Assert.notEmpty(List.of("test"), "collection is not empty"));
+	}
+
+	@Test
+	void testObjectNotNull() {
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+				() -> Assert.notNull(null, "object is null"));
+		assertEquals("object is null", e.getMessage());
+
+		assertDoesNotThrow(() -> Assert.notNull("test", "object is not null"));
+	}
+
+	@Test
+	void testStringHasText() {
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+				() -> Assert.hasText(null, "string is null"));
+		assertEquals("string is null", e.getMessage());
+
+		assertDoesNotThrow(() -> Assert.hasText("test", "string is not empty"));
+	}
+
+}

--- a/mcp/src/test/java/io/modelcontextprotocol/util/UtilsTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/util/UtilsTests.java
@@ -1,0 +1,36 @@
+package io.modelcontextprotocol.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UtilsTests {
+
+	@Test
+	void testHasText() {
+		assertFalse(Utils.hasText(null));
+		assertFalse(Utils.hasText(""));
+		assertFalse(Utils.hasText(" "));
+		assertTrue(Utils.hasText("test"));
+	}
+
+	@Test
+	void testCollectionIsEmpty() {
+		assertTrue(Utils.isEmpty((Collection<?>) null));
+		assertTrue(Utils.isEmpty(List.of()));
+		assertFalse(Utils.isEmpty(List.of("test")));
+	}
+
+	@Test
+	void testMapIsEmpty() {
+		assertTrue(Utils.isEmpty((Map<?, ?>) null));
+		assertTrue(Utils.isEmpty(Map.of()));
+		assertFalse(Utils.isEmpty(Map.of("key", "value")));
+	}
+
+}


### PR DESCRIPTION
Add unit tests for Assert and Utils classes.

## Motivation and Context
There is no unit tests for Assert and Utils classes, although their code is very simple, unit tests is still necessary.

## How Has This Been Tested?
Running tests with `./mvnw test`

## Breaking Changes
No breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
No additional context
