### PR TITLE
Replace Assert.hasText() method with Utils.hasText() for reducing duplicate code

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/util/Assert.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/util/Assert.java
@@ -56,24 +56,9 @@ public final class Assert {
 	 * @throws IllegalArgumentException if the text does not contain valid text content
 	 */
 	public static void hasText(@Nullable String text, String message) {
-		if (!hasText(text)) {
+		if (!Utils.hasText(text)) {
 			throw new IllegalArgumentException(message);
 		}
-	}
-
-	/**
-	 * Check whether the given {@code String} contains actual <em>text</em>.
-	 * <p>
-	 * More specifically, this method returns {@code true} if the {@code String} is not
-	 * {@code null}, its length is greater than 0, and it contains at least one
-	 * non-whitespace character.
-	 * @param str the {@code String} to check (may be {@code null})
-	 * @return {@code true} if the {@code String} is not {@code null}, its length is
-	 * greater than 0, and it does not contain whitespace only
-	 * @see Character#isWhitespace
-	 */
-	public static boolean hasText(@Nullable String str) {
-		return (str != null && !str.isBlank());
 	}
 
 }


### PR DESCRIPTION
Replace `Assert.hasText()` method with `Utils.hasText()` for reducing duplicate code.

## Motivation and Context
There is already `Utils.hasText()` method in the `Utils` class, and it's exactly the same as `Assert.hasText()`.

## How Has This Been Tested?
Running tests with `./mvnw test` (the related unit test is in my previous PR #70)

## Breaking Changes
No breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
No additional context