### PR TITLE
refactor(server): Fi StdioServerTransportProvider initialization flow

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
@@ -93,7 +93,9 @@ public class StdioServerTransportProvider implements McpServerTransportProvider 
 	@Override
 	public void setSessionFactory(McpServerSession.Factory sessionFactory) {
 		// Create a single session for the stdio connection
-		this.session = sessionFactory.create(new StdioMcpSessionTransport());
+		var transport = new StdioMcpSessionTransport();
+		this.session = sessionFactory.create(transport);
+		transport.initProcessing();
 	}
 
 	@Override
@@ -142,10 +144,6 @@ public class StdioServerTransportProvider implements McpServerTransportProvider 
 					"stdio-inbound");
 			this.outboundScheduler = Schedulers.fromExecutorService(Executors.newSingleThreadExecutor(),
 					"stdio-outbound");
-
-			handleIncomingMessages();
-			startInboundProcessing();
-			startOutboundProcessing();
 		}
 
 		@Override
@@ -179,6 +177,12 @@ public class StdioServerTransportProvider implements McpServerTransportProvider 
 		public void close() {
 			isClosing.set(true);
 			logger.debug("Session transport closed");
+		}
+
+		private void initProcessing() {
+			handleIncomingMessages();
+			startInboundProcessing();
+			startOutboundProcessing();
 		}
 
 		private void handleIncomingMessages() {


### PR DESCRIPTION
Extract message processing initialization from StdioMcpSessionTransport constructor into a separate initProcessing() method.

