### PR TITLE
feat: Support separate registration and published paths in WebMvcSseS…

### DIFF
--- a/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransportProvider.java
@@ -91,6 +91,8 @@ public class WebMvcSseServerTransportProvider implements McpServerTransportProvi
 
 	private final String sseEndpoint;
 
+	private final String publishedMessageEndpoint;
+
 	private final RouterFunction<ServerResponse> routerFunction;
 
 	private McpServerSession.Factory sessionFactory;
@@ -104,6 +106,36 @@ public class WebMvcSseServerTransportProvider implements McpServerTransportProvi
 	 * Flag indicating if the transport is shutting down.
 	 */
 	private volatile boolean isClosing = false;
+
+	/**
+	 * Constructs a new WebMvcSseServerTransportProvider instance.
+	 *
+	 * @param objectMapper             The ObjectMapper to use for JSON serialization/deserialization
+	 *                                 of messages.
+	 * @param messageEndpoint          The endpoint URI where clients should send their JSON-RPC
+	 *                                 messages via HTTP POST. This endpoint will be communicated to clients through the
+	 *                                 SSE connection's initial endpoint event.
+	 * @param publishedMessageEndpoint The published endpoint URI that will be sent to clients
+	 *                                 (might differ from the actual messageEndpoint in case of proxies, load balancers, etc.)
+	 * @param sseEndpoint              The endpoint URI where clients establish their SSE connections.
+	 * @throws IllegalArgumentException if any parameter is null
+	 */
+	public WebMvcSseServerTransportProvider(ObjectMapper objectMapper, String messageEndpoint,
+											String publishedMessageEndpoint, String sseEndpoint) {
+		Assert.notNull(objectMapper, "ObjectMapper must not be null");
+		Assert.notNull(messageEndpoint, "Message endpoint must not be null");
+		Assert.notNull(publishedMessageEndpoint, "Published message endpoint must not be null");
+		Assert.notNull(sseEndpoint, "SSE endpoint must not be null");
+
+		this.objectMapper = objectMapper;
+		this.messageEndpoint = messageEndpoint;
+		this.publishedMessageEndpoint = publishedMessageEndpoint;
+		this.sseEndpoint = sseEndpoint;
+		this.routerFunction = RouterFunctions.route()
+				.GET(this.sseEndpoint, this::handleSseConnection)
+				.POST(this.messageEndpoint, this::handleMessage)
+				.build();
+	}
 
 	/**
 	 * Constructs a new WebMvcSseServerTransportProvider instance.
@@ -122,6 +154,7 @@ public class WebMvcSseServerTransportProvider implements McpServerTransportProvi
 
 		this.objectMapper = objectMapper;
 		this.messageEndpoint = messageEndpoint;
+		this.publishedMessageEndpoint = messageEndpoint;
 		this.sseEndpoint = sseEndpoint;
 		this.routerFunction = RouterFunctions.route()
 			.GET(this.sseEndpoint, this::handleSseConnection)
@@ -248,7 +281,7 @@ public class WebMvcSseServerTransportProvider implements McpServerTransportProvi
 				try {
 					sseBuilder.id(sessionId)
 						.event(ENDPOINT_EVENT_TYPE)
-						.data(messageEndpoint + "?sessionId=" + sessionId);
+						.data(publishedMessageEndpoint + "?sessionId=" + sessionId);
 				}
 				catch (Exception e) {
 					logger.error("Failed to send initial endpoint event: {}", e.getMessage());


### PR DESCRIPTION
Resolves #79 
# Support separate registration and published paths in WebMvcSseServerTransportProvider

Adds a new constructor to WebMvcSseServerTransportProvider that accepts separate parameters for server registration paths and client-facing published paths.

This enhancement allows the provider to work correctly in environments with servlet context paths or global URL prefixes (like Spring Boot's spring.mvc.servlet.path) by:
- Using messageEndpoint for server-side router registration
- Using publishedMessageEndpoint when communicating with clients

The implementation maintains backward compatibility with existing code while addressing the needs of deployments behind proxies or with context paths.

## Motivation and Context
When using WebMvcSseServerTransportProvider in environments with servlet context paths or global URL prefixes, there's a mismatch between the path where handlers are registered with Spring's RouterFunction and the full path that needs to be communicated to clients. This enhancement solves that problem by allowing these paths to be configured separately.

For example, in Spring Boot applications with `spring.mvc.servlet.path=/api/v1`, the server needs to register handlers at bare paths like `/message`, but clients need to use the full path `/api/v1/message`.

## How Has This Been Tested?
Tested in a Spring Boot application with servlet context paths configured. Verified both the registration of handlers at the correct paths and the communication of full paths to clients through the SSE connection.

## Breaking Changes
No breaking changes. Existing code using the current constructors will continue to work as before.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
This implementation adds a new field `publishedMessageEndpoint` and modifies the `handleSseConnection` method to use this published endpoint when communicating with clients. All existing constructors are preserved, maintaining backward compatibility.