### PR TITLE
fix(tests): Failed to start process with command npx on Windows

### DIFF
--- a/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpAsyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpAsyncClientTests.java
@@ -22,14 +22,18 @@ class StdioMcpAsyncClientTests extends AbstractMcpAsyncClientTests {
 
 	@Override
 	protected McpClientTransport createMcpTransport() {
-		ServerParameters stdioParams = ServerParameters.builder("npx")
-			.args("-y", "@modelcontextprotocol/server-everything", "dir")
-			.build();
-		ServerParameters windowsStdioParams = ServerParameters.builder("cmd.exe")
-			.args("/c", "npx.cmd", "-y", "@modelcontextprotocol/server-everything", "dir")
-			.build();
-		boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win");
-		return new StdioClientTransport(isWindows ? windowsStdioParams : stdioParams);
+		ServerParameters stdioParams;
+		if (System.getProperty("os.name").toLowerCase().contains("win")) {
+			stdioParams = ServerParameters.builder("cmd.exe")
+				.args("/c", "npx.cmd", "-y", "@modelcontextprotocol/server-everything", "dir")
+				.build();
+		}
+		else {
+			stdioParams = ServerParameters.builder("npx")
+				.args("-y", "@modelcontextprotocol/server-everything", "dir")
+				.build();
+		}
+		return new StdioClientTransport(stdioParams);
 	}
 
 	protected Duration getInitializationTimeout() {

--- a/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpAsyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpAsyncClientTests.java
@@ -25,7 +25,11 @@ class StdioMcpAsyncClientTests extends AbstractMcpAsyncClientTests {
 		ServerParameters stdioParams = ServerParameters.builder("npx")
 			.args("-y", "@modelcontextprotocol/server-everything", "dir")
 			.build();
-		return new StdioClientTransport(stdioParams);
+		ServerParameters windowsStdioParams = ServerParameters.builder("cmd.exe")
+			.args("/c", "npx.cmd", "-y", "@modelcontextprotocol/server-everything", "dir")
+			.build();
+		boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win");
+		return new StdioClientTransport(isWindows ? windowsStdioParams : stdioParams);
 	}
 
 	protected Duration getInitializationTimeout() {

--- a/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpSyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpSyncClientTests.java
@@ -33,8 +33,11 @@ class StdioMcpSyncClientTests extends AbstractMcpSyncClientTests {
 		ServerParameters stdioParams = ServerParameters.builder("npx")
 			.args("-y", "@modelcontextprotocol/server-everything", "dir")
 			.build();
-
-		return new StdioClientTransport(stdioParams);
+		ServerParameters windowsStdioParams = ServerParameters.builder("cmd.exe")
+			.args("/c", "npx.cmd", "-y", "@modelcontextprotocol/server-everything", "dir")
+			.build();
+		boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win");
+		return new StdioClientTransport(isWindows ? windowsStdioParams : stdioParams);
 	}
 
 	@Test

--- a/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpSyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpSyncClientTests.java
@@ -30,14 +30,18 @@ class StdioMcpSyncClientTests extends AbstractMcpSyncClientTests {
 
 	@Override
 	protected McpClientTransport createMcpTransport() {
-		ServerParameters stdioParams = ServerParameters.builder("npx")
-			.args("-y", "@modelcontextprotocol/server-everything", "dir")
-			.build();
-		ServerParameters windowsStdioParams = ServerParameters.builder("cmd.exe")
-			.args("/c", "npx.cmd", "-y", "@modelcontextprotocol/server-everything", "dir")
-			.build();
-		boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win");
-		return new StdioClientTransport(isWindows ? windowsStdioParams : stdioParams);
+		ServerParameters stdioParams;
+		if (System.getProperty("os.name").toLowerCase().contains("win")) {
+			stdioParams = ServerParameters.builder("cmd.exe")
+				.args("/c", "npx.cmd", "-y", "@modelcontextprotocol/server-everything", "dir")
+				.build();
+		}
+		else {
+			stdioParams = ServerParameters.builder("npx")
+				.args("-y", "@modelcontextprotocol/server-everything", "dir")
+				.build();
+		}
+		return new StdioClientTransport(stdioParams);
 	}
 
 	@Test


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Fixed an exception when I was performing unit testing with `./mvnw test` on a Windows system:
``` java
reactor.core.Exceptions$ErrorCallbackNotImplemented: java.lang.RuntimeException: Failed to start process with command: [npx, -y, @modelcontextprotocol/server-everything, dir]
Caused by: java.lang.RuntimeException: Failed to start process with command: [npx, -y, @modelcontextprotocol/server-everything, dir]
        at io.modelcontextprotocol.client.transport.StdioClientTransport.lambda$connect$1(StdioClientTransport.java:132)
        at reactor.core.publisher.MonoRunnable.call(MonoRunnable.java:73)
        at reactor.core.publisher.MonoRunnable.call(MonoRunnable.java:32)
        at reactor.core.publisher.FluxSubscribeOnCallable$CallableSubscribeOnSubscription.run(FluxSubscribeOnCallable.java:228)
        at reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:68)
        at reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:28)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.io.IOException: Cannot run program "npx": CreateProcess error=2, System cannot find the file specified.
        at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1143)
        at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1073)
        at io.modelcontextprotocol.client.transport.StdioClientTransport.lambda$connect$1(StdioClientTransport.java:129)
```

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
As shown in the exception stack above, when I was running `./mvnw test`, I got the exception.

I am using Windows 11 and I confirmed the environment variables of `node` and `npx` have been set correctly, because I can run `node -v` and `npx -v` in any terminal window and any time.

I attempted to change the related code like this and run `./mvnw test` again, the exception disappeared, so I think it might be helpful to improve cross-platform compatibility.
``` java
ServerParameters.builder("cmd.exe")
    .args("/c", "npx.cmd", "-y", "@modelcontextprotocol/server-everything", "dir")
    .build();
boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win");
return new StdioClientTransport(isWindows ? windowsStdioParams : stdioParams);
```

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
No need more tests. Run exists tests.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No break changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
No additional context
