### PR TITLE
Pass request builder to constructor to support custom headers

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/FlowSseClient.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/FlowSseClient.java
@@ -38,6 +38,7 @@ import java.util.regex.Pattern;
 public class FlowSseClient {
 
 	private final HttpClient httpClient;
+	private final HttpRequest.Builder requestBuilder;
 
 	/**
 	 * Pattern to extract the data content from SSE data field lines. Matches lines
@@ -92,7 +93,17 @@ public class FlowSseClient {
 	 * @param httpClient the {@link HttpClient} instance to use for SSE connections
 	 */
 	public FlowSseClient(HttpClient httpClient) {
+		this(httpClient, HttpRequest.newBuilder());
+	}
+
+	/**
+	 * Creates a new FlowSseClient with the specified HTTP client and request builder.
+	 * @param httpClient the {@link HttpClient} instance to use for SSE connections
+	 * @param requestBuilder the {@link HttpRequest.Builder} to use for SSE requests
+	 */
+	public FlowSseClient(HttpClient httpClient, HttpRequest.Builder requestBuilder) {
 		this.httpClient = httpClient;
+		this.requestBuilder = requestBuilder;
 	}
 
 	/**
@@ -109,7 +120,7 @@ public class FlowSseClient {
 	 * @throws RuntimeException if the connection fails with a non-200 status code
 	 */
 	public void subscribe(String url, SseEventHandler eventHandler) {
-		HttpRequest request = HttpRequest.newBuilder()
+		HttpRequest request = requestBuilder
 			.uri(URI.create(url))
 			.header("Accept", "text/event-stream")
 			.header("Cache-Control", "no-cache")

--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
@@ -82,6 +82,9 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 	 */
 	private final HttpClient httpClient;
 
+	/** HTTP request builder for building requests to send messages to the server */
+	private final HttpRequest.Builder requestBuilder;
+
 	/** JSON object mapper for message serialization/deserialization */
 	protected ObjectMapper objectMapper;
 
@@ -126,15 +129,32 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 	 */
 	public HttpClientSseClientTransport(HttpClient.Builder clientBuilder, String baseUri, String sseEndpoint,
 			ObjectMapper objectMapper) {
+		this(clientBuilder, HttpRequest.newBuilder(), baseUri, sseEndpoint, objectMapper);
+	}
+
+	/**
+	 * Creates a new transport instance with custom HTTP client builder, object mapper, and headers.
+	 * @param clientBuilder the HTTP client builder to use
+	 * @param requestBuilder the HTTP request builder to use
+	 * @param baseUri the base URI of the MCP server
+	 * @param sseEndpoint the SSE endpoint path
+	 * @param objectMapper the object mapper for JSON serialization/deserialization
+	 * @throws IllegalArgumentException if objectMapper, clientBuilder, or headers is null
+	 */
+	public HttpClientSseClientTransport(HttpClient.Builder clientBuilder, HttpRequest.Builder requestBuilder, 
+		String baseUri, String sseEndpoint, ObjectMapper objectMapper) {
 		Assert.notNull(objectMapper, "ObjectMapper must not be null");
 		Assert.hasText(baseUri, "baseUri must not be empty");
 		Assert.hasText(sseEndpoint, "sseEndpoint must not be empty");
 		Assert.notNull(clientBuilder, "clientBuilder must not be null");
+		Assert.notNull(requestBuilder, "requestBuilder must not be null");
 		this.baseUri = baseUri;
 		this.sseEndpoint = sseEndpoint;
 		this.objectMapper = objectMapper;
 		this.httpClient = clientBuilder.connectTimeout(Duration.ofSeconds(10)).build();
-		this.sseClient = new FlowSseClient(this.httpClient);
+		this.requestBuilder = requestBuilder;
+		
+		this.sseClient = new FlowSseClient(this.httpClient, requestBuilder);
 	}
 
 	/**
@@ -158,6 +178,8 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 		private HttpClient.Builder clientBuilder = HttpClient.newBuilder();
 
 		private ObjectMapper objectMapper = new ObjectMapper();
+
+		private HttpRequest.Builder requestBuilder = HttpRequest.newBuilder();
 
 		/**
 		 * Creates a new builder with the specified base URI.
@@ -191,6 +213,17 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 		}
 
 		/**
+		 * Sets the HTTP request builder.
+		 * @param requestBuilder the HTTP request builder
+		 * @return this builder
+		 */
+		public Builder requestBuilder(HttpRequest.Builder requestBuilder) {
+			Assert.notNull(requestBuilder, "requestBuilder must not be null");
+			this.requestBuilder = requestBuilder;
+			return this;
+		}
+
+		/**
 		 * Sets the object mapper for JSON serialization/deserialization.
 		 * @param objectMapper the object mapper
 		 * @return this builder
@@ -206,7 +239,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 		 * @return a new transport instance
 		 */
 		public HttpClientSseClientTransport build() {
-			return new HttpClientSseClientTransport(clientBuilder, baseUri, sseEndpoint, objectMapper);
+			return new HttpClientSseClientTransport(clientBuilder, requestBuilder, baseUri, sseEndpoint, objectMapper);
 		}
 
 	}
@@ -301,7 +334,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 
 		try {
 			String jsonText = this.objectMapper.writeValueAsString(message);
-			HttpRequest request = HttpRequest.newBuilder()
+			HttpRequest request = this.requestBuilder
 				.uri(URI.create(this.baseUri + endpoint))
 				.header("Content-Type", "application/json")
 				.POST(HttpRequest.BodyPublishers.ofString(jsonText))


### PR DESCRIPTION
Adding support for custom request headers for SSE transport

## Motivation and Context
Close https://github.com/modelcontextprotocol/java-sdk/issues/68 

## How Has This Been Tested?
This change simply injects a HttpRequest.Builder to HttpClientSseClientTransport. Existing HttpClientSseClientTransportTests passed. I considered adding a test to mock the http client and verify a request is sent with custom headers within the unit, but it seems testing too much of the internal logic of the unit, not the input/output behavior. Let me know what you think. 

## Breaking Changes
No. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines (**where is the style guideline?**)
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
