### PR TITLE
feat(McpSchema): Add constructor to CallToolResult with one String entry

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -756,6 +756,22 @@ public final class McpSchema {
 	public record CallToolResult( // @formatter:off
 		@JsonProperty("content") List<Content> content,
 		@JsonProperty("isError") Boolean isError) {
+
+		/**
+		 * Creates a new instance of {@link CallToolResult} with a string containing the
+		 * tool result.
+		 *
+		 * @param content The content of the tool result. This will be mapped to a one-sized list
+		 * 				  with a {@link TextContent} element.
+		 * @param isError If true, indicates that the tool execution failed and the content contains error information.
+		 *                If false or absent, indicates successful execution.
+		 */
+		public CallToolResult(String content, Boolean isError) {
+			this(
+					List.of(new TextContent(content)),
+					isError
+			);
+		}
 	} // @formatter:on
 
 	// ---------------------------


### PR DESCRIPTION
Adds a new constructor to `CallToolResult`  which allows passing just a `String`.
The string argument is mapped to a `List` with just one `TextContent` element and makes the usage of creating a `CallToolResult` easier.

## Motivation and Context
The Javadoc for the usage of `CallToolResult` is diverging from the implementation at serveral places.

As an example `McpServer.java` has the following example:

```java
McpServer.sync(transportProvider)
 .serverInfo("my-server", "1.0.0")
 .tool(new Tool("calculator", "Performs calculations", schema),
  (exchange, args) -> new CallToolResult("Result: " + calculate(args)))
 .build();
```

But currently the `CallToolResult` expects different arguments and should be:

```java
CallToolResult(
 List.of(
  new TextContent("Result: " + calculate(expr))
 ),
 false
)
```

As this can be confusing for new users of the SDK, I thought first that the documentation should be changed.

But on the other hand it's nice to have an easy way to create a `CallToolResult`  with just one `String` entry.
This would enhance the readability of a codebase and make the usage easier.

This change enables the usage by adding an additional constructor to `CallToolResult`.

## How Has This Been Tested?
Tested it only manually. I can add (Unit) tests if wanted.

## Breaking Changes
-

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
