### PR TITLE
fix: add support to set server instructions

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -247,6 +247,8 @@ public class McpAsyncServer {
 
 		private final McpSchema.Implementation serverInfo;
 
+		private final String instructions;
+
 		private final CopyOnWriteArrayList<McpServerFeatures.AsyncToolSpecification> tools = new CopyOnWriteArrayList<>();
 
 		private final CopyOnWriteArrayList<McpSchema.ResourceTemplate> resourceTemplates = new CopyOnWriteArrayList<>();
@@ -265,6 +267,7 @@ public class McpAsyncServer {
 			this.objectMapper = objectMapper;
 			this.serverInfo = features.serverInfo();
 			this.serverCapabilities = features.serverCapabilities();
+			this.instructions = features.instructions();
 			this.tools.addAll(features.tools());
 			this.resources.putAll(features.resources());
 			this.resourceTemplates.addAll(features.resourceTemplates());
@@ -351,7 +354,7 @@ public class McpAsyncServer {
 				}
 
 				return Mono.just(new McpSchema.InitializeResult(serverProtocolVersion, this.serverCapabilities,
-						this.serverInfo, null));
+						this.serverInfo, this.instructions));
 			});
 		}
 

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpServer.java
@@ -160,6 +160,8 @@ public interface McpServer {
 
 		private McpSchema.ServerCapabilities serverCapabilities;
 
+		private String instructions;
+
 		/**
 		 * The Model Context Protocol (MCP) allows servers to expose tools that can be
 		 * invoked by language models. Tools enable models to interact with external
@@ -225,6 +227,18 @@ public interface McpServer {
 			Assert.hasText(name, "Name must not be null or empty");
 			Assert.hasText(version, "Version must not be null or empty");
 			this.serverInfo = new McpSchema.Implementation(name, version);
+			return this;
+		}
+
+		/**
+		 * Sets the server instructions that will be shared with clients during connection
+		 * initialization. These instructions provide guidance to the client on how to
+		 * interact with this server.
+		 * @param instructions The instructions text. Can be null or empty.
+		 * @return This builder instance for method chaining
+		 */
+		public AsyncSpecification instructions(String instructions) {
+			this.instructions = instructions;
 			return this;
 		}
 
@@ -549,7 +563,7 @@ public interface McpServer {
 		 */
 		public McpAsyncServer build() {
 			var features = new McpServerFeatures.Async(this.serverInfo, this.serverCapabilities, this.tools,
-					this.resources, this.resourceTemplates, this.prompts, this.rootsChangeHandlers);
+					this.resources, this.resourceTemplates, this.prompts, this.rootsChangeHandlers, this.instructions);
 			var mapper = this.objectMapper != null ? this.objectMapper : new ObjectMapper();
 			return new McpAsyncServer(this.transportProvider, mapper, features);
 		}
@@ -571,6 +585,8 @@ public interface McpServer {
 		private McpSchema.Implementation serverInfo = DEFAULT_SERVER_INFO;
 
 		private McpSchema.ServerCapabilities serverCapabilities;
+
+		private String instructions;
 
 		/**
 		 * The Model Context Protocol (MCP) allows servers to expose tools that can be
@@ -637,6 +653,18 @@ public interface McpServer {
 			Assert.hasText(name, "Name must not be null or empty");
 			Assert.hasText(version, "Version must not be null or empty");
 			this.serverInfo = new McpSchema.Implementation(name, version);
+			return this;
+		}
+
+		/**
+		 * Sets the server instructions that will be shared with clients during connection
+		 * initialization. These instructions provide guidance to the client on how to
+		 * interact with this server.
+		 * @param instructions The instructions text. Can be null or empty.
+		 * @return This builder instance for method chaining
+		 */
+		public SyncSpecification instructions(String instructions) {
+			this.instructions = instructions;
 			return this;
 		}
 
@@ -960,7 +988,8 @@ public interface McpServer {
 		 */
 		public McpSyncServer build() {
 			McpServerFeatures.Sync syncFeatures = new McpServerFeatures.Sync(this.serverInfo, this.serverCapabilities,
-					this.tools, this.resources, this.resourceTemplates, this.prompts, this.rootsChangeHandlers);
+					this.tools, this.resources, this.resourceTemplates, this.prompts, this.rootsChangeHandlers,
+					this.instructions);
 			McpServerFeatures.Async asyncFeatures = McpServerFeatures.Async.fromSync(syncFeatures);
 			var mapper = this.objectMapper != null ? this.objectMapper : new ObjectMapper();
 			var asyncServer = new McpAsyncServer(this.transportProvider, mapper, asyncFeatures);

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpServerFeatures.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpServerFeatures.java
@@ -35,12 +35,14 @@ public class McpServerFeatures {
 	 * @param prompts The map of prompt specifications
 	 * @param rootsChangeConsumers The list of consumers that will be notified when the
 	 * roots list changes
+	 * @param instructions The server instructions text
 	 */
 	record Async(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
 			List<McpServerFeatures.AsyncToolSpecification> tools, Map<String, AsyncResourceSpecification> resources,
 			List<McpSchema.ResourceTemplate> resourceTemplates,
 			Map<String, McpServerFeatures.AsyncPromptSpecification> prompts,
-			List<BiFunction<McpAsyncServerExchange, List<McpSchema.Root>, Mono<Void>>> rootsChangeConsumers) {
+			List<BiFunction<McpAsyncServerExchange, List<McpSchema.Root>, Mono<Void>>> rootsChangeConsumers,
+			String instructions) {
 
 		/**
 		 * Create an instance and validate the arguments.
@@ -52,12 +54,14 @@ public class McpServerFeatures {
 		 * @param prompts The map of prompt specifications
 		 * @param rootsChangeConsumers The list of consumers that will be notified when
 		 * the roots list changes
+		 * @param instructions The server instructions text
 		 */
 		Async(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
 				List<McpServerFeatures.AsyncToolSpecification> tools, Map<String, AsyncResourceSpecification> resources,
 				List<McpSchema.ResourceTemplate> resourceTemplates,
 				Map<String, McpServerFeatures.AsyncPromptSpecification> prompts,
-				List<BiFunction<McpAsyncServerExchange, List<McpSchema.Root>, Mono<Void>>> rootsChangeConsumers) {
+				List<BiFunction<McpAsyncServerExchange, List<McpSchema.Root>, Mono<Void>>> rootsChangeConsumers,
+				String instructions) {
 
 			Assert.notNull(serverInfo, "Server info must not be null");
 
@@ -78,6 +82,7 @@ public class McpServerFeatures {
 			this.resourceTemplates = (resourceTemplates != null) ? resourceTemplates : List.of();
 			this.prompts = (prompts != null) ? prompts : Map.of();
 			this.rootsChangeConsumers = (rootsChangeConsumers != null) ? rootsChangeConsumers : List.of();
+			this.instructions = instructions;
 		}
 
 		/**
@@ -113,7 +118,7 @@ public class McpServerFeatures {
 			}
 
 			return new Async(syncSpec.serverInfo(), syncSpec.serverCapabilities(), tools, resources,
-					syncSpec.resourceTemplates(), prompts, rootChangeConsumers);
+					syncSpec.resourceTemplates(), prompts, rootChangeConsumers, syncSpec.instructions());
 		}
 	}
 
@@ -128,13 +133,14 @@ public class McpServerFeatures {
 	 * @param prompts The map of prompt specifications
 	 * @param rootsChangeConsumers The list of consumers that will be notified when the
 	 * roots list changes
+	 * @param instructions The server instructions text
 	 */
 	record Sync(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
 			List<McpServerFeatures.SyncToolSpecification> tools,
 			Map<String, McpServerFeatures.SyncResourceSpecification> resources,
 			List<McpSchema.ResourceTemplate> resourceTemplates,
 			Map<String, McpServerFeatures.SyncPromptSpecification> prompts,
-			List<BiConsumer<McpSyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumers) {
+			List<BiConsumer<McpSyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumers, String instructions) {
 
 		/**
 		 * Create an instance and validate the arguments.
@@ -146,13 +152,15 @@ public class McpServerFeatures {
 		 * @param prompts The map of prompt specifications
 		 * @param rootsChangeConsumers The list of consumers that will be notified when
 		 * the roots list changes
+		 * @param instructions The server instructions text
 		 */
 		Sync(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
 				List<McpServerFeatures.SyncToolSpecification> tools,
 				Map<String, McpServerFeatures.SyncResourceSpecification> resources,
 				List<McpSchema.ResourceTemplate> resourceTemplates,
 				Map<String, McpServerFeatures.SyncPromptSpecification> prompts,
-				List<BiConsumer<McpSyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumers) {
+				List<BiConsumer<McpSyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumers,
+				String instructions) {
 
 			Assert.notNull(serverInfo, "Server info must not be null");
 
@@ -173,6 +181,7 @@ public class McpServerFeatures {
 			this.resourceTemplates = (resourceTemplates != null) ? resourceTemplates : new ArrayList<>();
 			this.prompts = (prompts != null) ? prompts : new HashMap<>();
 			this.rootsChangeConsumers = (rootsChangeConsumers != null) ? rootsChangeConsumers : new ArrayList<>();
+			this.instructions = instructions;
 		}
 
 	}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Fix #98 , we need to provide a method to set server `instructions`, which needs to be the same as the [python sdk](https://github.com/modelcontextprotocol/python-sdk)

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Already tested on `sync` and `async` server: 
```java
McpSyncServer server = McpServer.sync(transport)
    .serverInfo("stdio-server-example", "1.0.0")
    .instructions("This is a simple MCP server example that provides two tools: xxxx.")
    .tool(xxx)
    .build();
```

The server can return `instructions` normally: 
> 20:53:05.009 [pool-1-thread-1] INFO  i.m.client.McpAsyncClient - Server response with Protocol: 2024-11-05, Capabilities: ServerCapabilities[experimental=null, logging=LoggingCapabilities[], prompts=null, resources=null, tools=ToolCapabilities[listChanged=false]], Info: Implementation[name=stdio-server-async-example, version=1.0.0] and Instructions This is a simple MCP server example that provides two tools: xxxx.

And the build was success:

> [INFO] ------------------------------------------------------------------------
> [INFO] Reactor Summary for Java SDK MCP Parent 0.9.0-SNAPSHOT:
> [INFO]
> [INFO] Java SDK MCP Parent ................................ SUCCESS [  0.410 s]
> [INFO] Java SDK MCP BOM ................................... SUCCESS [  0.016 s]
> [INFO] Java MCP SDK ....................................... SUCCESS [  4.308 s]
> [INFO] Tests for the Java MCP SDK ......................... SUCCESS [  0.310 s]
> [INFO] WebFlux implementation of the Java MCP SSE transport SUCCESS [  1.222 s]
> [INFO] Spring Web MVC implementation of the Java MCP SSE transport SUCCESS [  1.101 s]
> [INFO] ------------------------------------------------------------------------
> [INFO] BUILD SUCCESS
> [INFO] ------------------------------------------------------------------------
> [INFO] Total time:  7.432 s
> [INFO] Finished at: 2025-04-01T20:59:09+08:00
> [INFO] ------------------------------------------------------------------------

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Users do not need to modify their original code if they do not need to set `instructions`

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
