### PR TITLE
Update HttpClientSseClientTransport.java

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
@@ -133,7 +133,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 		this.baseUri = baseUri;
 		this.sseEndpoint = sseEndpoint;
 		this.objectMapper = objectMapper;
-		this.httpClient = clientBuilder.connectTimeout(Duration.ofSeconds(10)).build();
+		this.httpClient = clientBuilder.version(HttpClient.Version.HTTP_1_1).connectTimeout(Duration.ofSeconds(10)).build();
 		this.sseClient = new FlowSseClient(this.httpClient);
 	}
 


### PR DESCRIPTION
fix: switch HttpClient to HTTP/1.1 to prevent body loss with Python servers

This change modifies the HttpClient configuration to explicitly use HTTP_1_1 instead  of the default HTTP_2, resolving a critical compatibility issue with Python-based  servers (uvicorn/starlette) that cannot properly handle HTTP/2 upgrade requests with  bodies.

The issue occurs because:
1. Java's HttpClient attempts to upgrade to HTTP/2 (h2c) while simultaneously  sending request bodies
2. Python servers (particularly with HttpToolsProtocol) prioritize protocol upgrade  handling, causing the body parsing to be skipped or interrupted
3. This results in request bodies being lost during transmission

<!-- Provide a brief summary of your changes -->
switch HttpClient to HTTP/1.1 to prevent body loss with Python servers
## Motivation and Context
Java HTTP clients sending h2c protocol upgrade requests with bodies encounter a critical issue where uvicorn (Python ASGI server) silently ignores the request body, causing data loss.
![image](https://github.com/user-attachments/assets/810f5b60-6d6d-4f87-9f67-a9af979a8fbc)


## Additional context
https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp  

