### PR TITLE
refactor: change notification params type from Map<String,Object> to Object

### DIFF
--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxSseServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxSseServerTransportProvider.java
@@ -188,7 +188,7 @@ public class WebFluxSseServerTransportProvider implements McpServerTransportProv
 	 * errors if any session fails to receive the message
 	 */
 	@Override
-	public Mono<Void> notifyClients(String method, Map<String, Object> params) {
+	public Mono<Void> notifyClients(String method, Object params) {
 		if (sessions.isEmpty()) {
 			logger.debug("No active sessions to broadcast message to");
 			return Mono.empty();

--- a/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransportProvider.java
@@ -179,7 +179,7 @@ public class WebMvcSseServerTransportProvider implements McpServerTransportProvi
 	 * @return A Mono that completes when the broadcast attempt is finished
 	 */
 	@Override
-	public Mono<Void> notifyClients(String method, Map<String, Object> params) {
+	public Mono<Void> notifyClients(String method, Object params) {
 		if (sessions.isEmpty()) {
 			logger.debug("No active sessions to broadcast message to");
 			return Mono.empty();

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -669,15 +669,17 @@ public class McpAsyncServer {
 				return Mono.error(new McpError("Logging message must not be null"));
 			}
 
-			Map<String, Object> params = this.objectMapper.convertValue(loggingMessageNotification,
-					new TypeReference<Map<String, Object>>() {
-					});
+			// Map<String, Object> params =
+			// this.objectMapper.convertValue(loggingMessageNotification,
+			// new TypeReference<Map<String, Object>>() {
+			// });
 
 			if (loggingMessageNotification.level().level() < minLoggingLevel.level()) {
 				return Mono.empty();
 			}
 
-			return this.mcpTransportProvider.notifyClients(McpSchema.METHOD_NOTIFICATION_MESSAGE, params);
+			return this.mcpTransportProvider.notifyClients(McpSchema.METHOD_NOTIFICATION_MESSAGE,
+					loggingMessageNotification);
 		}
 
 		private McpServerSession.RequestHandler<Void> setLoggerRequestHandler() {

--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
@@ -160,7 +160,7 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 	 * @return A Mono that completes when the broadcast attempt is finished
 	 */
 	@Override
-	public Mono<Void> notifyClients(String method, Map<String, Object> params) {
+	public Mono<Void> notifyClients(String method, Object params) {
 		if (sessions.isEmpty()) {
 			logger.debug("No active sessions to broadcast message to");
 			return Mono.empty();

--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
@@ -99,7 +99,7 @@ public class StdioServerTransportProvider implements McpServerTransportProvider 
 	}
 
 	@Override
-	public Mono<Void> notifyClients(String method, Map<String, Object> params) {
+	public Mono<Void> notifyClients(String method, Object params) {
 		if (this.session == null) {
 			return Mono.error(new McpError("No session to close"));
 		}

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpClientSession.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpClientSession.java
@@ -258,7 +258,7 @@ public class McpClientSession implements McpSession {
 	 * @return A Mono that completes when the notification is sent
 	 */
 	@Override
-	public Mono<Void> sendNotification(String method, Map<String, Object> params) {
+	public Mono<Void> sendNotification(String method, Object params) {
 		McpSchema.JSONRPCNotification jsonrpcNotification = new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION,
 				method, params);
 		return this.transport.sendMessage(jsonrpcNotification);

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -191,7 +191,7 @@ public final class McpSchema {
 	public record JSONRPCNotification( // @formatter:off
 			@JsonProperty("jsonrpc") String jsonrpc,
 			@JsonProperty("method") String method,
-			@JsonProperty("params") Map<String, Object> params) implements JSONRPCMessage {
+			@JsonProperty("params") Object params) implements JSONRPCMessage {
 	} // @formatter:on
 
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
@@ -132,7 +132,7 @@ public class McpServerSession implements McpSession {
 	}
 
 	@Override
-	public Mono<Void> sendNotification(String method, Map<String, Object> params) {
+	public Mono<Void> sendNotification(String method, Object params) {
 		McpSchema.JSONRPCNotification jsonrpcNotification = new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION,
 				method, params);
 		return this.transport.sendMessage(jsonrpcNotification);

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerTransportProvider.java
@@ -42,11 +42,11 @@ public interface McpServerTransportProvider {
 	/**
 	 * Sends a notification to all connected clients.
 	 * @param method the name of the notification method to be called on the clients
-	 * @param params a map of parameters to be sent with the notification
+	 * @param params parameters to be sent with the notification
 	 * @return a Mono that completes when the notification has been broadcast
 	 * @see McpSession#sendNotification(String, Map)
 	 */
-	Mono<Void> notifyClients(String method, Map<String, Object> params);
+	Mono<Void> notifyClients(String method, Object params);
 
 	/**
 	 * Immediately closes all the transports with connected clients and releases any

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpSession.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpSession.java
@@ -63,10 +63,10 @@ public interface McpSession {
 	 * parameters with the notification.
 	 * </p>
 	 * @param method the name of the notification method to be sent to the counterparty
-	 * @param params a map of parameters to be sent with the notification
+	 * @param params parameters to be sent with the notification
 	 * @return a Mono that completes when the notification has been sent
 	 */
-	Mono<Void> sendNotification(String method, Map<String, Object> params);
+	Mono<Void> sendNotification(String method, Object params);
 
 	/**
 	 * Closes the session and releases any associated resources asynchronously.

--- a/mcp/src/test/java/io/modelcontextprotocol/MockMcpServerTransportProvider.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/MockMcpServerTransportProvider.java
@@ -47,7 +47,7 @@ public class MockMcpServerTransportProvider implements McpServerTransportProvide
 	}
 
 	@Override
-	public Mono<Void> notifyClients(String method, Map<String, Object> params) {
+	public Mono<Void> notifyClients(String method, Object params) {
 		return session.sendNotification(method, params);
 	}
 


### PR DESCRIPTION
This change generalizes the parameter type for notification methods across the MCP framework, allowing for more flexible parameter passing. Instead of requiring parameters to be structured as a Map<String,Object>, the API now accepts any Object as parameters.

The primary motivation is to simplify client usage by allowing direct passing of strongly-typed
 objects without requiring conversion to a Map first, as demonstrated in the McpAsyncServer
logging notification implementation.

Affected components:

- McpSession interface and implementations
- McpServerTransportProvider interface and implementations
- McpSchema JSONRPCNotification record