### PR TITLE
fix: Add null check for session in WebFluxSseServerTransportProvider

### DIFF
--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxSseServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxSseServerTransportProvider.java
@@ -306,6 +306,11 @@ public class WebFluxSseServerTransportProvider implements McpServerTransportProv
 
 		McpServerSession session = sessions.get(request.queryParam("sessionId").get());
 
+		if (session == null) {
+			return ServerResponse.status(HttpStatus.NOT_FOUND)
+				.bodyValue(new McpError("Session not found: " + request.queryParam("sessionId").get()));
+		}
+
 		return request.bodyToMono(String.class).flatMap(body -> {
 			try {
 				McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(objectMapper, body);


### PR DESCRIPTION
Add error handling to return a 404 NOT_FOUND response when a request is made with a non-existent session ID. This prevents potential NullPointerExceptions when processing requests with invalid session IDs.
