### PR TITLE
add access to server instructions

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
@@ -113,6 +113,11 @@ public class McpAsyncClient {
 	private McpSchema.ServerCapabilities serverCapabilities;
 
 	/**
+	 * Server instructions.
+	 */
+	private String serverInstructions;
+
+	/**
 	 * Server implementation information.
 	 */
 	private McpSchema.Implementation serverInfo;
@@ -241,6 +246,15 @@ public class McpAsyncClient {
 	}
 
 	/**
+	 * Get the server instructions that provide guidance to the client on how to interact
+	 * with this server.
+	 * @return The server instructions
+	 */
+	public String getServerInstructions() {
+		return this.serverInstructions;
+	}
+
+	/**
 	 * Get the server implementation information.
 	 * @return The server implementation details
 	 */
@@ -328,6 +342,7 @@ public class McpAsyncClient {
 		return result.flatMap(initializeResult -> {
 
 			this.serverCapabilities = initializeResult.capabilities();
+			this.serverInstructions = initializeResult.instructions();
 			this.serverInfo = initializeResult.serverInfo();
 
 			logger.info("Server response with Protocol: {}, Capabilities: {}, Info: {} and Instructions {}",

--- a/mcp/src/main/java/io/modelcontextprotocol/client/McpSyncClient.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/McpSyncClient.java
@@ -80,6 +80,15 @@ public class McpSyncClient implements AutoCloseable {
 	}
 
 	/**
+	 * Get the server instructions that provide guidance to the client on how to interact
+	 * with this server.
+	 * @return The instructions
+	 */
+	public String getServerInstructions() {
+		return this.delegate.getServerInstructions();
+	}
+
+	/**
 	 * Get the server implementation information.
 	 * @return The server implementation details
 	 */


### PR DESCRIPTION
Enable the MCP Client to read the Server instructions.

## Motivation and Context
The instructions are optional and exist in the MCP spec, but not fully exposed in the Java SDK yet.

## How Has This Been Tested?
Also made modifications to Spring AI and a test project that uses this.

## Breaking Changes
No.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed