### PR TITLE
fix: propagate reactor context up till transport

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpClientSession.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpClientSession.java
@@ -225,18 +225,19 @@ public class McpClientSession implements McpSession {
 	public <T> Mono<T> sendRequest(String method, Object requestParams, TypeReference<T> typeRef) {
 		String requestId = this.generateRequestId();
 
-		return Mono.<McpSchema.JSONRPCResponse>create(sink -> {
+		return Mono.deferContextual(ctx -> Mono.<McpSchema.JSONRPCResponse>create(sink -> {
 			this.pendingResponses.put(requestId, sink);
 			McpSchema.JSONRPCRequest jsonrpcRequest = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, method,
 					requestId, requestParams);
 			this.transport.sendMessage(jsonrpcRequest)
+				.contextWrite(ctx)
 				// TODO: It's most efficient to create a dedicated Subscriber here
 				.subscribe(v -> {
 				}, error -> {
 					this.pendingResponses.remove(requestId);
 					sink.error(error);
 				});
-		}).timeout(this.requestTimeout).handle((jsonRpcResponse, sink) -> {
+		})).timeout(this.requestTimeout).handle((jsonRpcResponse, sink) -> {
 			if (jsonRpcResponse.error() != null) {
 				sink.error(new McpError(jsonRpcResponse.error()));
 			}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
When implementing my own custom transport class which has the requirement of passing in a unique JWT Token per incoming request to call tool, I came to realize that context propagation up till the transport's sendMessage function is not working for regular requests but only working for notifications.

Upon further inspection this is because of how sendRequest and sendNotification are implemented in the McpClientSession class.

The sendRequest method creates a response mono and the transport's sendMessage creates a separate mono, the context from the client is only propagated into the response mono but isn't passed into the mono returned by sendMessage. This differs from sendNotification that returns the mono created by the transport's sendMessage back to the client so the context attached by the client gets propagated into the mono in the transport's sendMessage for notifications.
![image](https://github.com/user-attachments/assets/00e41947-bc83-4fd7-b140-7aa99c2f73f3)

This MR modifies the McpClientSession's sendRequest to explicitly propagate the context into the mono created by transport's sendMessage allowing the transport's sendMessage to access the JWT Token from this context and perform the required logic.

## How Has This Been Tested?
yes, ran the existing tests.

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
