### PR TITLE
feat(server): tool call support context

### DIFF
--- a/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/WebFluxSseIntegrationTests.java
+++ b/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/WebFluxSseIntegrationTests.java
@@ -103,7 +103,7 @@ class WebFluxSseIntegrationTests {
 
 		McpServerFeatures.AsyncToolSpecification tool = new McpServerFeatures.AsyncToolSpecification(
 				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema),
-				(exchange, request) -> exchange.createMessage(mock(CreateMessageRequest.class))
+				(exchange, request, context) -> exchange.createMessage(mock(CreateMessageRequest.class))
 					.thenReturn(mock(CallToolResult.class)));
 
 		var server = McpServer.async(mcpServerTransportProvider).serverInfo("test-server", "1.0.0").tools(tool).build();
@@ -144,7 +144,7 @@ class WebFluxSseIntegrationTests {
 		AtomicReference<CreateMessageResult> samplingResult = new AtomicReference<>();
 
 		McpServerFeatures.AsyncToolSpecification tool = new McpServerFeatures.AsyncToolSpecification(
-				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request) -> {
+				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request, context) -> {
 
 					var createMessageRequest = McpSchema.CreateMessageRequest.builder()
 						.messages(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
@@ -220,7 +220,7 @@ class WebFluxSseIntegrationTests {
 		AtomicReference<CreateMessageResult> samplingResult = new AtomicReference<>();
 
 		McpServerFeatures.AsyncToolSpecification tool = new McpServerFeatures.AsyncToolSpecification(
-				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request) -> {
+				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request, context) -> {
 
 					var craeteMessageRequest = McpSchema.CreateMessageRequest.builder()
 						.messages(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
@@ -296,7 +296,7 @@ class WebFluxSseIntegrationTests {
 				null);
 
 		McpServerFeatures.AsyncToolSpecification tool = new McpServerFeatures.AsyncToolSpecification(
-				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request) -> {
+				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request, context) -> {
 
 					var craeteMessageRequest = McpSchema.CreateMessageRequest.builder()
 						.messages(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
@@ -386,7 +386,7 @@ class WebFluxSseIntegrationTests {
 		var clientBuilder = clientBuilders.get(clientType);
 
 		McpServerFeatures.SyncToolSpecification tool = new McpServerFeatures.SyncToolSpecification(
-				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request) -> {
+				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request, context) -> {
 
 					exchange.listRoots(); // try to list roots
 
@@ -525,7 +525,7 @@ class WebFluxSseIntegrationTests {
 
 		var callResponse = new McpSchema.CallToolResult(List.of(new McpSchema.TextContent("CALL RESPONSE")), null);
 		McpServerFeatures.SyncToolSpecification tool1 = new McpServerFeatures.SyncToolSpecification(
-				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request) -> {
+				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request, context) -> {
 					// perform a blocking call to a remote service
 					String response = RestClient.create()
 						.get()
@@ -565,7 +565,7 @@ class WebFluxSseIntegrationTests {
 
 		var callResponse = new McpSchema.CallToolResult(List.of(new McpSchema.TextContent("CALL RESPONSE")), null);
 		McpServerFeatures.SyncToolSpecification tool1 = new McpServerFeatures.SyncToolSpecification(
-				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request) -> {
+				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request, context) -> {
 					// perform a blocking call to a remote service
 					String response = RestClient.create()
 						.get()
@@ -617,7 +617,7 @@ class WebFluxSseIntegrationTests {
 			// Add a new tool
 			McpServerFeatures.SyncToolSpecification tool2 = new McpServerFeatures.SyncToolSpecification(
 					new McpSchema.Tool("tool2", "tool2 description", emptyJsonSchema),
-					(exchange, request) -> callResponse);
+					(exchange, request, context) -> callResponse);
 
 			mcpServer.addTool(tool2);
 
@@ -660,7 +660,7 @@ class WebFluxSseIntegrationTests {
 		// Create server with a tool that sends logging notifications
 		McpServerFeatures.AsyncToolSpecification tool = new McpServerFeatures.AsyncToolSpecification(
 				new McpSchema.Tool("logging-test", "Test logging notifications", emptyJsonSchema),
-				(exchange, request) -> {
+				(exchange, request, context) -> {
 
 					// Create and send notifications with different levels
 

--- a/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransportProvider.java
@@ -316,7 +316,7 @@ public class WebMvcSseServerTransportProvider implements McpServerTransportProvi
 			McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(objectMapper, body);
 
 			// Process the message through the session's handle method
-			session.handle(message).block(); // Block for WebMVC compatibility
+			session.handle(request, message).block(); // Block for WebMVC compatibility
 
 			return ServerResponse.ok().build();
 		}

--- a/mcp-spring/mcp-spring-webmvc/src/test/java/io/modelcontextprotocol/server/WebMvcSseIntegrationTests.java
+++ b/mcp-spring/mcp-spring-webmvc/src/test/java/io/modelcontextprotocol/server/WebMvcSseIntegrationTests.java
@@ -120,7 +120,7 @@ class WebMvcSseIntegrationTests {
 	void testCreateMessageWithoutSamplingCapabilities() {
 
 		McpServerFeatures.AsyncToolSpecification tool = new McpServerFeatures.AsyncToolSpecification(
-				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request) -> {
+				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request, context) -> {
 
 					exchange.createMessage(mock(McpSchema.CreateMessageRequest.class)).block();
 
@@ -167,7 +167,7 @@ class WebMvcSseIntegrationTests {
 				null);
 
 		McpServerFeatures.AsyncToolSpecification tool = new McpServerFeatures.AsyncToolSpecification(
-				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request) -> {
+				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request, context) -> {
 
 					var createMessageRequest = McpSchema.CreateMessageRequest.builder()
 						.messages(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
@@ -243,7 +243,7 @@ class WebMvcSseIntegrationTests {
 				null);
 
 		McpServerFeatures.AsyncToolSpecification tool = new McpServerFeatures.AsyncToolSpecification(
-				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request) -> {
+				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request, context) -> {
 
 					var craeteMessageRequest = McpSchema.CreateMessageRequest.builder()
 						.messages(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
@@ -315,7 +315,7 @@ class WebMvcSseIntegrationTests {
 				null);
 
 		McpServerFeatures.AsyncToolSpecification tool = new McpServerFeatures.AsyncToolSpecification(
-				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request) -> {
+				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request, context) -> {
 
 					var craeteMessageRequest = McpSchema.CreateMessageRequest.builder()
 						.messages(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
@@ -408,7 +408,7 @@ class WebMvcSseIntegrationTests {
 	void testRootsWithoutCapability() {
 
 		McpServerFeatures.SyncToolSpecification tool = new McpServerFeatures.SyncToolSpecification(
-				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request) -> {
+				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request, context) -> {
 
 					exchange.listRoots(); // try to list roots
 
@@ -535,7 +535,7 @@ class WebMvcSseIntegrationTests {
 
 		var callResponse = new McpSchema.CallToolResult(List.of(new McpSchema.TextContent("CALL RESPONSE")), null);
 		McpServerFeatures.SyncToolSpecification tool1 = new McpServerFeatures.SyncToolSpecification(
-				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request) -> {
+				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request, context) -> {
 					// perform a blocking call to a remote service
 					String response = RestClient.create()
 						.get()
@@ -571,7 +571,7 @@ class WebMvcSseIntegrationTests {
 
 		var callResponse = new McpSchema.CallToolResult(List.of(new McpSchema.TextContent("CALL RESPONSE")), null);
 		McpServerFeatures.SyncToolSpecification tool1 = new McpServerFeatures.SyncToolSpecification(
-				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request) -> {
+				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request, context) -> {
 					// perform a blocking call to a remote service
 					String response = RestClient.create()
 						.get()
@@ -623,7 +623,7 @@ class WebMvcSseIntegrationTests {
 			// Add a new tool
 			McpServerFeatures.SyncToolSpecification tool2 = new McpServerFeatures.SyncToolSpecification(
 					new McpSchema.Tool("tool2", "tool2 description", emptyJsonSchema),
-					(exchange, request) -> callResponse);
+					(exchange, request, context) -> callResponse);
 
 			mcpServer.addTool(tool2);
 

--- a/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpAsyncServerTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpAsyncServerTests.java
@@ -109,8 +109,9 @@ public abstract class AbstractMcpAsyncServerTests {
 			.capabilities(ServerCapabilities.builder().tools(true).build())
 			.build();
 
-		StepVerifier.create(mcpAsyncServer.addTool(new McpServerFeatures.AsyncToolSpecification(newTool,
-				(exchange, args) -> Mono.just(new CallToolResult(List.of(), false)))))
+		StepVerifier
+			.create(mcpAsyncServer.addTool(new McpServerFeatures.AsyncToolSpecification(newTool,
+					(exchange, args, requestContext) -> Mono.just(new CallToolResult(List.of(), false)))))
 			.verifyComplete();
 
 		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10))).doesNotThrowAnyException();
@@ -123,12 +124,12 @@ public abstract class AbstractMcpAsyncServerTests {
 		var mcpAsyncServer = McpServer.async(createMcpTransportProvider())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
-			.tool(duplicateTool, (exchange, args) -> Mono.just(new CallToolResult(List.of(), false)))
+			.tool(duplicateTool, (exchange, args, requestContext) -> Mono.just(new CallToolResult(List.of(), false)))
 			.build();
 
 		StepVerifier
 			.create(mcpAsyncServer.addTool(new McpServerFeatures.AsyncToolSpecification(duplicateTool,
-					(exchange, args) -> Mono.just(new CallToolResult(List.of(), false)))))
+					(exchange, args, requestContext) -> Mono.just(new CallToolResult(List.of(), false)))))
 			.verifyErrorSatisfies(error -> {
 				assertThat(error).isInstanceOf(McpError.class)
 					.hasMessage("Tool with name '" + TEST_TOOL_NAME + "' already exists");
@@ -144,7 +145,7 @@ public abstract class AbstractMcpAsyncServerTests {
 		var mcpAsyncServer = McpServer.async(createMcpTransportProvider())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
-			.tool(too, (exchange, args) -> Mono.just(new CallToolResult(List.of(), false)))
+			.tool(too, (exchange, args, requestContext) -> Mono.just(new CallToolResult(List.of(), false)))
 			.build();
 
 		StepVerifier.create(mcpAsyncServer.removeTool(TEST_TOOL_NAME)).verifyComplete();
@@ -173,7 +174,7 @@ public abstract class AbstractMcpAsyncServerTests {
 		var mcpAsyncServer = McpServer.async(createMcpTransportProvider())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
-			.tool(too, (exchange, args) -> Mono.just(new CallToolResult(List.of(), false)))
+			.tool(too, (exchange, args, requestContext) -> Mono.just(new CallToolResult(List.of(), false)))
 			.build();
 
 		StepVerifier.create(mcpAsyncServer.notifyToolsListChanged()).verifyComplete();

--- a/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
@@ -117,7 +117,7 @@ public abstract class AbstractMcpSyncServerTests {
 
 		Tool newTool = new McpSchema.Tool("new-tool", "New test tool", emptyJsonSchema);
 		assertThatCode(() -> mcpSyncServer.addTool(new McpServerFeatures.SyncToolSpecification(newTool,
-				(exchange, args) -> new CallToolResult(List.of(), false))))
+				(exchange, args, requestContext) -> new CallToolResult(List.of(), false))))
 			.doesNotThrowAnyException();
 
 		assertThatCode(() -> mcpSyncServer.closeGracefully()).doesNotThrowAnyException();
@@ -130,11 +130,11 @@ public abstract class AbstractMcpSyncServerTests {
 		var mcpSyncServer = McpServer.sync(createMcpTransportProvider())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
-			.tool(duplicateTool, (exchange, args) -> new CallToolResult(List.of(), false))
+			.tool(duplicateTool, (exchange, args, requestContext) -> new CallToolResult(List.of(), false))
 			.build();
 
 		assertThatThrownBy(() -> mcpSyncServer.addTool(new McpServerFeatures.SyncToolSpecification(duplicateTool,
-				(exchange, args) -> new CallToolResult(List.of(), false))))
+				(exchange, args, requestContext) -> new CallToolResult(List.of(), false))))
 			.isInstanceOf(McpError.class)
 			.hasMessage("Tool with name '" + TEST_TOOL_NAME + "' already exists");
 
@@ -148,7 +148,7 @@ public abstract class AbstractMcpSyncServerTests {
 		var mcpSyncServer = McpServer.sync(createMcpTransportProvider())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
-			.tool(tool, (exchange, args) -> new CallToolResult(List.of(), false))
+			.tool(tool, (exchange, args, requestContext) -> new CallToolResult(List.of(), false))
 			.build();
 
 		assertThatCode(() -> mcpSyncServer.removeTool(TEST_TOOL_NAME)).doesNotThrowAnyException();

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -292,7 +292,7 @@ public class McpAsyncServer {
 			// Initialize request handlers for standard MCP methods
 
 			// Ping MUST respond with an empty data, but not NULL response.
-			requestHandlers.put(McpSchema.METHOD_PING, (exchange, params) -> Mono.just(Map.of()));
+			requestHandlers.put(McpSchema.METHOD_PING, (exchange, params, context) -> Mono.just(Map.of()));
 
 			// Add tools API handlers if the tool capability is enabled
 			if (this.serverCapabilities.tools() != null) {
@@ -472,7 +472,7 @@ public class McpAsyncServer {
 		}
 
 		private McpServerSession.RequestHandler<McpSchema.ListToolsResult> toolsListRequestHandler() {
-			return (exchange, params) -> {
+			return (exchange, params, context) -> {
 				List<Tool> tools = this.tools.stream().map(McpServerFeatures.AsyncToolSpecification::tool).toList();
 
 				return Mono.just(new McpSchema.ListToolsResult(tools, null));
@@ -480,7 +480,7 @@ public class McpAsyncServer {
 		}
 
 		private McpServerSession.RequestHandler<CallToolResult> toolsCallRequestHandler() {
-			return (exchange, params) -> {
+			return (exchange, params, context) -> {
 				McpSchema.CallToolRequest callToolRequest = objectMapper.convertValue(params,
 						new TypeReference<McpSchema.CallToolRequest>() {
 						});
@@ -493,7 +493,7 @@ public class McpAsyncServer {
 					return Mono.error(new McpError("Tool not found: " + callToolRequest.name()));
 				}
 
-				return toolSpecification.map(tool -> tool.call().apply(exchange, callToolRequest.arguments()))
+				return toolSpecification.map(tool -> tool.call().apply(exchange, callToolRequest.arguments(), context))
 					.orElse(Mono.error(new McpError("Tool not found: " + callToolRequest.name())));
 			};
 		}
@@ -553,7 +553,7 @@ public class McpAsyncServer {
 		}
 
 		private McpServerSession.RequestHandler<McpSchema.ListResourcesResult> resourcesListRequestHandler() {
-			return (exchange, params) -> {
+			return (exchange, params, context) -> {
 				var resourceList = this.resources.values()
 					.stream()
 					.map(McpServerFeatures.AsyncResourceSpecification::resource)
@@ -563,13 +563,13 @@ public class McpAsyncServer {
 		}
 
 		private McpServerSession.RequestHandler<McpSchema.ListResourceTemplatesResult> resourceTemplateListRequestHandler() {
-			return (exchange, params) -> Mono
+			return (exchange, params, context) -> Mono
 				.just(new McpSchema.ListResourceTemplatesResult(this.resourceTemplates, null));
 
 		}
 
 		private McpServerSession.RequestHandler<McpSchema.ReadResourceResult> resourcesReadRequestHandler() {
-			return (exchange, params) -> {
+			return (exchange, params, context) -> {
 				McpSchema.ReadResourceRequest resourceRequest = objectMapper.convertValue(params,
 						new TypeReference<McpSchema.ReadResourceRequest>() {
 						});
@@ -646,7 +646,7 @@ public class McpAsyncServer {
 		}
 
 		private McpServerSession.RequestHandler<McpSchema.ListPromptsResult> promptsListRequestHandler() {
-			return (exchange, params) -> {
+			return (exchange, params, context) -> {
 				// TODO: Implement pagination
 				// McpSchema.PaginatedRequest request = objectMapper.convertValue(params,
 				// new TypeReference<McpSchema.PaginatedRequest>() {
@@ -662,7 +662,7 @@ public class McpAsyncServer {
 		}
 
 		private McpServerSession.RequestHandler<McpSchema.GetPromptResult> promptsGetRequestHandler() {
-			return (exchange, params) -> {
+			return (exchange, params, context) -> {
 				McpSchema.GetPromptRequest promptRequest = objectMapper.convertValue(params,
 						new TypeReference<McpSchema.GetPromptRequest>() {
 						});
@@ -697,7 +697,7 @@ public class McpAsyncServer {
 		}
 
 		private McpServerSession.RequestHandler<Object> setLoggerRequestHandler() {
-			return (exchange, params) -> {
+			return (exchange, params, context) -> {
 				return Mono.defer(() -> {
 
 					SetLevelRequest newMinLoggingLevel = objectMapper.convertValue(params,
@@ -716,7 +716,7 @@ public class McpAsyncServer {
 		}
 
 		private McpServerSession.RequestHandler<McpSchema.CompleteResult> completionCompleteRequestHandler() {
-			return (exchange, params) -> {
+			return (exchange, params, context) -> {
 				McpSchema.CompleteRequest request = parseCompletionParams(params);
 
 				if (request.ref() == null) {

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpServer.java
@@ -18,6 +18,7 @@ import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.ResourceTemplate;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
+import io.modelcontextprotocol.spec.RequestContext;
 import io.modelcontextprotocol.util.Assert;
 import reactor.core.publisher.Mono;
 
@@ -306,7 +307,7 @@ public interface McpServer {
 		 * @throws IllegalArgumentException if tool or handler is null
 		 */
 		public AsyncSpecification tool(McpSchema.Tool tool,
-				BiFunction<McpAsyncServerExchange, Map<String, Object>, Mono<CallToolResult>> handler) {
+				TriFunction<McpAsyncServerExchange, Map<String, Object>, RequestContext, Mono<CallToolResult>> handler) {
 			Assert.notNull(tool, "Tool must not be null");
 			Assert.notNull(handler, "Handler must not be null");
 
@@ -751,7 +752,7 @@ public interface McpServer {
 		 * @throws IllegalArgumentException if tool or handler is null
 		 */
 		public SyncSpecification tool(McpSchema.Tool tool,
-				BiFunction<McpSyncServerExchange, Map<String, Object>, McpSchema.CallToolResult> handler) {
+				TriFunction<McpSyncServerExchange, Map<String, Object>, RequestContext, McpSchema.CallToolResult> handler) {
 			Assert.notNull(tool, "Tool must not be null");
 			Assert.notNull(handler, "Handler must not be null");
 

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpServerFeatures.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpServerFeatures.java
@@ -4,18 +4,19 @@
 
 package io.modelcontextprotocol.server;
 
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.RequestContext;
+import io.modelcontextprotocol.util.Assert;
+import io.modelcontextprotocol.util.Utils;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
-
-import io.modelcontextprotocol.spec.McpSchema;
-import io.modelcontextprotocol.util.Assert;
-import io.modelcontextprotocol.util.Utils;
-import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 /**
  * MCP server features specification that a particular server can choose to support.
@@ -73,9 +74,9 @@ public class McpServerFeatures {
 					: new McpSchema.ServerCapabilities(null, // completions
 							null, // experimental
 							new McpSchema.ServerCapabilities.LoggingCapabilities(), // Enable
-																					// logging
-																					// by
-																					// default
+							// logging
+							// by
+							// default
 							!Utils.isEmpty(prompts) ? new McpSchema.ServerCapabilities.PromptCapabilities(false) : null,
 							!Utils.isEmpty(resources)
 									? new McpSchema.ServerCapabilities.ResourceCapabilities(false, false) : null,
@@ -181,9 +182,9 @@ public class McpServerFeatures {
 					: new McpSchema.ServerCapabilities(null, // completions
 							null, // experimental
 							new McpSchema.ServerCapabilities.LoggingCapabilities(), // Enable
-																					// logging
-																					// by
-																					// default
+							// logging
+							// by
+							// default
 							!Utils.isEmpty(prompts) ? new McpSchema.ServerCapabilities.PromptCapabilities(false) : null,
 							!Utils.isEmpty(resources)
 									? new McpSchema.ServerCapabilities.ResourceCapabilities(false, false) : null,
@@ -237,7 +238,7 @@ public class McpServerFeatures {
 	 * connected client. The second arguments is a map of tool arguments.
 	 */
 	public record AsyncToolSpecification(McpSchema.Tool tool,
-			BiFunction<McpAsyncServerExchange, Map<String, Object>, Mono<McpSchema.CallToolResult>> call) {
+			TriFunction<McpAsyncServerExchange, Map<String, Object>, RequestContext, Mono<McpSchema.CallToolResult>> call) {
 
 		static AsyncToolSpecification fromSync(SyncToolSpecification tool) {
 			// FIXME: This is temporary, proper validation should be implemented
@@ -245,8 +246,8 @@ public class McpServerFeatures {
 				return null;
 			}
 			return new AsyncToolSpecification(tool.tool(),
-					(exchange, map) -> Mono
-						.fromCallable(() -> tool.call().apply(new McpSyncServerExchange(exchange), map))
+					(exchange, map, context) -> Mono
+						.fromCallable(() -> tool.call().apply(new McpSyncServerExchange(exchange), map, context))
 						.subscribeOn(Schedulers.boundedElastic()));
 		}
 	}
@@ -413,7 +414,8 @@ public class McpServerFeatures {
 	 * client. The second arguments is a map of arguments passed to the tool.
 	 */
 	public record SyncToolSpecification(McpSchema.Tool tool,
-			BiFunction<McpSyncServerExchange, Map<String, Object>, McpSchema.CallToolResult> call) {
+			TriFunction<McpSyncServerExchange, Map<String, Object>, RequestContext, McpSchema.CallToolResult> call) {
+
 	}
 
 	/**

--- a/mcp/src/main/java/io/modelcontextprotocol/server/TriFunction.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/TriFunction.java
@@ -1,0 +1,19 @@
+package io.modelcontextprotocol.server;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * @author taobaorun
+ */
+@FunctionalInterface
+public interface TriFunction<T, U, V, R> {
+
+	R apply(T t, U u, V v);
+
+	default <K> TriFunction<T, U, V, K> andThen(Function<? super R, ? extends K> after) {
+		Objects.requireNonNull(after);
+		return (T t, U u, V v) -> after.apply(apply(t, u, v));
+	}
+
+}

--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
@@ -289,7 +289,7 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 			McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(objectMapper, body.toString());
 
 			// Process the message through the session's handle method
-			session.handle(message).block(); // Block for Servlet compatibility
+			session.handle(request, message).block(); // Block for Servlet compatibility
 
 			response.setStatus(HttpServletResponse.SC_OK);
 		}

--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
@@ -186,7 +186,7 @@ public class StdioServerTransportProvider implements McpServerTransportProvider 
 		}
 
 		private void handleIncomingMessages() {
-			this.inboundSink.asFlux().flatMap(message -> session.handle(message)).doOnTerminate(() -> {
+			this.inboundSink.asFlux().flatMap(message -> session.handle(null, message)).doOnTerminate(() -> {
 				// The outbound processing will dispose its scheduler upon completion
 				this.outboundSink.tryEmitComplete();
 				this.inboundScheduler.dispose();

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/RequestContext.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/RequestContext.java
@@ -1,0 +1,41 @@
+
+package io.modelcontextprotocol.spec;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Represents the context for MCP request execution.
+ *
+ * <p>
+ * The context map can contain any information that is relevant to the request.
+ * </p>
+ *
+ * @author taobaorun
+ */
+public class RequestContext {
+
+	/**
+	 * the original request object
+	 */
+	private Object request;
+
+	private final Map<String, Object> context;
+
+	public RequestContext(Map<String, Object> context) {
+		this.context = Collections.unmodifiableMap(context);
+	}
+
+	public Map<String, Object> getContext() {
+		return context;
+	}
+
+	public Object getRequest() {
+		return request;
+	}
+
+	public void setRequest(Object request) {
+		this.request = request;
+	}
+
+}

--- a/mcp/src/test/java/io/modelcontextprotocol/MockMcpServerTransportProvider.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/MockMcpServerTransportProvider.java
@@ -57,7 +57,7 @@ public class MockMcpServerTransportProvider implements McpServerTransportProvide
 	}
 
 	public void simulateIncomingMessage(McpSchema.JSONRPCMessage message) {
-		session.handle(message).subscribe();
+		session.handle(null, message).subscribe();
 	}
 
 }

--- a/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpAsyncServerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpAsyncServerTests.java
@@ -108,8 +108,9 @@ public abstract class AbstractMcpAsyncServerTests {
 			.capabilities(ServerCapabilities.builder().tools(true).build())
 			.build();
 
-		StepVerifier.create(mcpAsyncServer.addTool(new McpServerFeatures.AsyncToolSpecification(newTool,
-				(exchange, args) -> Mono.just(new CallToolResult(List.of(), false)))))
+		StepVerifier
+			.create(mcpAsyncServer.addTool(new McpServerFeatures.AsyncToolSpecification(newTool,
+					(exchange, args, requestContext) -> Mono.just(new CallToolResult(List.of(), false)))))
 			.verifyComplete();
 
 		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10))).doesNotThrowAnyException();
@@ -122,12 +123,12 @@ public abstract class AbstractMcpAsyncServerTests {
 		var mcpAsyncServer = McpServer.async(createMcpTransportProvider())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
-			.tool(duplicateTool, (exchange, args) -> Mono.just(new CallToolResult(List.of(), false)))
+			.tool(duplicateTool, (exchange, args, requestContext) -> Mono.just(new CallToolResult(List.of(), false)))
 			.build();
 
 		StepVerifier
 			.create(mcpAsyncServer.addTool(new McpServerFeatures.AsyncToolSpecification(duplicateTool,
-					(exchange, args) -> Mono.just(new CallToolResult(List.of(), false)))))
+					(exchange, args, requestContext) -> Mono.just(new CallToolResult(List.of(), false)))))
 			.verifyErrorSatisfies(error -> {
 				assertThat(error).isInstanceOf(McpError.class)
 					.hasMessage("Tool with name '" + TEST_TOOL_NAME + "' already exists");
@@ -143,7 +144,7 @@ public abstract class AbstractMcpAsyncServerTests {
 		var mcpAsyncServer = McpServer.async(createMcpTransportProvider())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
-			.tool(too, (exchange, args) -> Mono.just(new CallToolResult(List.of(), false)))
+			.tool(too, (exchange, args, requestContext) -> Mono.just(new CallToolResult(List.of(), false)))
 			.build();
 
 		StepVerifier.create(mcpAsyncServer.removeTool(TEST_TOOL_NAME)).verifyComplete();
@@ -172,7 +173,7 @@ public abstract class AbstractMcpAsyncServerTests {
 		var mcpAsyncServer = McpServer.async(createMcpTransportProvider())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
-			.tool(too, (exchange, args) -> Mono.just(new CallToolResult(List.of(), false)))
+			.tool(too, (exchange, args, requestContext) -> Mono.just(new CallToolResult(List.of(), false)))
 			.build();
 
 		StepVerifier.create(mcpAsyncServer.notifyToolsListChanged()).verifyComplete();

--- a/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
@@ -116,7 +116,7 @@ public abstract class AbstractMcpSyncServerTests {
 
 		Tool newTool = new McpSchema.Tool("new-tool", "New test tool", emptyJsonSchema);
 		assertThatCode(() -> mcpSyncServer.addTool(new McpServerFeatures.SyncToolSpecification(newTool,
-				(exchange, args) -> new CallToolResult(List.of(), false))))
+				(exchange, args, requestContext) -> new CallToolResult(List.of(), false))))
 			.doesNotThrowAnyException();
 
 		assertThatCode(() -> mcpSyncServer.closeGracefully()).doesNotThrowAnyException();
@@ -129,11 +129,11 @@ public abstract class AbstractMcpSyncServerTests {
 		var mcpSyncServer = McpServer.sync(createMcpTransportProvider())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
-			.tool(duplicateTool, (exchange, args) -> new CallToolResult(List.of(), false))
+			.tool(duplicateTool, (exchange, args, requestContext) -> new CallToolResult(List.of(), false))
 			.build();
 
 		assertThatThrownBy(() -> mcpSyncServer.addTool(new McpServerFeatures.SyncToolSpecification(duplicateTool,
-				(exchange, args) -> new CallToolResult(List.of(), false))))
+				(exchange, args, requestContext) -> new CallToolResult(List.of(), false))))
 			.isInstanceOf(McpError.class)
 			.hasMessage("Tool with name '" + TEST_TOOL_NAME + "' already exists");
 
@@ -147,7 +147,7 @@ public abstract class AbstractMcpSyncServerTests {
 		var mcpSyncServer = McpServer.sync(createMcpTransportProvider())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
-			.tool(tool, (exchange, args) -> new CallToolResult(List.of(), false))
+			.tool(tool, (exchange, args, requestContext) -> new CallToolResult(List.of(), false))
 			.build();
 
 		assertThatCode(() -> mcpSyncServer.removeTool(TEST_TOOL_NAME)).doesNotThrowAnyException();

--- a/mcp/src/test/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProviderIntegrationTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProviderIntegrationTests.java
@@ -108,7 +108,7 @@ class HttpServletSseServerTransportProviderIntegrationTests {
 	void testCreateMessageWithoutSamplingCapabilities() {
 
 		McpServerFeatures.AsyncToolSpecification tool = new McpServerFeatures.AsyncToolSpecification(
-				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request) -> {
+				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request, context) -> {
 
 					exchange.createMessage(mock(McpSchema.CreateMessageRequest.class)).block();
 
@@ -150,7 +150,7 @@ class HttpServletSseServerTransportProviderIntegrationTests {
 				null);
 
 		McpServerFeatures.AsyncToolSpecification tool = new McpServerFeatures.AsyncToolSpecification(
-				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request) -> {
+				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request, context) -> {
 
 					var createMessageRequest = McpSchema.CreateMessageRequest.builder()
 						.messages(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
@@ -225,7 +225,7 @@ class HttpServletSseServerTransportProviderIntegrationTests {
 				null);
 
 		McpServerFeatures.AsyncToolSpecification tool = new McpServerFeatures.AsyncToolSpecification(
-				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request) -> {
+				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request, context) -> {
 
 					var craeteMessageRequest = McpSchema.CreateMessageRequest.builder()
 						.messages(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
@@ -297,7 +297,7 @@ class HttpServletSseServerTransportProviderIntegrationTests {
 				null);
 
 		McpServerFeatures.AsyncToolSpecification tool = new McpServerFeatures.AsyncToolSpecification(
-				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request) -> {
+				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request, context) -> {
 
 					var craeteMessageRequest = McpSchema.CreateMessageRequest.builder()
 						.messages(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
@@ -390,7 +390,7 @@ class HttpServletSseServerTransportProviderIntegrationTests {
 	void testRootsWithoutCapability() {
 
 		McpServerFeatures.SyncToolSpecification tool = new McpServerFeatures.SyncToolSpecification(
-				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request) -> {
+				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request, context) -> {
 
 					exchange.listRoots(); // try to list roots
 
@@ -514,7 +514,7 @@ class HttpServletSseServerTransportProviderIntegrationTests {
 
 		var callResponse = new McpSchema.CallToolResult(List.of(new McpSchema.TextContent("CALL RESPONSE")), null);
 		McpServerFeatures.SyncToolSpecification tool1 = new McpServerFeatures.SyncToolSpecification(
-				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request) -> {
+				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request, context) -> {
 					// perform a blocking call to a remote service
 					String response = RestClient.create()
 						.get()
@@ -550,7 +550,7 @@ class HttpServletSseServerTransportProviderIntegrationTests {
 
 		var callResponse = new McpSchema.CallToolResult(List.of(new McpSchema.TextContent("CALL RESPONSE")), null);
 		McpServerFeatures.SyncToolSpecification tool1 = new McpServerFeatures.SyncToolSpecification(
-				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request) -> {
+				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema), (exchange, request, context) -> {
 					// perform a blocking call to a remote service
 					String response = RestClient.create()
 						.get()
@@ -602,7 +602,7 @@ class HttpServletSseServerTransportProviderIntegrationTests {
 			// Add a new tool
 			McpServerFeatures.SyncToolSpecification tool2 = new McpServerFeatures.SyncToolSpecification(
 					new McpSchema.Tool("tool2", "tool2 description", emptyJsonSchema),
-					(exchange, request) -> callResponse);
+					(exchange, request, context) -> callResponse);
 
 			mcpServer.addTool(tool2);
 
@@ -638,7 +638,7 @@ class HttpServletSseServerTransportProviderIntegrationTests {
 		// Create server with a tool that sends logging notifications
 		McpServerFeatures.AsyncToolSpecification tool = new McpServerFeatures.AsyncToolSpecification(
 				new McpSchema.Tool("logging-test", "Test logging notifications", emptyJsonSchema),
-				(exchange, request) -> {
+				(exchange, request, context) -> {
 
 					// Create and send notifications with different levels
 

--- a/mcp/src/test/java/io/modelcontextprotocol/server/transport/StdioServerTransportProviderTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/transport/StdioServerTransportProviderTests.java
@@ -112,7 +112,7 @@ class StdioServerTransportProviderTests {
 
 		McpServerSession.Factory realSessionFactory = transport -> {
 			McpServerSession session = mock(McpServerSession.class);
-			when(session.handle(any())).thenAnswer(invocation -> {
+			when(session.handle(any(), any())).thenAnswer(invocation -> {
 				capturedMessage.set(invocation.getArgument(0));
 				messageLatch.countDown();
 				return Mono.empty();


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Current call tool flow can't get some information about the request.for example the header value

+  handle with context (map) 
+ context has the  current original request. e.g. ServerRequest
+  has the current sessionId

if has the context,the tool method can get more information.

```java
 @Tool(description = "Get the current date and time in the user's timezone")
        String getCurrentDateTime(@ToolParam(required = false) ToolContext context) {
        context.getContext().get("sessionId")
        return LocalDateTime.now().atZone(LocaleContextHolder.getTimeZone().toZoneId()).toString();
    }
```


## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Worked in the real application


## Breaking Changes
<!-- Will users need to update their code or configurations? -->

+  SyncToolSpecification AsyncToolSpecification  definition  with the context

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
