### PR TITLE
feat: add a method in mcp session to provide the last request timestamp

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpClientSession.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpClientSession.java
@@ -61,6 +61,9 @@ public class McpClientSession implements McpSession {
 	/** Atomic counter for generating unique request IDs */
 	private final AtomicLong requestCounter = new AtomicLong(0);
 
+	/** To record the last request timestamp */
+	private final AtomicLong lastRequestTs = new AtomicLong(System.currentTimeMillis());
+
 	private final Disposable connection;
 
 	/**
@@ -135,6 +138,7 @@ public class McpClientSession implements McpSession {
 			}
 			else if (message instanceof McpSchema.JSONRPCRequest request) {
 				logger.debug("Received request: {}", request);
+				lastRequestTs.set(System.currentTimeMillis());
 				handleIncomingRequest(request).subscribe(response -> transport.sendMessage(response).subscribe(),
 						error -> {
 							var errorResponse = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(),
@@ -284,6 +288,11 @@ public class McpClientSession implements McpSession {
 	public void close() {
 		this.connection.dispose();
 		transport.close();
+	}
+
+	@Override
+	public long lastRequestTimestamp() {
+		return this.lastRequestTs.get();
 	}
 
 }

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
@@ -56,6 +56,9 @@ public class McpServerSession implements McpSession {
 
 	private final AtomicInteger state = new AtomicInteger(STATE_UNINITIALIZED);
 
+	/** To record the last request timestamp */
+	private final AtomicLong lastRequestTs = new AtomicLong(System.currentTimeMillis());
+
 	/**
 	 * Creates a new server session with the given parameters and the transport to use.
 	 * @param id session id
@@ -169,6 +172,7 @@ public class McpServerSession implements McpSession {
 			}
 			else if (message instanceof McpSchema.JSONRPCRequest request) {
 				logger.debug("Received request: {}", request);
+				lastRequestTs.set(System.currentTimeMillis());
 				return handleIncomingRequest(request).onErrorResume(error -> {
 					var errorResponse = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), null,
 							new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INTERNAL_ERROR,
@@ -275,6 +279,11 @@ public class McpServerSession implements McpSession {
 	@Override
 	public void close() {
 		this.transport.close();
+	}
+
+	@Override
+	public long lastRequestTimestamp() {
+		return lastRequestTs.get();
 	}
 
 	/**

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpSession.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpSession.java
@@ -79,4 +79,9 @@ public interface McpSession {
 	 */
 	void close();
 
+	/**
+	 * @return get the timestamp of the last request the session received.
+	 */
+	long lastRequestTimestamp();
+
 }


### PR DESCRIPTION
add a method in mcp session to provide the last request timestamp for the transport provider to check if the session need to be closed
## Motivation and Context
the issue @ #162 , which showed the problem of WebMvcSseServerTransportProvider