### PR TITLE
On branch edburns/38-reactor-mcp-sdk Fixes #38, but in a very trivial way.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # MCP Java SDK
 [![Build Status](https://github.com/modelcontextprotocol/java-sdk/actions/workflows/publish-snapshot.yml/badge.svg)](https://github.com/modelcontextprotocol/java-sdk/actions/workflows/publish-snapshot.yml)
 
-A set of projects that provide Java SDK integration for the [Model Context Protocol](https://modelcontextprotocol.org/docs/concepts/architecture). 
-This SDK enables Java applications to interact with AI models and tools through a standardized interface, supporting both synchronous and asynchronous communication patterns.
+A set of projects that provide Java SDK / `io.projectreactor` integration for the [Model Context Protocol](https://modelcontextprotocol.org/docs/concepts/architecture). 
+This SDK enables Java applications that depend on `io.projectreactor` to interact with AI models and tools through a standardized interface, supporting both synchronous and asynchronous communication patterns.
 
 ## 📚 Reference Documentation 
 

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -10,8 +10,8 @@
 	</parent>
 	<artifactId>mcp</artifactId>
 	<packaging>jar</packaging>
-	<name>Java MCP SDK</name>
-	<description>Java SDK implementation of the Model Context Protocol, enabling seamless integration with language models and AI tools</description>
+	<name>Java MCP SDK (based on io.projectreactor)</name>
+	<description>Java SDK / io.projectreactor implementation of the Model Context Protocol, enabling seamless integration with language models and AI tools</description>
 	<url>https://github.com/modelcontextprotocol/java-sdk</url>
 
 	<scm>


### PR DESCRIPTION
modified:   README.md
modified:   mcp/pom.xml

@hrstoyanov wrote:

> This project requires reactor (and therefore - netty), slf4j for reasons I cannot understand. In its current state it is more like "Spring MCP SDK" rather than "Java MCP SDK", so at least change the project title.

I realize @tzolov proposed a [remedy](https://github.com/orgs/modelcontextprotocol/discussions/246#discussioncomment-12854366), but even that seems problematic because it introduces a dependency on RS Publisher.

In the meantime, please consider this trivial PR, which implements "at least change the project title."

<!-- Provide a brief summary of your changes -->

## Motivation and Context

Fixes #38, but only in a very trivial way

## How Has This Been Tested?

Documentation only.

## Breaking Changes

No

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ X ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X ] My code follows the repository's style guidelines
- [NA ] New and existing tests pass locally
- [NA ] I have added appropriate error handling
- [X ] I have added or updated documentation as needed

## Additional context

I represent a decades long commitment to vendor neutrality in Java standards. Introducing non-neutral dependencies tarnishes the ability of MCP to legitimately call itself a standard.

