### PR TITLE
support auth by HTTP basic auth

### DIFF
--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxSseServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxSseServerTransportProvider.java
@@ -172,7 +172,7 @@ public class WebFluxSseServerTransportProvider implements McpServerTransportProv
 	 * @throws IllegalArgumentException if either parameter is null
 	 */
 	public WebFluxSseServerTransportProvider(ObjectMapper objectMapper, String baseUrl, String messageEndpoint,
-											 String sseEndpoint, McpServerAuthProvider authProvider) {
+			String sseEndpoint, McpServerAuthProvider authProvider) {
 		Assert.notNull(objectMapper, "ObjectMapper must not be null");
 		Assert.notNull(baseUrl, "Message base path must not be null");
 		Assert.notNull(messageEndpoint, "Message endpoint must not be null");
@@ -184,9 +184,9 @@ public class WebFluxSseServerTransportProvider implements McpServerTransportProv
 		this.sseEndpoint = sseEndpoint;
 		this.authProvider = authProvider;
 		this.routerFunction = RouterFunctions.route()
-				.GET(this.sseEndpoint, this::handleSseConnection)
-				.POST(this.messageEndpoint, this::handleMessage)
-				.build();
+			.GET(this.sseEndpoint, this::handleSseConnection)
+			.POST(this.messageEndpoint, this::handleMessage)
+			.build();
 	}
 
 	@Override
@@ -311,10 +311,10 @@ public class WebFluxSseServerTransportProvider implements McpServerTransportProv
 
 	private McpServerAuthParam assemblyAuthParam(ServerRequest request) {
 		return McpServerAuthParam.builder()
-				.sseEndpoint(this.sseEndpoint)
-				.uri(request.uri().toString())
-				.params(request.queryParams().toSingleValueMap())
-				.build();
+			.sseEndpoint(this.sseEndpoint)
+			.uri(request.uri().toString())
+			.params(request.queryParams().toSingleValueMap())
+			.build();
 	}
 
 	/**

--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxSseServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxSseServerTransportProvider.java
@@ -433,6 +433,17 @@ public class WebFluxSseServerTransportProvider implements McpServerTransportProv
 		private String messageEndpoint;
 
 		private String sseEndpoint = DEFAULT_SSE_ENDPOINT;
+		private McpServerAuthProvider authProvider = null;
+
+		/**
+		 * Sets the authentication provider.
+		 * @param authProvider the authentication provider
+		 * @return this builder instance
+		 */
+		public Builder authProvider(McpServerAuthProvider authProvider) {
+			this.authProvider = authProvider;
+			return this;
+		}
 
 		/**
 		 * Sets the ObjectMapper to use for JSON serialization/deserialization of MCP
@@ -494,7 +505,7 @@ public class WebFluxSseServerTransportProvider implements McpServerTransportProv
 			Assert.notNull(objectMapper, "ObjectMapper must be set");
 			Assert.notNull(messageEndpoint, "Message endpoint must be set");
 
-			return new WebFluxSseServerTransportProvider(objectMapper, baseUrl, messageEndpoint, sseEndpoint);
+			return new WebFluxSseServerTransportProvider(objectMapper, baseUrl, messageEndpoint, sseEndpoint, authProvider);
 		}
 
 	}

--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxSseServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxSseServerTransportProvider.java
@@ -433,6 +433,7 @@ public class WebFluxSseServerTransportProvider implements McpServerTransportProv
 		private String messageEndpoint;
 
 		private String sseEndpoint = DEFAULT_SSE_ENDPOINT;
+
 		private McpServerAuthProvider authProvider = null;
 
 		/**
@@ -505,7 +506,8 @@ public class WebFluxSseServerTransportProvider implements McpServerTransportProv
 			Assert.notNull(objectMapper, "ObjectMapper must be set");
 			Assert.notNull(messageEndpoint, "Message endpoint must be set");
 
-			return new WebFluxSseServerTransportProvider(objectMapper, baseUrl, messageEndpoint, sseEndpoint, authProvider);
+			return new WebFluxSseServerTransportProvider(objectMapper, baseUrl, messageEndpoint, sseEndpoint,
+					authProvider);
 		}
 
 	}

--- a/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransportProvider.java
@@ -169,7 +169,7 @@ public class WebMvcSseServerTransportProvider implements McpServerTransportProvi
 	 * @throws IllegalArgumentException if any parameter is null
 	 */
 	public WebMvcSseServerTransportProvider(ObjectMapper objectMapper, String baseUrl, String messageEndpoint,
-											String sseEndpoint, McpServerAuthProvider authProvider) {
+			String sseEndpoint, McpServerAuthProvider authProvider) {
 		Assert.notNull(objectMapper, "ObjectMapper must not be null");
 		Assert.notNull(baseUrl, "Message base URL must not be null");
 		Assert.notNull(messageEndpoint, "Message endpoint must not be null");
@@ -181,9 +181,9 @@ public class WebMvcSseServerTransportProvider implements McpServerTransportProvi
 		this.sseEndpoint = sseEndpoint;
 		this.authProvider = authProvider;
 		this.routerFunction = RouterFunctions.route()
-				.GET(this.sseEndpoint, this::handleSseConnection)
-				.POST(this.messageEndpoint, this::handleMessage)
-				.build();
+			.GET(this.sseEndpoint, this::handleSseConnection)
+			.POST(this.messageEndpoint, this::handleMessage)
+			.build();
 	}
 
 	@Override
@@ -312,10 +312,10 @@ public class WebMvcSseServerTransportProvider implements McpServerTransportProvi
 
 	private McpServerAuthParam assemblyAuthParam(ServerRequest request) {
 		return McpServerAuthParam.builder()
-				.sseEndpoint(this.sseEndpoint)
-				.uri(request.uri().toString())
-				.params(request.params().toSingleValueMap())
-				.build();
+			.sseEndpoint(this.sseEndpoint)
+			.uri(request.uri().toString())
+			.params(request.params().toSingleValueMap())
+			.build();
 	}
 
 	/**

--- a/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransportProvider.java
@@ -64,7 +64,9 @@ import org.springframework.web.servlet.function.ServerResponse.SseBuilder;
  *
  * @author Christian Tzolov
  * @author Alexandros Pappas
+ * @author lambochen
  * @see McpServerTransportProvider
+ * @see McpServerAuthProvider
  * @see RouterFunction
  */
 public class WebMvcSseServerTransportProvider implements McpServerTransportProvider {

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpServerAuthParam.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpServerAuthParam.java
@@ -9,51 +9,58 @@ import java.util.Map;
  */
 public class McpServerAuthParam {
 
-    /**
-     * mcp server sse endpoint
-     */
-    private final String sseEndpoint;
-    /**
-     * mcp server url
-     */
-    private final String uri;
-    /**
-     * mcp server params
-     */
-    private final Map<String, String> params;
+	/**
+	 * mcp server sse endpoint
+	 */
+	private final String sseEndpoint;
 
-    private McpServerAuthParam(String sseEndpoint, String uri, Map<String, String> params) {
-        this.sseEndpoint = sseEndpoint;
-        this.uri = uri;
-        this.params = params;
-    }
+	/**
+	 * mcp server url
+	 */
+	private final String uri;
 
-    public static Builder builder() {
-        return new Builder();
-    }
+	/**
+	 * mcp server params
+	 */
+	private final Map<String, String> params;
 
-    public static class Builder {
-        private String uri;
-        private String sseEndpoint;
-        private Map<String, String> params;
+	private McpServerAuthParam(String sseEndpoint, String uri, Map<String, String> params) {
+		this.sseEndpoint = sseEndpoint;
+		this.uri = uri;
+		this.params = params;
+	}
 
-        public Builder uri(String uri) {
-            this.uri = uri;
-            return this;
-        }
+	public static Builder builder() {
+		return new Builder();
+	}
 
-        public Builder sseEndpoint(String sseEndpoint) {
-            this.sseEndpoint = sseEndpoint;
-            return this;
-        }
+	public static class Builder {
 
-        public Builder params(Map<String, String> params) {
-            this.params = params;
-            return this;
-        }
+		private String uri;
 
-        public McpServerAuthParam build() {
-            return new McpServerAuthParam(sseEndpoint, uri, params);
-        }
-    }
+		private String sseEndpoint;
+
+		private Map<String, String> params;
+
+		public Builder uri(String uri) {
+			this.uri = uri;
+			return this;
+		}
+
+		public Builder sseEndpoint(String sseEndpoint) {
+			this.sseEndpoint = sseEndpoint;
+			return this;
+		}
+
+		public Builder params(Map<String, String> params) {
+			this.params = params;
+			return this;
+		}
+
+		public McpServerAuthParam build() {
+			return new McpServerAuthParam(sseEndpoint, uri, params);
+		}
+
+	}
+
 }

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpServerAuthParam.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpServerAuthParam.java
@@ -1,0 +1,59 @@
+package io.modelcontextprotocol.server;
+
+import java.util.Map;
+
+/**
+ * MCP server authentication context.
+ *
+ * @author lambochen
+ */
+public class McpServerAuthParam {
+
+    /**
+     * mcp server sse endpoint
+     */
+    private final String sseEndpoint;
+    /**
+     * mcp server url
+     */
+    private final String uri;
+    /**
+     * mcp server params
+     */
+    private final Map<String, String> params;
+
+    private McpServerAuthParam(String sseEndpoint, String uri, Map<String, String> params) {
+        this.sseEndpoint = sseEndpoint;
+        this.uri = uri;
+        this.params = params;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String uri;
+        private String sseEndpoint;
+        private Map<String, String> params;
+
+        public Builder uri(String uri) {
+            this.uri = uri;
+            return this;
+        }
+
+        public Builder sseEndpoint(String sseEndpoint) {
+            this.sseEndpoint = sseEndpoint;
+            return this;
+        }
+
+        public Builder params(Map<String, String> params) {
+            this.params = params;
+            return this;
+        }
+
+        public McpServerAuthParam build() {
+            return new McpServerAuthParam(sseEndpoint, uri, params);
+        }
+    }
+}

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpServerAuthParam.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpServerAuthParam.java
@@ -30,6 +30,18 @@ public class McpServerAuthParam {
 		this.params = params;
 	}
 
+	public String getSseEndpoint() {
+		return sseEndpoint;
+	}
+
+	public String getUri() {
+		return uri;
+	}
+
+	public Map<String, String> getParams() {
+		return params;
+	}
+
 	public static Builder builder() {
 		return new Builder();
 	}

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpServerAuthProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpServerAuthProvider.java
@@ -1,0 +1,18 @@
+package io.modelcontextprotocol.server;
+
+/**
+ * Marker interface for the server-side MCP authentication provider.
+ *
+ * @author lambochen
+ */
+public interface McpServerAuthProvider {
+
+    /**
+     * Authenticate by request params
+     *
+     * @param param request params and other information
+     * @return true if authenticate success, otherwise false
+     */
+    boolean authenticate(McpServerAuthParam param);
+
+}

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpServerAuthProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpServerAuthProvider.java
@@ -1,18 +1,17 @@
 package io.modelcontextprotocol.server;
 
 /**
- * Marker interface for the server-side MCP authentication provider.
+ * MCP server authentication provider by request params
  *
  * @author lambochen
  */
 public interface McpServerAuthProvider {
 
-    /**
-     * Authenticate by request params
-     *
-     * @param param request params and other information
-     * @return true if authenticate success, otherwise false
-     */
-    boolean authenticate(McpServerAuthParam param);
+	/**
+	 * Authenticate by request params
+	 * @param param request params and other information
+	 * @return true if authenticate success, otherwise false
+	 */
+	boolean authenticate(McpServerAuthParam param);
 
 }

--- a/mcp/src/test/java/io/modelcontextprotocol/auth/CustomMcpServerAuthProvider.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/auth/CustomMcpServerAuthProvider.java
@@ -1,0 +1,26 @@
+package io.modelcontextprotocol.auth;
+
+import io.modelcontextprotocol.server.McpServerAuthParam;
+import io.modelcontextprotocol.server.McpServerAuthProvider;
+// import org.springframework.stereotype.Component;
+
+/**
+ * MCP Client(eg: Claude) config: ``` { "mcpServers": { "mcp-remote-server-example": {
+ * "url": "http://{your mcp server}/sse?token=xxx" } } } ```
+ *
+ * {@link McpServerAuthProvider} example
+ *
+ * @author lambochen
+ */
+// @Component
+public class CustomMcpServerAuthProvider implements McpServerAuthProvider {
+
+	@Override
+	public boolean authenticate(McpServerAuthParam param) {
+		// example: get param
+		String token = param.getParams().get("token");
+		// TODO do something
+		return true;
+	}
+
+}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Support a way to auth client-server connection by request params. 
I think it's necessary, such as, When using Claude Desktop to connect to a remote MCP Server, only one URL can be filled in. If identity authentication and authorization are implemented, passing information from the request parameters is a good choice.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
