### PR TITLE
fix: Mockito inline mocking for Java 21+

### DIFF
--- a/mcp-spring/mcp-spring-webflux/pom.xml
+++ b/mcp-spring/mcp-spring-webflux/pom.xml
@@ -83,6 +83,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>net.bytebuddy</groupId>
+			<artifactId>byte-buddy</artifactId>
+			<version>${byte-buddy.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-test</artifactId>
 			<scope>test</scope>

--- a/mcp-spring/mcp-spring-webmvc/pom.xml
+++ b/mcp-spring/mcp-spring-webmvc/pom.xml
@@ -78,6 +78,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>net.bytebuddy</groupId>
+			<artifactId>byte-buddy</artifactId>
+			<version>${byte-buddy.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
 			<version>${testcontainers.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -165,11 +165,21 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>properties</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>${maven-surefire-plugin.version}</version>
 				<configuration>
-					<argLine>${surefireArgLine}</argLine>
-
+					<argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>
 					<useFile>false</useFile>
 					<trimStackTrace>false</trimStackTrace>
 


### PR DESCRIPTION
Before this fix the execution of the maven surefire plugin with Java 21 logged warnings that mockito should be added as a java agent, because the self-attaching won't be supported in future java releases.
In Java 24 the test just broke.

This problem is solved by modifying the `pom.xml` of the parent and doing this changes:

* Adding mockito as a java agent.
* Removing the `surefireArgLine` from the properties. This can be added back when it's needed (for example if JaCoCo will be used).

Furthermore, the `pom.xml` in the `mcp-spring-*` modules now have the byte-buddy dependency included, as the test would otherwise break when trying to mock `McpSchema#CreateMessageRequest`.

## Motivation and Context
This is a fix for #187 

## How Has This Been Tested?

I executed `mvn clean package`  with Java 17, 21 and 24 and checked for the warning and whether the modules can be built.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
