### PR TITLE
feat: Add URI template support for MCP resources

### DIFF
--- a/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/WebFluxSseIntegrationTests.java
+++ b/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/WebFluxSseIntegrationTests.java
@@ -776,7 +776,8 @@ class WebFluxSseIntegrationTests {
 		var mcpServer = McpServer.sync(mcpServerTransportProvider)
 			.capabilities(ServerCapabilities.builder().completions().build())
 			.prompts(new McpServerFeatures.SyncPromptSpecification(
-					new Prompt("code_review", "this is code review prompt", List.of()),
+					new Prompt("code_review", "this is code review prompt",
+							List.of(new PromptArgument("language", "string", false))),
 					(mcpSyncServerExchange, getPromptRequest) -> null))
 			.completions(new McpServerFeatures.SyncCompletionSpecification(
 					new McpSchema.PromptReference("ref/prompt", "code_review"), completionHandler))

--- a/mcp/src/main/java/io/modelcontextprotocol/util/DeafaultMcpUriTemplateManagerFactory.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/util/DeafaultMcpUriTemplateManagerFactory.java
@@ -1,0 +1,23 @@
+/*
+* Copyright 2025 - 2025 the original author or authors.
+*/
+package io.modelcontextprotocol.util;
+
+/**
+ * @author Christian Tzolov
+ */
+public class DeafaultMcpUriTemplateManagerFactory implements McpUriTemplateManagerFactory {
+
+	/**
+	 * Creates a new instance of {@link McpUriTemplateManager} with the specified URI
+	 * template.
+	 * @param uriTemplate The URI template to be used for variable extraction
+	 * @return A new instance of {@link McpUriTemplateManager}
+	 * @throws IllegalArgumentException if the URI template is null or empty
+	 */
+	@Override
+	public McpUriTemplateManager create(String uriTemplate) {
+		return new DefaultMcpUriTemplateManager(uriTemplate);
+	}
+
+}

--- a/mcp/src/main/java/io/modelcontextprotocol/util/DefaultMcpUriTemplateManager.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/util/DefaultMcpUriTemplateManager.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package io.modelcontextprotocol.util;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Default implementation of the UriTemplateUtils interface.
+ * <p>
+ * This class provides methods for extracting variables from URI templates and matching
+ * them against actual URIs.
+ *
+ * @author Christian Tzolov
+ */
+public class DefaultMcpUriTemplateManager implements McpUriTemplateManager {
+
+	/**
+	 * Pattern to match URI variables in the format {variableName}.
+	 */
+	private static final Pattern URI_VARIABLE_PATTERN = Pattern.compile("\\{([^/]+?)\\}");
+
+	private final String uriTemplate;
+
+	/**
+	 * Constructor for DefaultMcpUriTemplateManager.
+	 * @param uriTemplate The URI template to be used for variable extraction
+	 */
+	public DefaultMcpUriTemplateManager(String uriTemplate) {
+		if (uriTemplate == null || uriTemplate.isEmpty()) {
+			throw new IllegalArgumentException("URI template must not be null or empty");
+		}
+		this.uriTemplate = uriTemplate;
+	}
+
+	/**
+	 * Extract URI variable names from a URI template.
+	 * @param uriTemplate The URI template containing variables in the format
+	 * {variableName}
+	 * @return A list of variable names extracted from the template
+	 * @throws IllegalArgumentException if duplicate variable names are found
+	 */
+	@Override
+	public List<String> getVariableNames() {
+		if (uriTemplate == null || uriTemplate.isEmpty()) {
+			return List.of();
+		}
+
+		List<String> variables = new ArrayList<>();
+		Matcher matcher = URI_VARIABLE_PATTERN.matcher(this.uriTemplate);
+
+		while (matcher.find()) {
+			String variableName = matcher.group(1);
+			if (variables.contains(variableName)) {
+				throw new IllegalArgumentException("Duplicate URI variable name in template: " + variableName);
+			}
+			variables.add(variableName);
+		}
+
+		return variables;
+	}
+
+	/**
+	 * Extract URI variable values from the actual request URI.
+	 * <p>
+	 * This method converts the URI template into a regex pattern, then uses that pattern
+	 * to extract variable values from the request URI.
+	 * @param requestUri The actual URI from the request
+	 * @return A map of variable names to their values
+	 * @throws IllegalArgumentException if the URI template is invalid or the request URI
+	 * doesn't match the template pattern
+	 */
+	@Override
+	public Map<String, String> extractVariableValues(String requestUri) {
+		Map<String, String> variableValues = new HashMap<>();
+		List<String> uriVariables = this.getVariableNames();
+
+		if (requestUri == null || uriVariables.isEmpty()) {
+			return variableValues;
+		}
+
+		try {
+			// Create a regex pattern by replacing each {variableName} with a capturing
+			// group
+			StringBuilder patternBuilder = new StringBuilder("^");
+
+			// Find all variable placeholders and their positions
+			Matcher variableMatcher = URI_VARIABLE_PATTERN.matcher(uriTemplate);
+			int lastEnd = 0;
+
+			while (variableMatcher.find()) {
+				// Add the text between the last variable and this one, escaped for regex
+				String textBefore = uriTemplate.substring(lastEnd, variableMatcher.start());
+				patternBuilder.append(Pattern.quote(textBefore));
+
+				// Add a capturing group for the variable
+				patternBuilder.append("([^/]+)");
+
+				lastEnd = variableMatcher.end();
+			}
+
+			// Add any remaining text after the last variable
+			if (lastEnd < uriTemplate.length()) {
+				patternBuilder.append(Pattern.quote(uriTemplate.substring(lastEnd)));
+			}
+
+			patternBuilder.append("$");
+
+			// Compile the pattern and match against the request URI
+			Pattern pattern = Pattern.compile(patternBuilder.toString());
+			Matcher matcher = pattern.matcher(requestUri);
+
+			if (matcher.find() && matcher.groupCount() == uriVariables.size()) {
+				for (int i = 0; i < uriVariables.size(); i++) {
+					String value = matcher.group(i + 1);
+					if (value == null || value.isEmpty()) {
+						throw new IllegalArgumentException(
+								"Empty value for URI variable '" + uriVariables.get(i) + "' in URI: " + requestUri);
+					}
+					variableValues.put(uriVariables.get(i), value);
+				}
+			}
+		}
+		catch (Exception e) {
+			throw new IllegalArgumentException("Error parsing URI template: " + uriTemplate + " for URI: " + requestUri,
+					e);
+		}
+
+		return variableValues;
+	}
+
+	/**
+	 * Check if a URI matches the uriTemplate with variables.
+	 * @param uri The URI to check
+	 * @return true if the URI matches the pattern, false otherwise
+	 */
+	@Override
+	public boolean matches(String uri) {
+		// If the uriTemplate doesn't contain variables, do a direct comparison
+		if (!this.isUriTemplate(this.uriTemplate)) {
+			return uri.equals(this.uriTemplate);
+		}
+
+		// Convert the pattern to a regex
+		String regex = this.uriTemplate.replaceAll("\\{[^/]+?\\}", "([^/]+?)");
+		regex = regex.replace("/", "\\/");
+
+		// Check if the URI matches the regex
+		return Pattern.compile(regex).matcher(uri).matches();
+	}
+
+	@Override
+	public boolean isUriTemplate(String uri) {
+		return URI_VARIABLE_PATTERN.matcher(uri).find();
+	}
+
+}

--- a/mcp/src/main/java/io/modelcontextprotocol/util/McpUriTemplateManager.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/util/McpUriTemplateManager.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package io.modelcontextprotocol.util;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Interface for working with URI templates.
+ * <p>
+ * This interface provides methods for extracting variables from URI templates and
+ * matching them against actual URIs.
+ *
+ * @author Christian Tzolov
+ */
+public interface McpUriTemplateManager {
+
+	/**
+	 * Extract URI variable names from this URI template.
+	 * @return A list of variable names extracted from the template
+	 * @throws IllegalArgumentException if duplicate variable names are found
+	 */
+	List<String> getVariableNames();
+
+	/**
+	 * Extract URI variable values from the actual request URI.
+	 * <p>
+	 * This method converts the URI template into a regex pattern, then uses that pattern
+	 * to extract variable values from the request URI.
+	 * @param uri The actual URI from the request
+	 * @return A map of variable names to their values
+	 * @throws IllegalArgumentException if the URI template is invalid or the request URI
+	 * doesn't match the template pattern
+	 */
+	Map<String, String> extractVariableValues(String uri);
+
+	/**
+	 * Indicate whether the given URI matches this template.
+	 * @param uri the URI to match to
+	 * @return {@code true} if it matches; {@code false} otherwise
+	 */
+	boolean matches(String uri);
+
+	/**
+	 * Check if the given URI is a URI template.
+	 * @return Returns true if the URI contains variables in the format {variableName}
+	 */
+	public boolean isUriTemplate(String uri);
+
+}

--- a/mcp/src/main/java/io/modelcontextprotocol/util/McpUriTemplateManagerFactory.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/util/McpUriTemplateManagerFactory.java
@@ -1,0 +1,22 @@
+/*
+* Copyright 2025 - 2025 the original author or authors.
+*/
+package io.modelcontextprotocol.util;
+
+/**
+ * Factory interface for creating instances of {@link McpUriTemplateManager}.
+ *
+ * @author Christian Tzolov
+ */
+public interface McpUriTemplateManagerFactory {
+
+	/**
+	 * Creates a new instance of {@link McpUriTemplateManager} with the specified URI
+	 * template.
+	 * @param uriTemplate The URI template to be used for variable extraction
+	 * @return A new instance of {@link McpUriTemplateManager}
+	 * @throws IllegalArgumentException if the URI template is null or empty
+	 */
+	McpUriTemplateManager create(String uriTemplate);
+
+}

--- a/mcp/src/test/java/io/modelcontextprotocol/McpUriTemplateManagerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/McpUriTemplateManagerTests.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package io.modelcontextprotocol;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import io.modelcontextprotocol.util.DeafaultMcpUriTemplateManagerFactory;
+import io.modelcontextprotocol.util.McpUriTemplateManager;
+import io.modelcontextprotocol.util.McpUriTemplateManagerFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link McpUriTemplateManager} and its implementations.
+ *
+ * @author Christian Tzolov
+ */
+public class McpUriTemplateManagerTests {
+
+	private McpUriTemplateManagerFactory uriTemplateFactory;
+
+	@BeforeEach
+	void setUp() {
+		this.uriTemplateFactory = new DeafaultMcpUriTemplateManagerFactory();
+	}
+
+	@Test
+	void shouldExtractVariableNamesFromTemplate() {
+		List<String> variables = this.uriTemplateFactory.create("/api/users/{userId}/posts/{postId}")
+			.getVariableNames();
+		assertEquals(2, variables.size());
+		assertEquals("userId", variables.get(0));
+		assertEquals("postId", variables.get(1));
+	}
+
+	@Test
+	void shouldReturnEmptyListWhenTemplateHasNoVariables() {
+		List<String> variables = this.uriTemplateFactory.create("/api/users/all").getVariableNames();
+		assertEquals(0, variables.size());
+	}
+
+	@Test
+	void shouldThrowExceptionWhenExtractingVariablesFromNullTemplate() {
+		assertThrows(IllegalArgumentException.class, () -> this.uriTemplateFactory.create(null).getVariableNames());
+	}
+
+	@Test
+	void shouldThrowExceptionWhenExtractingVariablesFromEmptyTemplate() {
+		assertThrows(IllegalArgumentException.class, () -> this.uriTemplateFactory.create("").getVariableNames());
+	}
+
+	@Test
+	void shouldThrowExceptionWhenTemplateContainsDuplicateVariables() {
+		assertThrows(IllegalArgumentException.class,
+				() -> this.uriTemplateFactory.create("/api/users/{userId}/posts/{userId}").getVariableNames());
+	}
+
+	@Test
+	void shouldExtractVariableValuesFromRequestUri() {
+		Map<String, String> values = this.uriTemplateFactory.create("/api/users/{userId}/posts/{postId}")
+			.extractVariableValues("/api/users/123/posts/456");
+		assertEquals(2, values.size());
+		assertEquals("123", values.get("userId"));
+		assertEquals("456", values.get("postId"));
+	}
+
+	@Test
+	void shouldReturnEmptyMapWhenTemplateHasNoVariables() {
+		Map<String, String> values = this.uriTemplateFactory.create("/api/users/all")
+			.extractVariableValues("/api/users/all");
+		assertEquals(0, values.size());
+	}
+
+	@Test
+	void shouldReturnEmptyMapWhenRequestUriIsNull() {
+		Map<String, String> values = this.uriTemplateFactory.create("/api/users/{userId}/posts/{postId}")
+			.extractVariableValues(null);
+		assertEquals(0, values.size());
+	}
+
+	@Test
+	void shouldMatchUriAgainstTemplatePattern() {
+		var uriTemplateManager = this.uriTemplateFactory.create("/api/users/{userId}/posts/{postId}");
+
+		assertTrue(uriTemplateManager.matches("/api/users/123/posts/456"));
+		assertFalse(uriTemplateManager.matches("/api/users/123/comments/456"));
+	}
+
+}


### PR DESCRIPTION
Implement URI template functionality for MCP resources, allowing dynamic resource URIs with variables in the format {variableName}.

- Enable resource URIs with variable placeholders (e.g., "/api/users/{userId}")
- Automatic extraction of variable values from request URIs
- Validation of template arguments in completions
- Matching of request URIs against templates

- Add new URI template management interfaces and implementations
- Enhanced resource template listing to include templated resources
- Updated resource request handling to support template matching
- Test coverage for URI template functionality

