### PR TITLE
Support setting Spring authentication object in McpServerSession

### DIFF
--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -90,6 +90,12 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-core</artifactId>
+			<version>${springframework.version}</version>
+		</dependency>
+
 
 		<dependency>
 			<groupId>io.projectreactor.netty</groupId>

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
@@ -50,6 +50,10 @@ public class McpAsyncServerExchange {
 		this.clientInfo = clientInfo;
 	}
 
+	public McpServerSession getSession() {
+		return session;
+	}
+
 	/**
 	 * Get the client capabilities that define the supported features and functionality.
 	 * @return The client capabilities

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpSyncServerExchange.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpSyncServerExchange.java
@@ -90,4 +90,7 @@ public class McpSyncServerExchange {
 		this.exchange.loggingNotification(loggingMessageNotification).block();
 	}
 
+	public McpAsyncServerExchange getExchange() {
+		return exchange;
+	}
 }

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoSink;
 import reactor.core.publisher.Sinks;
@@ -48,6 +50,8 @@ public class McpServerSession implements McpSession {
 
 	private final AtomicReference<McpSchema.Implementation> clientInfo = new AtomicReference<>();
 
+	private Authentication authentication;
+
 	private static final int STATE_UNINITIALIZED = 0;
 
 	private static final int STATE_INITIALIZING = 1;
@@ -79,6 +83,7 @@ public class McpServerSession implements McpSession {
 		this.initNotificationHandler = initNotificationHandler;
 		this.requestHandlers = requestHandlers;
 		this.notificationHandlers = notificationHandlers;
+		this.authentication = SecurityContextHolder.getContext().getAuthentication();
 	}
 
 	/**
@@ -87,6 +92,14 @@ public class McpServerSession implements McpSession {
 	 */
 	public String getId() {
 		return this.id;
+	}
+
+	/**
+	 * Retrieve authentication object set by Spring security filters as per your project security config
+	 * @return Authentication
+	 */
+	public Authentication getAuthentication() {
+		return authentication;
 	}
 
 	/**


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
Change is required to fetch Spring authentication object in ToolContext of tool method (annotated with @Tool spring annotation). 
Each application has it's own authentication mechanism which can be achieved using Spring Security. Both /sse and /mcp/message endpoint can be authenticated this way but the problem is Authentication object is not available when calling Tool method so that it can be used for authorization.

## How Has This Been Tested?
Yes, the change is tested in our application to work with our internal Auth mechanism.

## Breaking Changes
The change is backward compatible

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x ] My code follows the repository's style guidelines
- [ x] New and existing tests pass locally
- [x ] I have added appropriate error handling
- [ x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
