### PR TITLE
Update example with current Spring WebFlux server API

### DIFF
--- a/mcp-spring/mcp-spring-webflux/README.md
+++ b/mcp-spring/mcp-spring-webflux/README.md
@@ -8,48 +8,51 @@
 ```
 
 ```java
-String MESSAGE_ENDPOINT = "/mcp/message";
+import io.modelcontextprotocol.server.McpAsyncServer;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.transport.WebFluxSseServerTransportProvider;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpServerTransportProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.server.RouterFunction;
 
 @Configuration
-static class MyConfig {
-
+public class MyConfig {
     // SSE transport
-	@Bean
-	public WebFluxSseServerTransport sseServerTransport() {
-		return new WebFluxSseServerTransport(new ObjectMapper(), "/mcp/message");
-	}
+    @Bean
+    public WebFluxSseServerTransportProvider sseServerTransportProvider() {
+        return WebFluxSseServerTransportProvider.builder()
+                .messageEndpoint("/mcp/message")
+                .sseEndpoint("/mcp")
+                .build();
+    }
 
-	// Router function for SSE transport used by Spring WebFlux to start an HTTP
-	// server.
-	@Bean
-	public RouterFunction<?> mcpRouterFunction(WebFluxSseServerTransport transport) {
-		return transport.getRouterFunction();
-	}
+    // Router function for SSE transport used by Spring WebFlux to start an HTTP
+    // server.
+    @Bean
+    public RouterFunction<?> mcpRouterFunction(WebFluxSseServerTransportProvider transport) {
+        return transport.getRouterFunction();
+    }
 
-	@Bean
-	public McpAsyncServer mcpServer(ServerMcpTransport transport, OpenLibrary openLibrary) {
+    @Bean
+    public McpAsyncServer mcpServer(McpServerTransportProvider transport, OpenLibrary openLibrary) {
+        // Configure server capabilities with resource support
+        var capabilities = McpSchema.ServerCapabilities.builder()
+                .resources(false, true) // No subscribe support, but list changes notifications
+                .tools(true) // Tool support with list changes notifications
+                .prompts(true) // Prompt support with list changes notifications
+                .logging() // Logging support
+                .build();
 
-		// Configure server capabilities with resource support
-		var capabilities = McpSchema.ServerCapabilities.builder()
-			.resources(false, true) // No subscribe support, but list changes notifications
-			.tools(true) // Tool support with list changes notifications
-			.prompts(true) // Prompt support with list changes notifications
-			.logging() // Logging support
-			.build();
-
-		// Create the server with both tool and resource capabilities
-		var server = McpServer.using(transport)
-			.serverInfo("MCP Demo Server", "1.0.0")
-			.capabilities(capabilities)
-			.resources(systemInfoResourceRegistration())
-			.prompts(greetingPromptRegistration())
-			.tools(openLibraryToolRegistrations(openLibrary))
-			.async();
-		
-		return server;
-	} 
-
-    // ...
-
+        // Create the server with both tool and resource capabilities
+        return McpServer.async(transport)
+                .serverInfo("MCP Demo Server", "1.0.0")
+                .capabilities(capabilities)
+                .resources(systemInfoResourceRegistration())
+                .prompts(greetingPromptRegistration())
+                .tools(openLibraryToolRegistrations(openLibrary))
+                .build();
+    }
 }
 ```


### PR DESCRIPTION
I was working through using Spring WebFlux on the server, noticed that the example doesn't seem to match the current APIs. Quick update, and no errors in my IDE

## Motivation and Context
Updated docs for clarity

## How Has This Been Tested?
Docs change needs no tests.

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
