### PR TITLE
Support runtime replacement in McpServer via put methods

### DIFF
--- a/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpAsyncServerTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpAsyncServerTests.java
@@ -201,7 +201,7 @@ public abstract class AbstractMcpAsyncServerTests {
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
 			.build();
 
-		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "text/plain", "Test resource description",
+		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "Test resource description", "text/plain",
 				null);
 		McpServerFeatures.AsyncResourceSpecification specification = new McpServerFeatures.AsyncResourceSpecification(
 				resource, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
@@ -233,7 +233,7 @@ public abstract class AbstractMcpAsyncServerTests {
 			.serverInfo("test-server", "1.0.0")
 			.build();
 
-		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "text/plain", "Test resource description",
+		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "Test resource description", "text/plain",
 				null);
 		McpServerFeatures.AsyncResourceSpecification specification = new McpServerFeatures.AsyncResourceSpecification(
 				resource, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));

--- a/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpAsyncServerTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpAsyncServerTests.java
@@ -138,6 +138,30 @@ public abstract class AbstractMcpAsyncServerTests {
 	}
 
 	@Test
+	void testPutTool(){
+		var mcpAsyncServer = McpServer.async(createMcpTransportProvider())
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().tools(true).build())
+			.build();
+
+		Tool toolV1 = new McpSchema.Tool(TEST_TOOL_NAME, "Tool with version 1.0.0", emptyJsonSchema);
+
+		StepVerifier
+			.create(mcpAsyncServer.putTool(new McpServerFeatures.AsyncToolSpecification(toolV1,
+					(exchange, args) -> Mono.just(new CallToolResult(List.of(), false)))))
+			.verifyComplete();
+
+		Tool toolV2 = new McpSchema.Tool(TEST_TOOL_NAME, "Tool with version 2.0.0", emptyJsonSchema);
+
+		StepVerifier
+			.create(mcpAsyncServer.putTool(new McpServerFeatures.AsyncToolSpecification(toolV2,
+					(exchange, args) -> Mono.just(new CallToolResult(List.of(), false)))))
+			.verifyComplete();
+
+		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10))).doesNotThrowAnyException();
+	}
+
+	@Test
 	void testRemoveTool() {
 		Tool too = new McpSchema.Tool(TEST_TOOL_NAME, "Duplicate tool", emptyJsonSchema);
 
@@ -245,6 +269,28 @@ public abstract class AbstractMcpAsyncServerTests {
 	}
 
 	@Test
+	void testPutResource() {
+		var mcpAsyncServer = McpServer.async(createMcpTransportProvider())
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().resources(true, false).build())
+			.build();
+
+		Resource resourceV1 = new Resource(TEST_RESOURCE_URI, "Test Resource",
+				"Resource with version 1.0.0", "text/plain", null);
+		McpServerFeatures.AsyncResourceSpecification specificationV1 = new McpServerFeatures.AsyncResourceSpecification(
+				resourceV1, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
+		StepVerifier.create(mcpAsyncServer.putResource(specificationV1)).verifyComplete();
+
+		Resource resourceV2 = new Resource(TEST_RESOURCE_URI, "Test Resource",
+				"Resource with version 2.0.0", "text/plain", null);
+		McpServerFeatures.AsyncResourceSpecification specificationV2 = new McpServerFeatures.AsyncResourceSpecification(
+				resourceV2, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
+		StepVerifier.create(mcpAsyncServer.putResource(specificationV2)).verifyComplete();
+
+		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10))).doesNotThrowAnyException();
+	}
+
+	@Test
 	void testRemoveResourceWithoutCapability() {
 		// Create a server without resource capabilities
 		McpAsyncServer serverWithoutResources = McpServer.async(createMcpTransportProvider())
@@ -299,6 +345,28 @@ public abstract class AbstractMcpAsyncServerTests {
 			assertThat(error).isInstanceOf(McpError.class)
 				.hasMessage("Server must be configured with prompt capabilities");
 		});
+	}
+
+	@Test
+	void testPutPrompt() {
+		var mcpAsyncServer = McpServer.async(createMcpTransportProvider())
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().prompts(false).build())
+			.build();
+
+		Prompt promptV1 = new Prompt(TEST_PROMPT_NAME, "Prompt with version 1.0.0", List.of());
+		McpServerFeatures.AsyncPromptSpecification specificationV1 = new McpServerFeatures.AsyncPromptSpecification(
+				promptV1, (exchange, req) -> Mono.just(new GetPromptResult("Test prompt description",
+				List.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content"))))));
+
+		StepVerifier.create(mcpAsyncServer.putPrompt(specificationV1)).verifyComplete();
+
+		Prompt promptV2 = new Prompt(TEST_PROMPT_NAME, "Prompt with version 2.0.0", List.of());
+		McpServerFeatures.AsyncPromptSpecification specificationV2 = new McpServerFeatures.AsyncPromptSpecification(
+				promptV2, (exchange, req) -> Mono.just(new GetPromptResult("Test prompt description",
+				List.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content"))))));
+
+		StepVerifier.create(mcpAsyncServer.putPrompt(specificationV2)).verifyComplete();
 	}
 
 	@Test

--- a/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpAsyncServerTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpAsyncServerTests.java
@@ -138,7 +138,7 @@ public abstract class AbstractMcpAsyncServerTests {
 	}
 
 	@Test
-	void testPutTool(){
+	void testPutTool() {
 		var mcpAsyncServer = McpServer.async(createMcpTransportProvider())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
@@ -146,16 +146,14 @@ public abstract class AbstractMcpAsyncServerTests {
 
 		Tool toolV1 = new McpSchema.Tool(TEST_TOOL_NAME, "Tool with version 1.0.0", emptyJsonSchema);
 
-		StepVerifier
-			.create(mcpAsyncServer.putTool(new McpServerFeatures.AsyncToolSpecification(toolV1,
-					(exchange, args) -> Mono.just(new CallToolResult(List.of(), false)))))
+		StepVerifier.create(mcpAsyncServer.putTool(new McpServerFeatures.AsyncToolSpecification(toolV1,
+				(exchange, args) -> Mono.just(new CallToolResult(List.of(), false)))))
 			.verifyComplete();
 
 		Tool toolV2 = new McpSchema.Tool(TEST_TOOL_NAME, "Tool with version 2.0.0", emptyJsonSchema);
 
-		StepVerifier
-			.create(mcpAsyncServer.putTool(new McpServerFeatures.AsyncToolSpecification(toolV2,
-					(exchange, args) -> Mono.just(new CallToolResult(List.of(), false)))))
+		StepVerifier.create(mcpAsyncServer.putTool(new McpServerFeatures.AsyncToolSpecification(toolV2,
+				(exchange, args) -> Mono.just(new CallToolResult(List.of(), false)))))
 			.verifyComplete();
 
 		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10))).doesNotThrowAnyException();
@@ -275,14 +273,14 @@ public abstract class AbstractMcpAsyncServerTests {
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
 			.build();
 
-		Resource resourceV1 = new Resource(TEST_RESOURCE_URI, "Test Resource",
-				"Resource with version 1.0.0", "text/plain", null);
+		Resource resourceV1 = new Resource(TEST_RESOURCE_URI, "Test Resource", "Resource with version 1.0.0",
+				"text/plain", null);
 		McpServerFeatures.AsyncResourceSpecification specificationV1 = new McpServerFeatures.AsyncResourceSpecification(
 				resourceV1, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
 		StepVerifier.create(mcpAsyncServer.putResource(specificationV1)).verifyComplete();
 
-		Resource resourceV2 = new Resource(TEST_RESOURCE_URI, "Test Resource",
-				"Resource with version 2.0.0", "text/plain", null);
+		Resource resourceV2 = new Resource(TEST_RESOURCE_URI, "Test Resource", "Resource with version 2.0.0",
+				"text/plain", null);
 		McpServerFeatures.AsyncResourceSpecification specificationV2 = new McpServerFeatures.AsyncResourceSpecification(
 				resourceV2, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
 		StepVerifier.create(mcpAsyncServer.putResource(specificationV2)).verifyComplete();
@@ -356,15 +354,15 @@ public abstract class AbstractMcpAsyncServerTests {
 
 		Prompt promptV1 = new Prompt(TEST_PROMPT_NAME, "Prompt with version 1.0.0", List.of());
 		McpServerFeatures.AsyncPromptSpecification specificationV1 = new McpServerFeatures.AsyncPromptSpecification(
-				promptV1, (exchange, req) -> Mono.just(new GetPromptResult("Test prompt description",
-				List.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content"))))));
+				promptV1, (exchange, req) -> Mono.just(new GetPromptResult("Test prompt description", List
+					.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content"))))));
 
 		StepVerifier.create(mcpAsyncServer.putPrompt(specificationV1)).verifyComplete();
 
 		Prompt promptV2 = new Prompt(TEST_PROMPT_NAME, "Prompt with version 2.0.0", List.of());
 		McpServerFeatures.AsyncPromptSpecification specificationV2 = new McpServerFeatures.AsyncPromptSpecification(
-				promptV2, (exchange, req) -> Mono.just(new GetPromptResult("Test prompt description",
-				List.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content"))))));
+				promptV2, (exchange, req) -> Mono.just(new GetPromptResult("Test prompt description", List
+					.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content"))))));
 
 		StepVerifier.create(mcpAsyncServer.putPrompt(specificationV2)).verifyComplete();
 	}

--- a/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
@@ -198,7 +198,7 @@ public abstract class AbstractMcpSyncServerTests {
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
 			.build();
 
-		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "text/plain", "Test resource description",
+		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "Test resource description", "text/plain",
 				null);
 		McpServerFeatures.SyncResourceSpecification specification = new McpServerFeatures.SyncResourceSpecification(
 				resource, (exchange, req) -> new ReadResourceResult(List.of()));
@@ -228,7 +228,7 @@ public abstract class AbstractMcpSyncServerTests {
 			.serverInfo("test-server", "1.0.0")
 			.build();
 
-		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "text/plain", "Test resource description",
+		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "Test resource description", "text/plain",
 				null);
 		McpServerFeatures.SyncResourceSpecification specification = new McpServerFeatures.SyncResourceSpecification(
 				resource, (exchange, req) -> new ReadResourceResult(List.of()));

--- a/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
@@ -142,6 +142,28 @@ public abstract class AbstractMcpSyncServerTests {
 	}
 
 	@Test
+	void testPutTool() {
+		var mcpSyncServer = McpServer.sync(createMcpTransportProvider())
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().tools(true).build())
+			.build();
+
+		Tool toolV1 = new McpSchema.Tool(TEST_TOOL_NAME, "Tool with version 1.0.0", emptyJsonSchema);
+
+		assertThatCode(() -> mcpSyncServer.putTool(new McpServerFeatures.SyncToolSpecification(toolV1,
+				(exchange, args) -> new CallToolResult(List.of(), false))))
+			.doesNotThrowAnyException();
+
+		Tool toolV2 = new McpSchema.Tool(TEST_TOOL_NAME, "Tool with version 2.0.0", emptyJsonSchema);
+
+		assertThatCode(() -> mcpSyncServer.putTool(new McpServerFeatures.SyncToolSpecification(toolV2,
+				(exchange, args) -> new CallToolResult(List.of(), false))))
+			.doesNotThrowAnyException();
+
+		assertThatCode(() -> mcpSyncServer.closeGracefully()).doesNotThrowAnyException();
+	}
+
+	@Test
 	void testRemoveTool() {
 		Tool tool = new McpSchema.Tool(TEST_TOOL_NAME, "Test tool", emptyJsonSchema);
 
@@ -238,6 +260,30 @@ public abstract class AbstractMcpSyncServerTests {
 	}
 
 	@Test
+	void testPutResource() {
+		var mcpSyncServer = McpServer.sync(createMcpTransportProvider())
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().resources(true, false).build())
+			.build();
+
+		Resource resourceV1 = new Resource(TEST_RESOURCE_URI, "Test Resource",
+				"Resource with version 1.0.0", "text/plain", null);
+		McpServerFeatures.SyncResourceSpecification specificationV1 = new McpServerFeatures.SyncResourceSpecification(
+				resourceV1, (exchange, req) -> new ReadResourceResult(List.of()));
+		assertThatCode(() -> mcpSyncServer.putResource(specificationV1))
+			.doesNotThrowAnyException();
+
+		Resource resourceV2 = new Resource(TEST_RESOURCE_URI, "Test Resource",
+				"Resource with version 2.0.0", "text/plain", null);
+		McpServerFeatures.SyncResourceSpecification specificationV2 = new McpServerFeatures.SyncResourceSpecification(
+				resourceV2, (exchange, req) -> new ReadResourceResult(List.of()));
+		assertThatCode(() -> mcpSyncServer.putResource(specificationV2))
+			.doesNotThrowAnyException();
+
+		assertThatCode(() -> mcpSyncServer.closeGracefully()).doesNotThrowAnyException();
+	}
+
+	@Test
 	void testRemoveResourceWithoutCapability() {
 		var serverWithoutResources = McpServer.sync(createMcpTransportProvider())
 			.serverInfo("test-server", "1.0.0")
@@ -285,6 +331,26 @@ public abstract class AbstractMcpSyncServerTests {
 
 		assertThatThrownBy(() -> serverWithoutPrompts.addPrompt(specification)).isInstanceOf(McpError.class)
 			.hasMessage("Server must be configured with prompt capabilities");
+	}
+
+	@Test
+	void testPutPrompt(){
+		var mcpSyncServer = McpServer.sync(createMcpTransportProvider())
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().prompts(false).build())
+			.build();
+
+		Prompt promptV1 = new Prompt(TEST_PROMPT_NAME, "Prompt with version 1.0.0", List.of());
+		McpServerFeatures.SyncPromptSpecification specificationV1 = new McpServerFeatures.SyncPromptSpecification(promptV1,
+				(exchange, req) -> new GetPromptResult("Test prompt description", List
+					.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content")))));
+		assertThatCode(() -> mcpSyncServer.putPrompt(specificationV1)).doesNotThrowAnyException();
+
+		Prompt promptV2 = new Prompt(TEST_PROMPT_NAME, "Prompt with version 2.0.0", List.of());
+		McpServerFeatures.SyncPromptSpecification specificationV2 = new McpServerFeatures.SyncPromptSpecification(promptV2,
+				(exchange, req) -> new GetPromptResult("Test prompt description", List
+					.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content")))));
+		assertThatCode(() -> mcpSyncServer.putPrompt(specificationV2)).doesNotThrowAnyException();
 	}
 
 	@Test

--- a/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
@@ -266,19 +266,17 @@ public abstract class AbstractMcpSyncServerTests {
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
 			.build();
 
-		Resource resourceV1 = new Resource(TEST_RESOURCE_URI, "Test Resource",
-				"Resource with version 1.0.0", "text/plain", null);
+		Resource resourceV1 = new Resource(TEST_RESOURCE_URI, "Test Resource", "Resource with version 1.0.0",
+				"text/plain", null);
 		McpServerFeatures.SyncResourceSpecification specificationV1 = new McpServerFeatures.SyncResourceSpecification(
 				resourceV1, (exchange, req) -> new ReadResourceResult(List.of()));
-		assertThatCode(() -> mcpSyncServer.putResource(specificationV1))
-			.doesNotThrowAnyException();
+		assertThatCode(() -> mcpSyncServer.putResource(specificationV1)).doesNotThrowAnyException();
 
-		Resource resourceV2 = new Resource(TEST_RESOURCE_URI, "Test Resource",
-				"Resource with version 2.0.0", "text/plain", null);
+		Resource resourceV2 = new Resource(TEST_RESOURCE_URI, "Test Resource", "Resource with version 2.0.0",
+				"text/plain", null);
 		McpServerFeatures.SyncResourceSpecification specificationV2 = new McpServerFeatures.SyncResourceSpecification(
 				resourceV2, (exchange, req) -> new ReadResourceResult(List.of()));
-		assertThatCode(() -> mcpSyncServer.putResource(specificationV2))
-			.doesNotThrowAnyException();
+		assertThatCode(() -> mcpSyncServer.putResource(specificationV2)).doesNotThrowAnyException();
 
 		assertThatCode(() -> mcpSyncServer.closeGracefully()).doesNotThrowAnyException();
 	}
@@ -334,21 +332,21 @@ public abstract class AbstractMcpSyncServerTests {
 	}
 
 	@Test
-	void testPutPrompt(){
+	void testPutPrompt() {
 		var mcpSyncServer = McpServer.sync(createMcpTransportProvider())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().prompts(false).build())
 			.build();
 
 		Prompt promptV1 = new Prompt(TEST_PROMPT_NAME, "Prompt with version 1.0.0", List.of());
-		McpServerFeatures.SyncPromptSpecification specificationV1 = new McpServerFeatures.SyncPromptSpecification(promptV1,
-				(exchange, req) -> new GetPromptResult("Test prompt description", List
+		McpServerFeatures.SyncPromptSpecification specificationV1 = new McpServerFeatures.SyncPromptSpecification(
+				promptV1, (exchange, req) -> new GetPromptResult("Test prompt description", List
 					.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content")))));
 		assertThatCode(() -> mcpSyncServer.putPrompt(specificationV1)).doesNotThrowAnyException();
 
 		Prompt promptV2 = new Prompt(TEST_PROMPT_NAME, "Prompt with version 2.0.0", List.of());
-		McpServerFeatures.SyncPromptSpecification specificationV2 = new McpServerFeatures.SyncPromptSpecification(promptV2,
-				(exchange, req) -> new GetPromptResult("Test prompt description", List
+		McpServerFeatures.SyncPromptSpecification specificationV2 = new McpServerFeatures.SyncPromptSpecification(
+				promptV2, (exchange, req) -> new GetPromptResult("Test prompt description", List
 					.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content")))));
 		assertThatCode(() -> mcpSyncServer.putPrompt(specificationV2)).doesNotThrowAnyException();
 	}

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -451,7 +451,8 @@ public class McpAsyncServer {
 		return Mono.defer(() -> {
 			if (this.resources.put(resourceSpecification.resource().uri(), resourceSpecification) != null) {
 				logger.debug("Replaced resource handler: {}", resourceSpecification.resource().uri());
-			} else {
+			}
+			else {
 				logger.debug("Added resource handler: {}", resourceSpecification.resource().uri());
 			}
 			if (this.serverCapabilities.resources().listChanged()) {
@@ -601,7 +602,8 @@ public class McpAsyncServer {
 		return Mono.defer(() -> {
 			if (this.prompts.put(promptSpecification.prompt().name(), promptSpecification) != null) {
 				logger.debug("Replaced prompt handler: {}", promptSpecification.prompt().name());
-			} else {
+			}
+			else {
 				logger.debug("Added prompt handler: {}", promptSpecification.prompt().name());
 			}
 

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpSyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpSyncServer.java
@@ -72,6 +72,14 @@ public class McpSyncServer {
 	}
 
 	/**
+	 * Put a new tool handler or update an existing one.
+	 * @param toolHandler The tool handler to put
+	 */
+	public void putTool(McpServerFeatures.SyncToolSpecification toolHandler) {
+		this.asyncServer.putTool(McpServerFeatures.AsyncToolSpecification.fromSync(toolHandler)).block();
+	}
+
+	/**
 	 * Remove a tool handler.
 	 * @param toolName The name of the tool handler to remove
 	 */
@@ -88,6 +96,14 @@ public class McpSyncServer {
 	}
 
 	/**
+	 * Put a new resource handler or update an existing one.
+	 * @param resourceHandler The resource handler to put
+	 */
+	public void putResource(McpServerFeatures.SyncResourceSpecification resourceHandler) {
+		this.asyncServer.putResource(McpServerFeatures.AsyncResourceSpecification.fromSync(resourceHandler)).block();
+	}
+
+	/**
 	 * Remove a resource handler.
 	 * @param resourceUri The URI of the resource handler to remove
 	 */
@@ -101,6 +117,14 @@ public class McpSyncServer {
 	 */
 	public void addPrompt(McpServerFeatures.SyncPromptSpecification promptSpecification) {
 		this.asyncServer.addPrompt(McpServerFeatures.AsyncPromptSpecification.fromSync(promptSpecification)).block();
+	}
+
+	/**
+	 * Put a new prompt handler or update an existing one.
+	 * @param promptSpecification The prompt specification to put
+	 */
+	public void putPrompt(McpServerFeatures.SyncPromptSpecification promptSpecification) {
+		this.asyncServer.putPrompt(McpServerFeatures.AsyncPromptSpecification.fromSync(promptSpecification)).block();
 	}
 
 	/**

--- a/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpAsyncServerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpAsyncServerTests.java
@@ -200,7 +200,7 @@ public abstract class AbstractMcpAsyncServerTests {
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
 			.build();
 
-		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "text/plain", "Test resource description",
+		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "Test resource description", "text/plain",
 				null);
 		McpServerFeatures.AsyncResourceSpecification specification = new McpServerFeatures.AsyncResourceSpecification(
 				resource, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
@@ -232,7 +232,7 @@ public abstract class AbstractMcpAsyncServerTests {
 			.serverInfo("test-server", "1.0.0")
 			.build();
 
-		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "text/plain", "Test resource description",
+		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "Test resource description", "text/plain",
 				null);
 		McpServerFeatures.AsyncResourceSpecification specification = new McpServerFeatures.AsyncResourceSpecification(
 				resource, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));

--- a/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpAsyncServerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpAsyncServerTests.java
@@ -137,7 +137,7 @@ public abstract class AbstractMcpAsyncServerTests {
 	}
 
 	@Test
-	void testPutTool(){
+	void testPutTool() {
 		var mcpAsyncServer = McpServer.async(createMcpTransportProvider())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
@@ -145,16 +145,14 @@ public abstract class AbstractMcpAsyncServerTests {
 
 		Tool toolV1 = new McpSchema.Tool(TEST_TOOL_NAME, "Tool with version 1.0.0", emptyJsonSchema);
 
-		StepVerifier
-			.create(mcpAsyncServer.putTool(new McpServerFeatures.AsyncToolSpecification(toolV1,
-					(exchange, args) -> Mono.just(new CallToolResult(List.of(), false)))))
+		StepVerifier.create(mcpAsyncServer.putTool(new McpServerFeatures.AsyncToolSpecification(toolV1,
+				(exchange, args) -> Mono.just(new CallToolResult(List.of(), false)))))
 			.verifyComplete();
 
 		Tool toolV2 = new McpSchema.Tool(TEST_TOOL_NAME, "Tool with version 2.0.0", emptyJsonSchema);
 
-		StepVerifier
-			.create(mcpAsyncServer.putTool(new McpServerFeatures.AsyncToolSpecification(toolV2,
-					(exchange, args) -> Mono.just(new CallToolResult(List.of(), false)))))
+		StepVerifier.create(mcpAsyncServer.putTool(new McpServerFeatures.AsyncToolSpecification(toolV2,
+				(exchange, args) -> Mono.just(new CallToolResult(List.of(), false)))))
 			.verifyComplete();
 
 		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10))).doesNotThrowAnyException();
@@ -274,14 +272,14 @@ public abstract class AbstractMcpAsyncServerTests {
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
 			.build();
 
-		Resource resourceV1 = new Resource(TEST_RESOURCE_URI, "Test Resource",
-				"Resource with version 1.0.0", "text/plain", null);
+		Resource resourceV1 = new Resource(TEST_RESOURCE_URI, "Test Resource", "Resource with version 1.0.0",
+				"text/plain", null);
 		McpServerFeatures.AsyncResourceSpecification specificationV1 = new McpServerFeatures.AsyncResourceSpecification(
 				resourceV1, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
 		StepVerifier.create(mcpAsyncServer.putResource(specificationV1)).verifyComplete();
 
-		Resource resourceV2 = new Resource(TEST_RESOURCE_URI, "Test Resource",
-				"Resource with version 2.0.0", "text/plain", null);
+		Resource resourceV2 = new Resource(TEST_RESOURCE_URI, "Test Resource", "Resource with version 2.0.0",
+				"text/plain", null);
 		McpServerFeatures.AsyncResourceSpecification specificationV2 = new McpServerFeatures.AsyncResourceSpecification(
 				resourceV2, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
 		StepVerifier.create(mcpAsyncServer.putResource(specificationV2)).verifyComplete();
@@ -355,15 +353,15 @@ public abstract class AbstractMcpAsyncServerTests {
 
 		Prompt promptV1 = new Prompt(TEST_PROMPT_NAME, "Prompt with version 1.0.0", List.of());
 		McpServerFeatures.AsyncPromptSpecification specificationV1 = new McpServerFeatures.AsyncPromptSpecification(
-				promptV1, (exchange, req) -> Mono.just(new GetPromptResult("Test prompt description",
-				List.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content"))))));
+				promptV1, (exchange, req) -> Mono.just(new GetPromptResult("Test prompt description", List
+					.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content"))))));
 
 		StepVerifier.create(mcpAsyncServer.putPrompt(specificationV1)).verifyComplete();
 
 		Prompt promptV2 = new Prompt(TEST_PROMPT_NAME, "Prompt with version 2.0.0", List.of());
 		McpServerFeatures.AsyncPromptSpecification specificationV2 = new McpServerFeatures.AsyncPromptSpecification(
-				promptV2, (exchange, req) -> Mono.just(new GetPromptResult("Test prompt description",
-				List.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content"))))));
+				promptV2, (exchange, req) -> Mono.just(new GetPromptResult("Test prompt description", List
+					.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content"))))));
 
 		StepVerifier.create(mcpAsyncServer.putPrompt(specificationV2)).verifyComplete();
 	}

--- a/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpAsyncServerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpAsyncServerTests.java
@@ -137,6 +137,30 @@ public abstract class AbstractMcpAsyncServerTests {
 	}
 
 	@Test
+	void testPutTool(){
+		var mcpAsyncServer = McpServer.async(createMcpTransportProvider())
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().tools(true).build())
+			.build();
+
+		Tool toolV1 = new McpSchema.Tool(TEST_TOOL_NAME, "Tool with version 1.0.0", emptyJsonSchema);
+
+		StepVerifier
+			.create(mcpAsyncServer.putTool(new McpServerFeatures.AsyncToolSpecification(toolV1,
+					(exchange, args) -> Mono.just(new CallToolResult(List.of(), false)))))
+			.verifyComplete();
+
+		Tool toolV2 = new McpSchema.Tool(TEST_TOOL_NAME, "Tool with version 2.0.0", emptyJsonSchema);
+
+		StepVerifier
+			.create(mcpAsyncServer.putTool(new McpServerFeatures.AsyncToolSpecification(toolV2,
+					(exchange, args) -> Mono.just(new CallToolResult(List.of(), false)))))
+			.verifyComplete();
+
+		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10))).doesNotThrowAnyException();
+	}
+
+	@Test
 	void testRemoveTool() {
 		Tool too = new McpSchema.Tool(TEST_TOOL_NAME, "Duplicate tool", emptyJsonSchema);
 
@@ -244,6 +268,28 @@ public abstract class AbstractMcpAsyncServerTests {
 	}
 
 	@Test
+	void testPutResource() {
+		var mcpAsyncServer = McpServer.async(createMcpTransportProvider())
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().resources(true, false).build())
+			.build();
+
+		Resource resourceV1 = new Resource(TEST_RESOURCE_URI, "Test Resource",
+				"Resource with version 1.0.0", "text/plain", null);
+		McpServerFeatures.AsyncResourceSpecification specificationV1 = new McpServerFeatures.AsyncResourceSpecification(
+				resourceV1, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
+		StepVerifier.create(mcpAsyncServer.putResource(specificationV1)).verifyComplete();
+
+		Resource resourceV2 = new Resource(TEST_RESOURCE_URI, "Test Resource",
+				"Resource with version 2.0.0", "text/plain", null);
+		McpServerFeatures.AsyncResourceSpecification specificationV2 = new McpServerFeatures.AsyncResourceSpecification(
+				resourceV2, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
+		StepVerifier.create(mcpAsyncServer.putResource(specificationV2)).verifyComplete();
+
+		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10))).doesNotThrowAnyException();
+	}
+
+	@Test
 	void testRemoveResourceWithoutCapability() {
 		// Create a server without resource capabilities
 		McpAsyncServer serverWithoutResources = McpServer.async(createMcpTransportProvider())
@@ -298,6 +344,28 @@ public abstract class AbstractMcpAsyncServerTests {
 			assertThat(error).isInstanceOf(McpError.class)
 				.hasMessage("Server must be configured with prompt capabilities");
 		});
+	}
+
+	@Test
+	void testPutPrompt() {
+		var mcpAsyncServer = McpServer.async(createMcpTransportProvider())
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().prompts(false).build())
+			.build();
+
+		Prompt promptV1 = new Prompt(TEST_PROMPT_NAME, "Prompt with version 1.0.0", List.of());
+		McpServerFeatures.AsyncPromptSpecification specificationV1 = new McpServerFeatures.AsyncPromptSpecification(
+				promptV1, (exchange, req) -> Mono.just(new GetPromptResult("Test prompt description",
+				List.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content"))))));
+
+		StepVerifier.create(mcpAsyncServer.putPrompt(specificationV1)).verifyComplete();
+
+		Prompt promptV2 = new Prompt(TEST_PROMPT_NAME, "Prompt with version 2.0.0", List.of());
+		McpServerFeatures.AsyncPromptSpecification specificationV2 = new McpServerFeatures.AsyncPromptSpecification(
+				promptV2, (exchange, req) -> Mono.just(new GetPromptResult("Test prompt description",
+				List.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content"))))));
+
+		StepVerifier.create(mcpAsyncServer.putPrompt(specificationV2)).verifyComplete();
 	}
 
 	@Test

--- a/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
@@ -197,7 +197,7 @@ public abstract class AbstractMcpSyncServerTests {
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
 			.build();
 
-		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "text/plain", "Test resource description",
+		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "Test resource description", "text/plain",
 				null);
 		McpServerFeatures.SyncResourceSpecification specification = new McpServerFeatures.SyncResourceSpecification(
 				resource, (exchange, req) -> new ReadResourceResult(List.of()));
@@ -227,7 +227,7 @@ public abstract class AbstractMcpSyncServerTests {
 			.serverInfo("test-server", "1.0.0")
 			.build();
 
-		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "text/plain", "Test resource description",
+		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "Test resource description", "text/plain",
 				null);
 		McpServerFeatures.SyncResourceSpecification specification = new McpServerFeatures.SyncResourceSpecification(
 				resource, (exchange, req) -> new ReadResourceResult(List.of()));

--- a/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
@@ -141,6 +141,28 @@ public abstract class AbstractMcpSyncServerTests {
 	}
 
 	@Test
+	void testPutTool() {
+		var mcpSyncServer = McpServer.sync(createMcpTransportProvider())
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().tools(true).build())
+			.build();
+
+		Tool toolV1 = new McpSchema.Tool(TEST_TOOL_NAME, "Tool with version 1.0.0", emptyJsonSchema);
+
+		assertThatCode(() -> mcpSyncServer.putTool(new McpServerFeatures.SyncToolSpecification(toolV1,
+				(exchange, args) -> new CallToolResult(List.of(), false))))
+			.doesNotThrowAnyException();
+
+		Tool toolV2 = new McpSchema.Tool(TEST_TOOL_NAME, "Tool with version 2.0.0", emptyJsonSchema);
+
+		assertThatCode(() -> mcpSyncServer.putTool(new McpServerFeatures.SyncToolSpecification(toolV2,
+				(exchange, args) -> new CallToolResult(List.of(), false))))
+			.doesNotThrowAnyException();
+
+		assertThatCode(() -> mcpSyncServer.closeGracefully()).doesNotThrowAnyException();
+	}
+
+	@Test
 	void testRemoveTool() {
 		Tool tool = new McpSchema.Tool(TEST_TOOL_NAME, "Test tool", emptyJsonSchema);
 
@@ -237,6 +259,30 @@ public abstract class AbstractMcpSyncServerTests {
 	}
 
 	@Test
+	void testPutResource() {
+		var mcpSyncServer = McpServer.sync(createMcpTransportProvider())
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().resources(true, false).build())
+			.build();
+
+		Resource resourceV1 = new Resource(TEST_RESOURCE_URI, "Test Resource",
+				"Resource with version 1.0.0", "text/plain", null);
+		McpServerFeatures.SyncResourceSpecification specificationV1 = new McpServerFeatures.SyncResourceSpecification(
+				resourceV1, (exchange, req) -> new ReadResourceResult(List.of()));
+		assertThatCode(() -> mcpSyncServer.putResource(specificationV1))
+			.doesNotThrowAnyException();
+
+		Resource resourceV2 = new Resource(TEST_RESOURCE_URI, "Test Resource",
+				"Resource with version 2.0.0", "text/plain", null);
+		McpServerFeatures.SyncResourceSpecification specificationV2 = new McpServerFeatures.SyncResourceSpecification(
+				resourceV2, (exchange, req) -> new ReadResourceResult(List.of()));
+		assertThatCode(() -> mcpSyncServer.putResource(specificationV2))
+			.doesNotThrowAnyException();
+
+		assertThatCode(() -> mcpSyncServer.closeGracefully()).doesNotThrowAnyException();
+	}
+
+	@Test
 	void testRemoveResourceWithoutCapability() {
 		var serverWithoutResources = McpServer.sync(createMcpTransportProvider())
 			.serverInfo("test-server", "1.0.0")
@@ -284,6 +330,26 @@ public abstract class AbstractMcpSyncServerTests {
 
 		assertThatThrownBy(() -> serverWithoutPrompts.addPrompt(specification)).isInstanceOf(McpError.class)
 			.hasMessage("Server must be configured with prompt capabilities");
+	}
+
+	@Test
+	void testPutPrompt(){
+		var mcpSyncServer = McpServer.sync(createMcpTransportProvider())
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().prompts(false).build())
+			.build();
+
+		Prompt promptV1 = new Prompt(TEST_PROMPT_NAME, "Prompt with version 1.0.0", List.of());
+		McpServerFeatures.SyncPromptSpecification specificationV1 = new McpServerFeatures.SyncPromptSpecification(promptV1,
+				(exchange, req) -> new GetPromptResult("Test prompt description", List
+					.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content")))));
+		assertThatCode(() -> mcpSyncServer.putPrompt(specificationV1)).doesNotThrowAnyException();
+
+		Prompt promptV2 = new Prompt(TEST_PROMPT_NAME, "Prompt with version 2.0.0", List.of());
+		McpServerFeatures.SyncPromptSpecification specificationV2 = new McpServerFeatures.SyncPromptSpecification(promptV2,
+				(exchange, req) -> new GetPromptResult("Test prompt description", List
+					.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content")))));
+		assertThatCode(() -> mcpSyncServer.putPrompt(specificationV2)).doesNotThrowAnyException();
 	}
 
 	@Test

--- a/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
@@ -265,19 +265,17 @@ public abstract class AbstractMcpSyncServerTests {
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
 			.build();
 
-		Resource resourceV1 = new Resource(TEST_RESOURCE_URI, "Test Resource",
-				"Resource with version 1.0.0", "text/plain", null);
+		Resource resourceV1 = new Resource(TEST_RESOURCE_URI, "Test Resource", "Resource with version 1.0.0",
+				"text/plain", null);
 		McpServerFeatures.SyncResourceSpecification specificationV1 = new McpServerFeatures.SyncResourceSpecification(
 				resourceV1, (exchange, req) -> new ReadResourceResult(List.of()));
-		assertThatCode(() -> mcpSyncServer.putResource(specificationV1))
-			.doesNotThrowAnyException();
+		assertThatCode(() -> mcpSyncServer.putResource(specificationV1)).doesNotThrowAnyException();
 
-		Resource resourceV2 = new Resource(TEST_RESOURCE_URI, "Test Resource",
-				"Resource with version 2.0.0", "text/plain", null);
+		Resource resourceV2 = new Resource(TEST_RESOURCE_URI, "Test Resource", "Resource with version 2.0.0",
+				"text/plain", null);
 		McpServerFeatures.SyncResourceSpecification specificationV2 = new McpServerFeatures.SyncResourceSpecification(
 				resourceV2, (exchange, req) -> new ReadResourceResult(List.of()));
-		assertThatCode(() -> mcpSyncServer.putResource(specificationV2))
-			.doesNotThrowAnyException();
+		assertThatCode(() -> mcpSyncServer.putResource(specificationV2)).doesNotThrowAnyException();
 
 		assertThatCode(() -> mcpSyncServer.closeGracefully()).doesNotThrowAnyException();
 	}
@@ -333,21 +331,21 @@ public abstract class AbstractMcpSyncServerTests {
 	}
 
 	@Test
-	void testPutPrompt(){
+	void testPutPrompt() {
 		var mcpSyncServer = McpServer.sync(createMcpTransportProvider())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().prompts(false).build())
 			.build();
 
 		Prompt promptV1 = new Prompt(TEST_PROMPT_NAME, "Prompt with version 1.0.0", List.of());
-		McpServerFeatures.SyncPromptSpecification specificationV1 = new McpServerFeatures.SyncPromptSpecification(promptV1,
-				(exchange, req) -> new GetPromptResult("Test prompt description", List
+		McpServerFeatures.SyncPromptSpecification specificationV1 = new McpServerFeatures.SyncPromptSpecification(
+				promptV1, (exchange, req) -> new GetPromptResult("Test prompt description", List
 					.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content")))));
 		assertThatCode(() -> mcpSyncServer.putPrompt(specificationV1)).doesNotThrowAnyException();
 
 		Prompt promptV2 = new Prompt(TEST_PROMPT_NAME, "Prompt with version 2.0.0", List.of());
-		McpServerFeatures.SyncPromptSpecification specificationV2 = new McpServerFeatures.SyncPromptSpecification(promptV2,
-				(exchange, req) -> new GetPromptResult("Test prompt description", List
+		McpServerFeatures.SyncPromptSpecification specificationV2 = new McpServerFeatures.SyncPromptSpecification(
+				promptV2, (exchange, req) -> new GetPromptResult("Test prompt description", List
 					.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content")))));
 		assertThatCode(() -> mcpSyncServer.putPrompt(specificationV2)).doesNotThrowAnyException();
 	}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Previously, updating a `Tool` at runtime required explicitly calling `removeTool()` followed by `addTool()`. If `listChanged` was enabled, this would trigger two separate notifications to the client. 

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Yes, I tested that the put methods work correctly. The behavior is consistent with performing a remove followed by an add, but without generating redundant notifications.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->