### PR TITLE
feat: supported McpServerSessionListener on SseSession events.

### DIFF
--- a/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransportProvider.java
@@ -12,11 +12,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.modelcontextprotocol.spec.McpError;
-import io.modelcontextprotocol.spec.McpSchema;
-import io.modelcontextprotocol.spec.McpServerTransport;
-import io.modelcontextprotocol.spec.McpServerTransportProvider;
-import io.modelcontextprotocol.spec.McpServerSession;
+import io.modelcontextprotocol.spec.*;
 import io.modelcontextprotocol.util.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,6 +93,8 @@ public class WebMvcSseServerTransportProvider implements McpServerTransportProvi
 
 	private McpServerSession.Factory sessionFactory;
 
+	private McpServerSessionListener<ServerRequest> mcpServerSessionListener;
+
 	/**
 	 * Map of active client sessions, keyed by session ID.
 	 */
@@ -149,6 +147,24 @@ public class WebMvcSseServerTransportProvider implements McpServerTransportProvi
 	 */
 	public WebMvcSseServerTransportProvider(ObjectMapper objectMapper, String baseUrl, String messageEndpoint,
 			String sseEndpoint) {
+		this(objectMapper, baseUrl, messageEndpoint, sseEndpoint, null);
+	}
+
+	/**
+	 * Constructs a new WebMvcSseServerTransportProvider instance.
+	 * @param objectMapper The ObjectMapper to use for JSON serialization/deserialization
+	 * of messages.
+	 * @param baseUrl The base URL for the message endpoint, used to construct the full
+	 * endpoint URL for clients.
+	 * @param messageEndpoint The endpoint URI where clients should send their JSON-RPC
+	 * messages via HTTP POST. This endpoint will be communicated to clients through the
+	 * SSE connection's initial endpoint event.
+	 * @param mcpServerSessionListener The listener for handling server session events.
+	 * @param sseEndpoint The endpoint URI where clients establish their SSE connections.
+	 * @throws IllegalArgumentException if any parameter is null
+	 */
+	public WebMvcSseServerTransportProvider(ObjectMapper objectMapper, String baseUrl, String messageEndpoint,
+			String sseEndpoint, McpServerSessionListener<ServerRequest> mcpServerSessionListener) {
 		Assert.notNull(objectMapper, "ObjectMapper must not be null");
 		Assert.notNull(baseUrl, "Message base URL must not be null");
 		Assert.notNull(messageEndpoint, "Message endpoint must not be null");
@@ -162,6 +178,7 @@ public class WebMvcSseServerTransportProvider implements McpServerTransportProvi
 			.GET(this.sseEndpoint, this::handleSseConnection)
 			.POST(this.messageEndpoint, this::handleMessage)
 			.build();
+		this.mcpServerSessionListener = mcpServerSessionListener;
 	}
 
 	@Override
@@ -213,6 +230,10 @@ public class WebMvcSseServerTransportProvider implements McpServerTransportProvi
 			.flatMap(McpServerSession::closeGracefully)
 			.then()
 			.doOnSuccess(v -> logger.debug("Graceful shutdown completed"));
+	}
+
+	public void setMcpServerSessionListener(McpServerSessionListener<ServerRequest> mcpServerSessionListener) {
+		this.mcpServerSessionListener = mcpServerSessionListener;
 	}
 
 	/**
@@ -275,6 +296,10 @@ public class WebMvcSseServerTransportProvider implements McpServerTransportProvi
 					logger.error("Failed to send initial endpoint event: {}", e.getMessage());
 					sseBuilder.error(e);
 				}
+
+				if (null != mcpServerSessionListener) {
+					mcpServerSessionListener.onConnection(session, request);
+				}
 			}, Duration.ZERO);
 		}
 		catch (Exception e) {
@@ -309,6 +334,10 @@ public class WebMvcSseServerTransportProvider implements McpServerTransportProvi
 
 		if (session == null) {
 			return ServerResponse.status(HttpStatus.NOT_FOUND).body(new McpError("Session not found: " + sessionId));
+		}
+
+		if (null != mcpServerSessionListener) {
+			mcpServerSessionListener.onConnection(session, request);
 		}
 
 		try {
@@ -413,6 +442,11 @@ public class WebMvcSseServerTransportProvider implements McpServerTransportProvi
 			catch (Exception e) {
 				logger.warn("Failed to complete SSE builder for session {}: {}", sessionId, e.getMessage());
 			}
+		}
+
+		@Override
+		public String getSessionId() {
+			return sessionId;
 		}
 
 	}

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -350,9 +350,12 @@ public class McpAsyncServer {
 			notificationHandlers.put(McpSchema.METHOD_NOTIFICATION_ROOTS_LIST_CHANGED,
 					asyncRootsListChangedNotificationHandler(rootsChangeConsumers));
 
-			mcpTransportProvider.setSessionFactory(
-					transport -> new McpServerSession(UUID.randomUUID().toString(), requestTimeout, transport,
-							this::asyncInitializeRequestHandler, Mono::empty, requestHandlers, notificationHandlers));
+			mcpTransportProvider.setSessionFactory(transport -> {
+				// If the sessionId is not provided, generate a random one.
+				String sessionId = Optional.ofNullable(transport.getSessionId()).orElse(UUID.randomUUID().toString());
+				return new McpServerSession(sessionId, requestTimeout, transport, this::asyncInitializeRequestHandler,
+						Mono::empty, requestHandlers, notificationHandlers);
+			});
 		}
 
 		// ---------------------------------------

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -183,9 +183,12 @@ public class McpAsyncServer {
 		notificationHandlers.put(McpSchema.METHOD_NOTIFICATION_ROOTS_LIST_CHANGED,
 				asyncRootsListChangedNotificationHandler(rootsChangeConsumers));
 
-		mcpTransportProvider.setSessionFactory(
-				transport -> new McpServerSession(UUID.randomUUID().toString(), requestTimeout, transport,
-						this::asyncInitializeRequestHandler, Mono::empty, requestHandlers, notificationHandlers));
+		mcpTransportProvider.setSessionFactory(transport -> {
+			// If the sessionId is not provided, generate a random one.
+			String sessionId = Optional.ofNullable(transport.getSessionId()).orElse(UUID.randomUUID().toString());
+			return new McpServerSession(sessionId, requestTimeout, transport, this::asyncInitializeRequestHandler,
+					Mono::empty, requestHandlers, notificationHandlers);
+		});
 	}
 
 	// ---------------------------------------

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
@@ -51,6 +51,14 @@ public class McpAsyncServerExchange {
 	}
 
 	/**
+	 * Get the session id.
+	 * @return The session id
+	 */
+	public String getSessionId() {
+		return this.session.getId();
+	}
+
+	/**
 	 * Get the client capabilities that define the supported features and functionality.
 	 * @return The client capabilities
 	 */

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpSyncServerExchange.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpSyncServerExchange.java
@@ -29,6 +29,14 @@ public class McpSyncServerExchange {
 	}
 
 	/**
+	 * Get the session id.
+	 * @return The session id
+	 */
+	public String getSessionId() {
+		return this.exchange.getSessionId();
+	}
+
+	/**
 	 * Get the client capabilities that define the supported features and functionality.
 	 * @return The client capabilities
 	 */

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerSessionListener.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerSessionListener.java
@@ -1,0 +1,25 @@
+package io.modelcontextprotocol.spec;
+
+/**
+ * Listener for McpServerSession events.
+ *
+ * @param <T> The type of request object used in the session.
+ * @author Allen Hu
+ */
+public interface McpServerSessionListener<T> {
+
+	/**
+	 * Called when a new session is connected.
+	 * @param session The session that was connected.
+	 * @param request The request object used in the session.
+	 */
+	void onConnection(McpServerSession session, T request);
+
+	/**
+	 * Called when a message is received.
+	 * @param session The session that received the message.
+	 * @param request The request object used in the session.
+	 */
+	void onMessage(McpServerSession session, T request);
+
+}

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerTransport.java
@@ -8,4 +8,12 @@ package io.modelcontextprotocol.spec;
  */
 public interface McpServerTransport extends McpTransport {
 
+	/**
+	 * Returns the session id.
+	 * @return the session id. default is null.
+	 */
+	default String getSessionId() {
+		return null;
+	}
+
 }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
https://github.com/modelcontextprotocol/java-sdk/issues/59
https://github.com/modelcontextprotocol/java-sdk/issues/77

### feat:
In the development of MCP in business systems, the SSE server usually needs to obtain client identity information, such as user information, when processing with the @Tool tool. Currently, most MCP clients support passing user information through HTTP Headers, such as API KEY. However, the MCP SDK cannot pass HTTP Headers to the @Tool method. Therefore, this change mainly supports this requirement.

### fix:
In addition, it also fixes the issue where the keys and corresponding values of the sessions variable in WebMvcSseServerTransportProvider are inconsistent with the sessionId.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

### with Spring-AI
**McpWebFluxServerAutoConfiguration.java**
```
@Bean
@ConditionalOnMissingBean
public WebFluxSseServerTransportProvider webFluxTransport(ObjectProvider<ObjectMapper> objectMapperProvider,
		McpServerProperties serverProperties,
		ObjectProvider<McpServerSessionListener<ServerRequest>> mcpServerSessionListeners) {
	ObjectMapper objectMapper = objectMapperProvider.getIfAvailable(ObjectMapper::new);
	WebFluxSseServerTransportProvider webFluxSseServerTransportProvider = new WebFluxSseServerTransportProvider(
			objectMapper, serverProperties.getSseMessageEndpoint(), serverProperties.getSseEndpoint());
	webFluxSseServerTransportProvider.setMcpServerSessionListener(mcpServerSessionListeners.getIfAvailable());
	return webFluxSseServerTransportProvider;
}
```

**ToolProviderAutoConfiguration.java**
```
@Configuration
public class ToolProviderAutoConfiguration {

    public static final Map<String, HttpHeaders> sessionHeaders = new ConcurrentHashMap<>();

    @Bean
    public ToolCallbackProvider toolCallbackProvider(WeatherToolProvider weatherToolProvider) {
        return MethodToolCallbackProvider.builder().toolObjects(weatherToolProvider).build();
    }

    @Bean
    public McpServerSessionListener<ServerRequest> mcpServerSessionListener() {
        return new McpServerSessionListener<>() {

            @Override
            public void onConnection(McpServerSession session, ServerRequest request) {
                HttpHeaders httpHeaders = request.headers().asHttpHeaders();
                sessionHeaders.put(session.getId(), httpHeaders);
            }

            @Override
            public void onMessage(McpServerSession session, ServerRequest request) {
            }
        };
    }
}
```

**WeatherToolProvider.java**
```
@Service
public class WeatherToolProvider {

    @Tool(name = "query_weather", description = "查询天气信息。")
    public String queryWeather(String city,
                               ToolContext toolContext) {
        Object o = toolContext.getContext().get("exchange");
        if (o instanceof McpSyncServerExchange) {
            String sessionId = ((McpSyncServerExchange) o).getSessionId();
            log.info("sessionId: {}", sessionId);

            HttpHeaders httpHeaders = ToolProviderAutoConfiguration.sessionHeaders.get(sessionId);
            log.info("httpHeaders: {}", httpHeaders);
        }

        return "今天晴转多云，18-26°C，东南风3-4级。";
    }
}
```

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No need, add an interface, implementation is not necessary.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
After the change is merged, I will submit the auto configure code for spring-ai.