### PR TITLE
Annotation classes to support variety of frameworks/tools

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/annotations/Tool.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/annotations/Tool.java
@@ -1,0 +1,15 @@
+package io.modelcontextprotocol.annotations;
+
+import io.modelcontextprotocol.util.ToolCallResultConverter;
+
+public @interface Tool {
+
+	String name() default "";
+
+	String description() default "";
+
+	boolean returnDirect() default false;
+
+	Class<? extends ToolCallResultConverter> resultConverter();
+
+}

--- a/mcp/src/main/java/io/modelcontextprotocol/annotations/ToolParam.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/annotations/ToolParam.java
@@ -1,0 +1,9 @@
+package io.modelcontextprotocol.annotations;
+
+public @interface ToolParam {
+
+	boolean required() default true;
+
+	String description() default "";
+
+}

--- a/mcp/src/main/java/io/modelcontextprotocol/util/ToolCallResultConverter.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/util/ToolCallResultConverter.java
@@ -1,0 +1,9 @@
+package io.modelcontextprotocol.util;
+
+import java.lang.reflect.Type;
+
+public interface ToolCallResultConverter {
+
+	String convert(Object result, Type returnType);
+
+}


### PR DESCRIPTION
This pr defines two annotation classes (Tool and ToolParam) and one support interface class ToolCallResultConverter.   

As per issue #224 it would be helpful if the mcp java sdk had these annotation classes so that tools builders didn't need to create their own/duplicate separate annotations for each tool suite.  As things are now,  java tooling and framework builders are creating their own Tool and ToolParam annotation classes, making it difficult to be tooling vendor independent wrt building mcp servers.

## Motivation and Context
Having these classes as part of the mcp sdk would allow vendor neutral mcp servers to be more easily created.

## Breaking Changes
This should supersede the tooling and framework-specific annotation classes each framework vendor is using.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Additional context

Obviously, these annotation classes are very much like the vendor-specific versions currently being deployed.   I would suggest that this change be made before/as part of 1.0.0 release of mcp sdk.

I've intentionally left off any copyright notice, license, or documentation.  Any appropriate for this project is fine with me.  I would expect that wrt documentation links to the specification fields (e.g. description) could be provided.   I would not object to changing package structure or other naming.  This is just a suggestion
