### PR TITLE
Fix stdio tests - proper server-everything argument

### DIFF
--- a/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpAsyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpAsyncClientTests.java
@@ -25,12 +25,12 @@ class StdioMcpAsyncClientTests extends AbstractMcpAsyncClientTests {
 		ServerParameters stdioParams;
 		if (System.getProperty("os.name").toLowerCase().contains("win")) {
 			stdioParams = ServerParameters.builder("cmd.exe")
-				.args("/c", "npx.cmd", "-y", "@modelcontextprotocol/server-everything", "dir")
+				.args("/c", "npx.cmd", "-y", "@modelcontextprotocol/server-everything", "stdio")
 				.build();
 		}
 		else {
 			stdioParams = ServerParameters.builder("npx")
-				.args("-y", "@modelcontextprotocol/server-everything", "dir")
+				.args("-y", "@modelcontextprotocol/server-everything", "stdio")
 				.build();
 		}
 		return new StdioClientTransport(stdioParams);

--- a/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpSyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpSyncClientTests.java
@@ -33,12 +33,12 @@ class StdioMcpSyncClientTests extends AbstractMcpSyncClientTests {
 		ServerParameters stdioParams;
 		if (System.getProperty("os.name").toLowerCase().contains("win")) {
 			stdioParams = ServerParameters.builder("cmd.exe")
-				.args("/c", "npx.cmd", "-y", "@modelcontextprotocol/server-everything", "dir")
+				.args("/c", "npx.cmd", "-y", "@modelcontextprotocol/server-everything", "stdio")
 				.build();
 		}
 		else {
 			stdioParams = ServerParameters.builder("npx")
-				.args("-y", "@modelcontextprotocol/server-everything", "dir")
+				.args("-y", "@modelcontextprotocol/server-everything", "stdio")
 				.build();
 		}
 		return new StdioClientTransport(stdioParams);


### PR DESCRIPTION
The Stdio test started to fail due to a change in the server-everything running in Docker.