### PR TITLE
fix: model content annotations as nested objects

### DIFF
--- a/mcp-test/pom.xml
+++ b/mcp-test/pom.xml
@@ -55,6 +55,11 @@
 			<version>${junit.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+			<version>${junit.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<version>${mockito.version}</version>

--- a/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
@@ -31,6 +31,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -38,6 +40,8 @@ import reactor.test.StepVerifier;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
  * Test suite for the {@link McpAsyncClient} that can be used with different
@@ -199,6 +203,64 @@ public abstract class AbstractMcpAsyncClientTests {
 				.consumeErrorWith(
 						e -> assertThat(e).isInstanceOf(McpError.class).hasMessage("Unknown tool: nonexistent_tool"))
 				.verify();
+		});
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "success", "error", "debug" })
+	void testCallToolWithMessageAnnotations(String messageType) {
+		McpClientTransport transport = createMcpTransport();
+
+		withClient(transport, mcpAsyncClient -> {
+			StepVerifier.create(mcpAsyncClient.initialize()
+				.then(mcpAsyncClient.callTool(new McpSchema.CallToolRequest("annotatedMessage",
+						Map.of("messageType", messageType, "includeImage", true)))))
+				.consumeNextWith(result -> {
+					assertThat(result).isNotNull();
+					assertThat(result.isError()).isNotEqualTo(true);
+					assertThat(result.content()).isNotEmpty();
+					assertThat(result.content()).allSatisfy(content -> {
+						switch (content.type()) {
+							case "text":
+								McpSchema.TextContent textContent = assertInstanceOf(McpSchema.TextContent.class,
+										content);
+								assertThat(textContent.text()).isNotEmpty();
+								assertThat(textContent.annotations()).isNotNull();
+
+								switch (messageType) {
+									case "error":
+										assertThat(textContent.annotations().priority()).isEqualTo(1.0);
+										assertThat(textContent.annotations().audience())
+											.containsOnly(McpSchema.Role.USER, McpSchema.Role.ASSISTANT);
+										break;
+									case "success":
+										assertThat(textContent.annotations().priority()).isEqualTo(0.7);
+										assertThat(textContent.annotations().audience())
+											.containsExactly(McpSchema.Role.USER);
+										break;
+									case "debug":
+										assertThat(textContent.annotations().priority()).isEqualTo(0.3);
+										assertThat(textContent.annotations().audience())
+											.containsExactly(McpSchema.Role.ASSISTANT);
+										break;
+									default:
+										throw new IllegalStateException("Unexpected value: " + content.type());
+								}
+								break;
+							case "image":
+								McpSchema.ImageContent imageContent = assertInstanceOf(McpSchema.ImageContent.class,
+										content);
+								assertThat(imageContent.data()).isNotEmpty();
+								assertThat(imageContent.annotations()).isNotNull();
+								assertThat(imageContent.annotations().priority()).isEqualTo(0.5);
+								assertThat(imageContent.annotations().audience()).containsExactly(McpSchema.Role.USER);
+								break;
+							default:
+								fail("Unexpected content type: " + content.type());
+						}
+					});
+				})
+				.verifyComplete();
 		});
 	}
 

--- a/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
@@ -30,6 +30,8 @@ import io.modelcontextprotocol.spec.McpSchema.UnsubscribeRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
@@ -38,6 +40,8 @@ import reactor.test.StepVerifier;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
  * Unit tests for MCP Client Session functionality.
@@ -179,6 +183,60 @@ public abstract class AbstractMcpSyncClientTests {
 				assertThat(content).isNotNull();
 				assertThat(content.text()).isNotNull();
 				assertThat(content.text()).contains("7");
+			});
+		});
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "success", "error", "debug" })
+	void testCallToolWithMessageAnnotations(String messageType) {
+		McpClientTransport transport = createMcpTransport();
+
+		withClient(transport, client -> {
+			client.initialize();
+
+			McpSchema.CallToolResult result = client.callTool(new McpSchema.CallToolRequest("annotatedMessage",
+					Map.of("messageType", messageType, "includeImage", true)));
+
+			assertThat(result).isNotNull();
+			assertThat(result.isError()).isNotEqualTo(true);
+			assertThat(result.content()).isNotEmpty();
+			assertThat(result.content()).allSatisfy(content -> {
+				switch (content.type()) {
+					case "text":
+						McpSchema.TextContent textContent = assertInstanceOf(McpSchema.TextContent.class, content);
+						assertThat(textContent.text()).isNotEmpty();
+						assertThat(textContent.annotations()).isNotNull();
+
+						switch (messageType) {
+							case "error":
+								assertThat(textContent.annotations().priority()).isEqualTo(1.0);
+								assertThat(textContent.annotations().audience()).containsOnly(McpSchema.Role.USER,
+										McpSchema.Role.ASSISTANT);
+								break;
+							case "success":
+								assertThat(textContent.annotations().priority()).isEqualTo(0.7);
+								assertThat(textContent.annotations().audience()).containsExactly(McpSchema.Role.USER);
+								break;
+							case "debug":
+								assertThat(textContent.annotations().priority()).isEqualTo(0.3);
+								assertThat(textContent.annotations().audience())
+									.containsExactly(McpSchema.Role.ASSISTANT);
+								break;
+							default:
+								throw new IllegalStateException("Unexpected value: " + content.type());
+						}
+						break;
+					case "image":
+						McpSchema.ImageContent imageContent = assertInstanceOf(McpSchema.ImageContent.class, content);
+						assertThat(imageContent.data()).isNotEmpty();
+						assertThat(imageContent.annotations()).isNotNull();
+						assertThat(imageContent.annotations().priority()).isEqualTo(0.5);
+						assertThat(imageContent.annotations().audience()).containsExactly(McpSchema.Role.USER);
+						break;
+					default:
+						fail("Unexpected content type: " + content.type());
+				}
 			});
 		});
 	}

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -1277,30 +1277,52 @@ public final class McpSchema {
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record TextContent( // @formatter:off
-		@JsonProperty("audience") List<Role> audience,
-		@JsonProperty("priority") Double priority,
-		@JsonProperty("text") String text) implements Content { // @formatter:on
+		@JsonProperty("annotations") Annotations annotations,
+		@JsonProperty("text") String text) implements Annotated, Content { // @formatter:on
 
 		public TextContent(String content) {
-			this(null, null, content);
+			this(null, content);
+		}
+
+		/**
+		 * @deprecated Only exists for backwards-compatibility purposes. Use
+		 * {@link TextContent#TextContent(Annotations, String)} instead.
+		 */
+		public TextContent(List<Role> audience, Double priority, String content) {
+			this(audience != null || priority != null ? new Annotations(audience, priority) : null, content);
 		}
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ImageContent( // @formatter:off
-		@JsonProperty("audience") List<Role> audience,
-		@JsonProperty("priority") Double priority,
+		@JsonProperty("annotations") Annotations annotations,
 		@JsonProperty("data") String data,
-		@JsonProperty("mimeType") String mimeType) implements Content { // @formatter:on
+		@JsonProperty("mimeType") String mimeType) implements Annotated, Content { // @formatter:on
+
+		/**
+		 * @deprecated Only exists for backwards-compatibility purposes. Use
+		 * {@link ImageContent#ImageContent(Annotations, String, String)} instead.
+		 */
+		public ImageContent(List<Role> audience, Double priority, String data, String mimeType) {
+			this(audience != null || priority != null ? new Annotations(audience, priority) : null, data, mimeType);
+		}
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record EmbeddedResource( // @formatter:off
-		@JsonProperty("audience") List<Role> audience,
-		@JsonProperty("priority") Double priority,
-		@JsonProperty("resource") ResourceContents resource) implements Content { // @formatter:on
+		@JsonProperty("annotations") Annotations annotations,
+		@JsonProperty("resource") ResourceContents resource) implements Annotated, Content { // @formatter:on
+
+		/**
+		 * @deprecated Only exists for backwards-compatibility purposes. Use
+		 * {@link EmbeddedResource#EmbeddedResource(Annotations, ResourceContents)}
+		 * instead.
+		 */
+		public EmbeddedResource(List<Role> audience, Double priority, ResourceContents resource) {
+			this(audience != null || priority != null ? new Annotations(audience, priority) : null, resource);
+		}
 	}
 
 	// ---------------------------

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -5,10 +5,7 @@
 package io.modelcontextprotocol.spec;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -1291,6 +1288,22 @@ public final class McpSchema {
 		public TextContent(List<Role> audience, Double priority, String content) {
 			this(audience != null || priority != null ? new Annotations(audience, priority) : null, content);
 		}
+
+		/**
+		 * @deprecated Only exists for backwards-compatibility purposes. Use
+		 * {@link TextContent#annotations()} instead.
+		 */
+		public List<Role> audience() {
+			return annotations == null ? null : annotations.audience();
+		}
+
+		/**
+		 * @deprecated Only exists for backwards-compatibility purposes. Use
+		 * {@link TextContent#annotations()} instead.
+		 */
+		public Double priority() {
+			return annotations == null ? null : annotations.priority();
+		}
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
@@ -1307,6 +1320,22 @@ public final class McpSchema {
 		public ImageContent(List<Role> audience, Double priority, String data, String mimeType) {
 			this(audience != null || priority != null ? new Annotations(audience, priority) : null, data, mimeType);
 		}
+
+		/**
+		 * @deprecated Only exists for backwards-compatibility purposes. Use
+		 * {@link ImageContent#annotations()} instead.
+		 */
+		public List<Role> audience() {
+			return annotations == null ? null : annotations.audience();
+		}
+
+		/**
+		 * @deprecated Only exists for backwards-compatibility purposes. Use
+		 * {@link ImageContent#annotations()} instead.
+		 */
+		public Double priority() {
+			return annotations == null ? null : annotations.priority();
+		}
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
@@ -1322,6 +1351,22 @@ public final class McpSchema {
 		 */
 		public EmbeddedResource(List<Role> audience, Double priority, ResourceContents resource) {
 			this(audience != null || priority != null ? new Annotations(audience, priority) : null, resource);
+		}
+
+		/**
+		 * @deprecated Only exists for backwards-compatibility purposes. Use
+		 * {@link EmbeddedResource#annotations()} instead.
+		 */
+		public List<Role> audience() {
+			return annotations == null ? null : annotations.audience();
+		}
+
+		/**
+		 * @deprecated Only exists for backwards-compatibility purposes. Use
+		 * {@link EmbeddedResource#annotations()} instead.
+		 */
+		public Double priority() {
+			return annotations == null ? null : annotations.priority();
 		}
 	}
 

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -5,7 +5,10 @@
 package io.modelcontextprotocol.spec;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -40,6 +42,8 @@ import reactor.test.StepVerifier;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
  * Test suite for the {@link McpAsyncClient} that can be used with different
@@ -202,6 +206,64 @@ public abstract class AbstractMcpAsyncClientTests {
 				.consumeErrorWith(
 						e -> assertThat(e).isInstanceOf(McpError.class).hasMessage("Unknown tool: nonexistent_tool"))
 				.verify();
+		});
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "success", "error", "debug" })
+	void testCallToolWithMessageAnnotations(String messageType) {
+		McpClientTransport transport = createMcpTransport();
+
+		withClient(transport, mcpAsyncClient -> {
+			StepVerifier.create(mcpAsyncClient.initialize()
+				.then(mcpAsyncClient.callTool(new McpSchema.CallToolRequest("annotatedMessage",
+						Map.of("messageType", messageType, "includeImage", true)))))
+				.consumeNextWith(result -> {
+					assertThat(result).isNotNull();
+					assertThat(result.isError()).isNotEqualTo(true);
+					assertThat(result.content()).isNotEmpty();
+					assertThat(result.content()).allSatisfy(content -> {
+						switch (content.type()) {
+							case "text":
+								McpSchema.TextContent textContent = assertInstanceOf(McpSchema.TextContent.class,
+										content);
+								assertThat(textContent.text()).isNotEmpty();
+								assertThat(textContent.annotations()).isNotNull();
+
+								switch (messageType) {
+									case "error":
+										assertThat(textContent.annotations().priority()).isEqualTo(1.0);
+										assertThat(textContent.annotations().audience())
+											.containsOnly(McpSchema.Role.USER, McpSchema.Role.ASSISTANT);
+										break;
+									case "success":
+										assertThat(textContent.annotations().priority()).isEqualTo(0.7);
+										assertThat(textContent.annotations().audience())
+											.containsExactly(McpSchema.Role.USER);
+										break;
+									case "debug":
+										assertThat(textContent.annotations().priority()).isEqualTo(0.3);
+										assertThat(textContent.annotations().audience())
+											.containsExactly(McpSchema.Role.ASSISTANT);
+										break;
+									default:
+										throw new IllegalStateException("Unexpected value: " + content.type());
+								}
+								break;
+							case "image":
+								McpSchema.ImageContent imageContent = assertInstanceOf(McpSchema.ImageContent.class,
+										content);
+								assertThat(imageContent.data()).isNotEmpty();
+								assertThat(imageContent.annotations()).isNotNull();
+								assertThat(imageContent.annotations().priority()).isEqualTo(0.5);
+								assertThat(imageContent.annotations().audience()).containsExactly(McpSchema.Role.USER);
+								break;
+							default:
+								fail("Unexpected content type: " + content.type());
+						}
+					});
+				})
+				.verifyComplete();
 		});
 	}
 

--- a/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
@@ -30,6 +30,8 @@ import io.modelcontextprotocol.spec.McpSchema.UnsubscribeRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
@@ -38,6 +40,8 @@ import reactor.test.StepVerifier;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
  * Unit tests for MCP Client Session functionality.
@@ -224,6 +228,60 @@ public abstract class AbstractMcpSyncClientTests {
 			CallToolRequest invalidRequest = new CallToolRequest("nonexistent_tool", Map.of("message", TEST_MESSAGE));
 
 			assertThatThrownBy(() -> mcpSyncClient.callTool(invalidRequest)).isInstanceOf(Exception.class);
+		});
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "success", "error", "debug" })
+	void testCallToolWithMessageAnnotations(String messageType) {
+		McpClientTransport transport = createMcpTransport();
+
+		withClient(transport, client -> {
+			client.initialize();
+
+			McpSchema.CallToolResult result = client.callTool(new McpSchema.CallToolRequest("annotatedMessage",
+					Map.of("messageType", messageType, "includeImage", true)));
+
+			assertThat(result).isNotNull();
+			assertThat(result.isError()).isNotEqualTo(true);
+			assertThat(result.content()).isNotEmpty();
+			assertThat(result.content()).allSatisfy(content -> {
+				switch (content.type()) {
+					case "text":
+						McpSchema.TextContent textContent = assertInstanceOf(McpSchema.TextContent.class, content);
+						assertThat(textContent.text()).isNotEmpty();
+						assertThat(textContent.annotations()).isNotNull();
+
+						switch (messageType) {
+							case "error":
+								assertThat(textContent.annotations().priority()).isEqualTo(1.0);
+								assertThat(textContent.annotations().audience()).containsOnly(McpSchema.Role.USER,
+										McpSchema.Role.ASSISTANT);
+								break;
+							case "success":
+								assertThat(textContent.annotations().priority()).isEqualTo(0.7);
+								assertThat(textContent.annotations().audience()).containsExactly(McpSchema.Role.USER);
+								break;
+							case "debug":
+								assertThat(textContent.annotations().priority()).isEqualTo(0.3);
+								assertThat(textContent.annotations().audience())
+									.containsExactly(McpSchema.Role.ASSISTANT);
+								break;
+							default:
+								throw new IllegalStateException("Unexpected value: " + content.type());
+						}
+						break;
+					case "image":
+						McpSchema.ImageContent imageContent = assertInstanceOf(McpSchema.ImageContent.class, content);
+						assertThat(imageContent.data()).isNotEmpty();
+						assertThat(imageContent.annotations()).isNotNull();
+						assertThat(imageContent.annotations().priority()).isEqualTo(0.5);
+						assertThat(imageContent.annotations().audience()).containsExactly(McpSchema.Role.USER);
+						break;
+					default:
+						fail("Unexpected content type: " + content.type());
+				}
+			});
 		});
 	}
 

--- a/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpSyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpSyncClientTests.java
@@ -5,7 +5,6 @@
 package io.modelcontextprotocol.client;
 
 import java.time.Duration;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -13,17 +12,12 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.modelcontextprotocol.client.transport.ServerParameters;
 import io.modelcontextprotocol.client.transport.StdioClientTransport;
 import io.modelcontextprotocol.spec.McpClientTransport;
-import io.modelcontextprotocol.spec.McpSchema;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.publisher.Sinks;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
  * Tests for the {@link McpSyncClient} with {@link StdioClientTransport}.
@@ -71,60 +65,6 @@ class StdioMcpSyncClientTests extends AbstractMcpSyncClientTests {
 		assertThat(receivedError.get()).isNotNull().isEqualTo(errorMessage);
 
 		StepVerifier.create(transport.closeGracefully()).expectComplete().verify(Duration.ofSeconds(5));
-	}
-
-	@ParameterizedTest
-	@ValueSource(strings = { "success", "error", "debug" })
-	void testMessageAnnotations(String messageType) {
-		McpClientTransport transport = createMcpTransport();
-
-		withClient(transport, client -> {
-			client.initialize();
-
-			McpSchema.CallToolResult result = client.callTool(new McpSchema.CallToolRequest("annotatedMessage",
-					Map.of("messageType", messageType, "includeImage", true)));
-
-			assertThat(result).isNotNull();
-			assertThat(result.isError()).isNotEqualTo(true);
-			assertThat(result.content()).isNotEmpty();
-			assertThat(result.content()).allSatisfy(content -> {
-				switch (content.type()) {
-					case "text":
-						McpSchema.TextContent textContent = assertInstanceOf(McpSchema.TextContent.class, content);
-						assertThat(textContent.text()).isNotEmpty();
-						assertThat(textContent.annotations()).isNotNull();
-
-						switch (messageType) {
-							case "error":
-								assertThat(textContent.annotations().priority()).isEqualTo(1.0);
-								assertThat(textContent.annotations().audience()).containsOnly(McpSchema.Role.USER,
-										McpSchema.Role.ASSISTANT);
-								break;
-							case "success":
-								assertThat(textContent.annotations().priority()).isEqualTo(0.7);
-								assertThat(textContent.annotations().audience()).containsExactly(McpSchema.Role.USER);
-								break;
-							case "debug":
-								assertThat(textContent.annotations().priority()).isEqualTo(0.3);
-								assertThat(textContent.annotations().audience())
-									.containsExactly(McpSchema.Role.ASSISTANT);
-								break;
-							default:
-								throw new IllegalStateException("Unexpected value: " + content.type());
-						}
-						break;
-					case "image":
-						McpSchema.ImageContent imageContent = assertInstanceOf(McpSchema.ImageContent.class, content);
-						assertThat(imageContent.data()).isNotEmpty();
-						assertThat(imageContent.annotations()).isNotNull();
-						assertThat(imageContent.annotations().priority()).isEqualTo(0.5);
-						assertThat(imageContent.annotations().audience()).containsExactly(McpSchema.Role.USER);
-						break;
-					default:
-						fail("Unexpected content type: " + content.type());
-				}
-			});
-		});
 	}
 
 	protected Duration getInitializationTimeout() {


### PR DESCRIPTION
Updates all Content types to represent annotations as nested objects instead of directly on the content itself. The existing ctors have been moved to deprecated shim ctors for backwards-compat.

This brings the implementation in line with the content types [as modeled by](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/c87a0da6d8c2436d56a6398023c80b0562224454/schema/2025-03-26/schema.json#L1970-L1973) the specification. An integration test has been added to ensure this doesn't drift in the future.

## Motivation and Context
Content annotations have been incorrect for at least [six months](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/c87a0da6d8c2436d56a6398023c80b0562224454/schema/2024-11-05/schema.json#L1924-L1941). The integration test added in this PR fails without the related schema changes.

## How Has This Been Tested?
Newly-implemented integration test, leveraging the appropriate tool from [everything](https://github.com/modelcontextprotocol/servers/tree/main/src/everything#tools).

## Breaking Changes
None; the old constructor has been maintained for backwards-compatibility purposes. The old auto-generated record properties (`.audience()` and `.priority()`) have also been maintained.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
