### PR TITLE
feat: implement audio content

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -1256,8 +1256,9 @@ public final class McpSchema {
 	@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 	@JsonSubTypes({ @JsonSubTypes.Type(value = TextContent.class, name = "text"),
 			@JsonSubTypes.Type(value = ImageContent.class, name = "image"),
+			@JsonSubTypes.Type(value = AudioContent.class, name = "audio"),
 			@JsonSubTypes.Type(value = EmbeddedResource.class, name = "resource") })
-	public sealed interface Content permits TextContent, ImageContent, EmbeddedResource {
+	public sealed interface Content permits TextContent, ImageContent, AudioContent, EmbeddedResource {
 
 		default String type() {
 			if (this instanceof TextContent) {
@@ -1265,6 +1266,9 @@ public final class McpSchema {
 			}
 			else if (this instanceof ImageContent) {
 				return "image";
+			}
+			else if (this instanceof AudioContent) {
+				return "audio";
 			}
 			else if (this instanceof EmbeddedResource) {
 				return "resource";
@@ -1293,6 +1297,14 @@ public final class McpSchema {
 		@JsonProperty("priority") Double priority,
 		@JsonProperty("data") String data,
 		@JsonProperty("mimeType") String mimeType) implements Content { // @formatter:on
+	}
+
+	@JsonInclude(JsonInclude.Include.NON_ABSENT)
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record AudioContent( // @formatter:off
+		@JsonProperty("annotations") Annotations annotations,
+		@JsonProperty("data") String data,
+		@JsonProperty("mimeType") String mimeType) implements Annotated, Content { // @formatter:on
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)

--- a/mcp/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
@@ -59,7 +59,7 @@ public class McpSchemaTests {
 				{"type":"WRONG","text":"XXX"}""", McpSchema.TextContent.class))
 			.isInstanceOf(InvalidTypeIdException.class)
 			.hasMessageContaining(
-					"Could not resolve type id 'WRONG' as a subtype of `io.modelcontextprotocol.spec.McpSchema$TextContent`: known type ids = [image, resource, text]");
+					"Could not resolve type id 'WRONG' as a subtype of `io.modelcontextprotocol.spec.McpSchema$TextContent`: known type ids = [audio, image, resource, text]");
 	}
 
 	@Test
@@ -82,6 +82,28 @@ public class McpSchemaTests {
 		assertThat(imageContent.type()).isEqualTo("image");
 		assertThat(imageContent.data()).isEqualTo("base64encodeddata");
 		assertThat(imageContent.mimeType()).isEqualTo("image/png");
+	}
+
+	@Test
+	void testAudioContent() throws Exception {
+		McpSchema.AudioContent audioContent = new McpSchema.AudioContent(null, "base64encodeddata", "audio/wav");
+		String value = mapper.writeValueAsString(audioContent);
+
+		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
+			.when(Option.IGNORING_EXTRA_ARRAY_ITEMS)
+			.isObject()
+			.isEqualTo(json("""
+					{"type":"audio","data":"base64encodeddata","mimeType":"audio/wav"}"""));
+	}
+
+	@Test
+	void testAudioContentDeserialization() throws Exception {
+		McpSchema.AudioContent audioContent = mapper.readValue("""
+				{"type":"audio","data":"base64encodeddata","mimeType":"audio/wav"}""", McpSchema.AudioContent.class);
+		assertThat(audioContent).isNotNull();
+		assertThat(audioContent.type()).isEqualTo("audio");
+		assertThat(audioContent.data()).isEqualTo("base64encodeddata");
+		assertThat(audioContent.mimeType()).isEqualTo("audio/wav");
 	}
 
 	@Test


### PR DESCRIPTION
Implements the `AudioContent` type [as defined by](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/c87a0da6d8c2436d56a6398023c80b0562224454/schema/2025-03-26/schema.ts#L987-L1009) the spec.

## Motivation and Context
Adds a missing data type from the most recent specification version.

## How Has This Been Tested?
Added unit tests.

## Breaking Changes
None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Content annotations have been implemented as described in #242 (this PR does not depend on that one). The way annotations are implemented in this PR is correct, but inconsistent with how annotations were defined on other Content subtypes with the expectation that #242 will eventually be merged.
