### PR TITLE
chore: implement integration tests for resources

### DIFF
--- a/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpSyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpSyncClientTests.java
@@ -88,14 +88,17 @@ class StdioMcpSyncClientTests extends AbstractMcpSyncClientTests {
 
 					if (i % 2 == 0) {
 						assertThat(resourceResult.contents()).allSatisfy(content -> {
-							McpSchema.TextResourceContents text = assertInstanceOf(McpSchema.TextResourceContents.class, content);
+							McpSchema.TextResourceContents text = assertInstanceOf(McpSchema.TextResourceContents.class,
+									content);
 							assertThat(text.mimeType()).isEqualTo("text/plain");
 							assertThat(text.uri()).isNotEmpty();
 							assertThat(text.text()).isNotEmpty();
 						});
-					} else {
+					}
+					else {
 						assertThat(resourceResult.contents()).allSatisfy(content -> {
-							McpSchema.BlobResourceContents blob = assertInstanceOf(McpSchema.BlobResourceContents.class, content);
+							McpSchema.BlobResourceContents blob = assertInstanceOf(McpSchema.BlobResourceContents.class,
+									content);
 							assertThat(blob.mimeType()).isEqualTo("application/octet-stream");
 							assertThat(blob.uri()).isNotEmpty();
 							assertThat(blob.blob()).isNotEmpty();
@@ -104,7 +107,8 @@ class StdioMcpSyncClientTests extends AbstractMcpSyncClientTests {
 
 					i++;
 				}
-			} while (nextCursor != null);
+			}
+			while (nextCursor != null);
 		});
 	}
 
@@ -121,13 +125,15 @@ class StdioMcpSyncClientTests extends AbstractMcpSyncClientTests {
 				nextCursor = result.nextCursor();
 
 				for (McpSchema.ResourceTemplate resourceTemplate : result.resourceTemplates()) {
-					// mimeType is null in @modelcontextprotocol/server-everything, but we don't assert that it's
+					// mimeType is null in @modelcontextprotocol/server-everything, but we
+					// don't assert that it's
 					// null in case they change that later.
 					assertThat(resourceTemplate.uriTemplate()).isNotEmpty();
 					assertThat(resourceTemplate.name()).isNotEmpty();
 					assertThat(resourceTemplate.description()).isNotEmpty();
 				}
-			} while (nextCursor != null);
+			}
+			while (nextCursor != null);
 		});
 	}
 
@@ -138,16 +144,16 @@ class StdioMcpSyncClientTests extends AbstractMcpSyncClientTests {
 		withClient(transport, client -> {
 			client.initialize();
 
-			McpSchema.CallToolResult result = client.callTool(new McpSchema.CallToolRequest("getResourceReference",
-					Map.of(
-							"resourceId", 1
-					)));
+			McpSchema.CallToolResult result = client
+				.callTool(new McpSchema.CallToolRequest("getResourceReference", Map.of("resourceId", 1)));
 
 			assertThat(result.content()).hasAtLeastOneElementOfType(McpSchema.EmbeddedResource.class);
 			assertThat(result.content()).allSatisfy(content -> {
-				if (!(content instanceof McpSchema.EmbeddedResource resource)) return;
+				if (!(content instanceof McpSchema.EmbeddedResource resource))
+					return;
 
-                McpSchema.TextResourceContents text = assertInstanceOf(McpSchema.TextResourceContents.class, resource.resource());
+				McpSchema.TextResourceContents text = assertInstanceOf(McpSchema.TextResourceContents.class,
+						resource.resource());
 				assertThat(text.mimeType()).isEqualTo("text/plain");
 				assertThat(text.uri()).isNotEmpty();
 				assertThat(text.text()).isNotEmpty();


### PR DESCRIPTION
Implements basic integration tests for resources and resource templates. Just helps to ensure things don't fall too far out of step with the upstream protocol. Resource subscriptions are [supported by](https://github.com/modelcontextprotocol/servers/blob/8b832005ac9fc3a2f41ca7188b6a353dd5bda4f1/src/everything/everything.ts#L120-L128) `@modelcontextprotocol/everything`, but are not tested here due to lacking client support (#251).

## Motivation and Context
Avoids regressions against the protocol.

## How Has This Been Tested?
This PR only adds integration tests.

## Breaking Changes
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
