### PR TITLE
Add an interface for McpServerSession to allow for more extensibility

### DIFF
--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxSseServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxSseServerTransportProvider.java
@@ -1,9 +1,5 @@
 package io.modelcontextprotocol.server.transport;
 
-import java.io.IOException;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.spec.McpError;
@@ -12,13 +8,10 @@ import io.modelcontextprotocol.spec.McpServerSession;
 import io.modelcontextprotocol.spec.McpServerTransport;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
 import io.modelcontextprotocol.util.Assert;
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import reactor.core.Exceptions;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.FluxSink;
-import reactor.core.publisher.Mono;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerSentEvent;
@@ -26,6 +19,10 @@ import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.RouterFunctions;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.Exceptions;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
+import reactor.core.publisher.Mono;
 
 /**
  * Server-side implementation of the MCP (Model Context Protocol) HTTP transport using

--- a/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransportProvider.java
@@ -4,31 +4,28 @@
 
 package io.modelcontextprotocol.server.transport;
 
-import java.io.IOException;
-import java.time.Duration;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpServerSession;
 import io.modelcontextprotocol.spec.McpServerTransport;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
-import io.modelcontextprotocol.spec.McpServerSession;
 import io.modelcontextprotocol.util.Assert;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.web.servlet.function.RouterFunction;
 import org.springframework.web.servlet.function.RouterFunctions;
 import org.springframework.web.servlet.function.ServerRequest;
 import org.springframework.web.servlet.function.ServerResponse;
 import org.springframework.web.servlet.function.ServerResponse.SseBuilder;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
  * Server-side implementation of the Model Context Protocol (MCP) transport layer using

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -4,6 +4,7 @@
 
 package io.modelcontextprotocol.server;
 
+import io.modelcontextprotocol.spec.McpServerSessionImpl;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -184,7 +185,7 @@ public class McpAsyncServer {
 				asyncRootsListChangedNotificationHandler(rootsChangeConsumers));
 
 		mcpTransportProvider.setSessionFactory(
-				transport -> new McpServerSession(UUID.randomUUID().toString(), requestTimeout, transport,
+				transport -> new McpServerSessionImpl(UUID.randomUUID().toString(), requestTimeout, transport,
 						this::asyncInitializeRequestHandler, Mono::empty, requestHandlers, notificationHandlers));
 	}
 

--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
@@ -3,14 +3,6 @@
  */
 package io.modelcontextprotocol.server.transport;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.spec.McpError;
@@ -25,6 +17,13 @@ import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;

--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
@@ -4,18 +4,6 @@
 
 package io.modelcontextprotocol.server.transport;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.Reader;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.spec.McpError;
@@ -24,7 +12,17 @@ import io.modelcontextprotocol.spec.McpSchema.JSONRPCMessage;
 import io.modelcontextprotocol.spec.McpServerSession;
 import io.modelcontextprotocol.spec.McpServerTransport;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
+import io.modelcontextprotocol.spec.McpSession;
 import io.modelcontextprotocol.util.Assert;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
@@ -50,7 +48,7 @@ public class StdioServerTransportProvider implements McpServerTransportProvider 
 
 	private final OutputStream outputStream;
 
-	private McpServerSession session;
+  private McpSession session;
 
 	private final AtomicBoolean isClosing = new AtomicBoolean(false);
 

--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
@@ -48,7 +48,7 @@ public class StdioServerTransportProvider implements McpServerTransportProvider 
 
 	private final OutputStream outputStream;
 
-  private McpSession session;
+	private McpServerSession session;
 
 	private final AtomicBoolean isClosing = new AtomicBoolean(false);
 

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
@@ -5,85 +5,86 @@ import reactor.core.publisher.Mono;
 
 public interface McpServerSession extends McpSession {
 
-  String getId();
+	String getId();
 
-  Mono<Void> handle(McpSchema.JSONRPCMessage message);
+	Mono<Void> handle(McpSchema.JSONRPCMessage message);
 
-  /**
-   * Request handler for the initialization request.
-   */
-  interface InitRequestHandler {
+	/**
+	 * Request handler for the initialization request.
+	 */
+	interface InitRequestHandler {
 
-    /**
-     * Handles the initialization request.
-     * @param initializeRequest the initialization request by the client
-     * @return a Mono that will emit the result of the initialization
-     */
-    Mono<McpSchema.InitializeResult> handle(McpSchema.InitializeRequest initializeRequest);
+		/**
+		 * Handles the initialization request.
+		 * @param initializeRequest the initialization request by the client
+		 * @return a Mono that will emit the result of the initialization
+		 */
+		Mono<McpSchema.InitializeResult> handle(McpSchema.InitializeRequest initializeRequest);
 
-  }
+	}
 
-  /**
-   * Notification handler for the initialization notification from the client.
-   */
-  interface InitNotificationHandler {
+	/**
+	 * Notification handler for the initialization notification from the client.
+	 */
+	interface InitNotificationHandler {
 
-    /**
-     * Specifies an action to take upon successful initialization.
-     * @return a Mono that will complete when the initialization is acted upon.
-     */
-    Mono<Void> handle();
+		/**
+		 * Specifies an action to take upon successful initialization.
+		 * @return a Mono that will complete when the initialization is acted upon.
+		 */
+		Mono<Void> handle();
 
-  }
+	}
 
-  /**
-   * A handler for client-initiated notifications.
-   */
-  interface NotificationHandler {
+	/**
+	 * A handler for client-initiated notifications.
+	 */
+	interface NotificationHandler {
 
-    /**
-     * Handles a notification from the client.
-     * @param exchange the exchange associated with the client that allows calling
-     * back to the connected client or inspecting its capabilities.
-     * @param params the parameters of the notification.
-     * @return a Mono that completes once the notification is handled.
-     */
-    Mono<Void> handle(McpAsyncServerExchange exchange, Object params);
+		/**
+		 * Handles a notification from the client.
+		 * @param exchange the exchange associated with the client that allows calling
+		 * back to the connected client or inspecting its capabilities.
+		 * @param params the parameters of the notification.
+		 * @return a Mono that completes once the notification is handled.
+		 */
+		Mono<Void> handle(McpAsyncServerExchange exchange, Object params);
 
-  }
+	}
 
-  /**
-   * A handler for client-initiated requests.
-   *
-   * @param <T> the type of the response that is expected as a result of handling the
-   * request.
-   */
-  interface RequestHandler<T> {
+	/**
+	 * A handler for client-initiated requests.
+	 *
+	 * @param <T> the type of the response that is expected as a result of handling the
+	 * request.
+	 */
+	interface RequestHandler<T> {
 
-    /**
-     * Handles a request from the client.
-     * @param exchange the exchange associated with the client that allows calling
-     * back to the connected client or inspecting its capabilities.
-     * @param params the parameters of the request.
-     * @return a Mono that will emit the response to the request.
-     */
-    Mono<T> handle(McpAsyncServerExchange exchange, Object params);
+		/**
+		 * Handles a request from the client.
+		 * @param exchange the exchange associated with the client that allows calling
+		 * back to the connected client or inspecting its capabilities.
+		 * @param params the parameters of the request.
+		 * @return a Mono that will emit the response to the request.
+		 */
+		Mono<T> handle(McpAsyncServerExchange exchange, Object params);
 
-  }
+	}
 
-  /**
-   * Factory for creating server sessions which delegate to a provided 1:1 transport
-   * with a connected client.
-   */
-  @FunctionalInterface
-  interface Factory {
+	/**
+	 * Factory for creating server sessions which delegate to a provided 1:1 transport
+	 * with a connected client.
+	 */
+	@FunctionalInterface
+	interface Factory {
 
-    /**
-     * Creates a new 1:1 representation of the client-server interaction.
-     * @param sessionTransport the transport to use for communication with the client.
-     * @return a new server session.
-     */
-    McpServerSession create(McpServerTransport sessionTransport);
+		/**
+		 * Creates a new 1:1 representation of the client-server interaction.
+		 * @param sessionTransport the transport to use for communication with the client.
+		 * @return a new server session.
+		 */
+		McpServerSession create(McpServerTransport sessionTransport);
 
-  }
+	}
+
 }

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
@@ -1,353 +1,89 @@
 package io.modelcontextprotocol.spec;
 
-import java.time.Duration;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
-
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
-import reactor.core.publisher.MonoSink;
-import reactor.core.publisher.Sinks;
 
-/**
- * Represents a Model Control Protocol (MCP) session on the server side. It manages
- * bidirectional JSON-RPC communication with the client.
- */
-public class McpServerSession implements McpSession {
+public interface McpServerSession extends McpSession {
 
-	private static final Logger logger = LoggerFactory.getLogger(McpServerSession.class);
+  String getId();
 
-	private final ConcurrentHashMap<Object, MonoSink<McpSchema.JSONRPCResponse>> pendingResponses = new ConcurrentHashMap<>();
+  Mono<Void> handle(McpSchema.JSONRPCMessage message);
 
-	private final String id;
+  /**
+   * Request handler for the initialization request.
+   */
+  interface InitRequestHandler {
 
-	/** Duration to wait for request responses before timing out */
-	private final Duration requestTimeout;
+    /**
+     * Handles the initialization request.
+     * @param initializeRequest the initialization request by the client
+     * @return a Mono that will emit the result of the initialization
+     */
+    Mono<McpSchema.InitializeResult> handle(McpSchema.InitializeRequest initializeRequest);
 
-	private final AtomicLong requestCounter = new AtomicLong(0);
+  }
 
-	private final InitRequestHandler initRequestHandler;
+  /**
+   * Notification handler for the initialization notification from the client.
+   */
+  interface InitNotificationHandler {
 
-	private final InitNotificationHandler initNotificationHandler;
+    /**
+     * Specifies an action to take upon successful initialization.
+     * @return a Mono that will complete when the initialization is acted upon.
+     */
+    Mono<Void> handle();
 
-	private final Map<String, RequestHandler<?>> requestHandlers;
+  }
 
-	private final Map<String, NotificationHandler> notificationHandlers;
+  /**
+   * A handler for client-initiated notifications.
+   */
+  interface NotificationHandler {
 
-	private final McpServerTransport transport;
+    /**
+     * Handles a notification from the client.
+     * @param exchange the exchange associated with the client that allows calling
+     * back to the connected client or inspecting its capabilities.
+     * @param params the parameters of the notification.
+     * @return a Mono that completes once the notification is handled.
+     */
+    Mono<Void> handle(McpAsyncServerExchange exchange, Object params);
 
-	private final Sinks.One<McpAsyncServerExchange> exchangeSink = Sinks.one();
+  }
 
-	private final AtomicReference<McpSchema.ClientCapabilities> clientCapabilities = new AtomicReference<>();
+  /**
+   * A handler for client-initiated requests.
+   *
+   * @param <T> the type of the response that is expected as a result of handling the
+   * request.
+   */
+  interface RequestHandler<T> {
 
-	private final AtomicReference<McpSchema.Implementation> clientInfo = new AtomicReference<>();
+    /**
+     * Handles a request from the client.
+     * @param exchange the exchange associated with the client that allows calling
+     * back to the connected client or inspecting its capabilities.
+     * @param params the parameters of the request.
+     * @return a Mono that will emit the response to the request.
+     */
+    Mono<T> handle(McpAsyncServerExchange exchange, Object params);
 
-	private static final int STATE_UNINITIALIZED = 0;
+  }
 
-	private static final int STATE_INITIALIZING = 1;
+  /**
+   * Factory for creating server sessions which delegate to a provided 1:1 transport
+   * with a connected client.
+   */
+  @FunctionalInterface
+  interface Factory {
 
-	private static final int STATE_INITIALIZED = 2;
+    /**
+     * Creates a new 1:1 representation of the client-server interaction.
+     * @param sessionTransport the transport to use for communication with the client.
+     * @return a new server session.
+     */
+    McpServerSession create(McpServerTransport sessionTransport);
 
-	private final AtomicInteger state = new AtomicInteger(STATE_UNINITIALIZED);
-
-	/**
-	 * Creates a new server session with the given parameters and the transport to use.
-	 * @param id session id
-	 * @param transport the transport to use
-	 * @param initHandler called when a
-	 * {@link io.modelcontextprotocol.spec.McpSchema.InitializeRequest} is received by the
-	 * server
-	 * @param initNotificationHandler called when a
-	 * {@link io.modelcontextprotocol.spec.McpSchema#METHOD_NOTIFICATION_INITIALIZED} is
-	 * received.
-	 * @param requestHandlers map of request handlers to use
-	 * @param notificationHandlers map of notification handlers to use
-	 */
-	public McpServerSession(String id, Duration requestTimeout, McpServerTransport transport,
-			InitRequestHandler initHandler, InitNotificationHandler initNotificationHandler,
-			Map<String, RequestHandler<?>> requestHandlers, Map<String, NotificationHandler> notificationHandlers) {
-		this.id = id;
-		this.requestTimeout = requestTimeout;
-		this.transport = transport;
-		this.initRequestHandler = initHandler;
-		this.initNotificationHandler = initNotificationHandler;
-		this.requestHandlers = requestHandlers;
-		this.notificationHandlers = notificationHandlers;
-	}
-
-	/**
-	 * Retrieve the session id.
-	 * @return session id
-	 */
-	public String getId() {
-		return this.id;
-	}
-
-	/**
-	 * Called upon successful initialization sequence between the client and the server
-	 * with the client capabilities and information.
-	 *
-	 * <a href=
-	 * "https://github.com/modelcontextprotocol/specification/blob/main/docs/specification/basic/lifecycle.md#initialization">Initialization
-	 * Spec</a>
-	 * @param clientCapabilities the capabilities the connected client provides
-	 * @param clientInfo the information about the connected client
-	 */
-	public void init(McpSchema.ClientCapabilities clientCapabilities, McpSchema.Implementation clientInfo) {
-		this.clientCapabilities.lazySet(clientCapabilities);
-		this.clientInfo.lazySet(clientInfo);
-	}
-
-	private String generateRequestId() {
-		return this.id + "-" + this.requestCounter.getAndIncrement();
-	}
-
-	@Override
-	public <T> Mono<T> sendRequest(String method, Object requestParams, TypeReference<T> typeRef) {
-		String requestId = this.generateRequestId();
-
-		return Mono.<McpSchema.JSONRPCResponse>create(sink -> {
-			this.pendingResponses.put(requestId, sink);
-			McpSchema.JSONRPCRequest jsonrpcRequest = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, method,
-					requestId, requestParams);
-			this.transport.sendMessage(jsonrpcRequest).subscribe(v -> {
-			}, error -> {
-				this.pendingResponses.remove(requestId);
-				sink.error(error);
-			});
-		}).timeout(requestTimeout).handle((jsonRpcResponse, sink) -> {
-			if (jsonRpcResponse.error() != null) {
-				sink.error(new McpError(jsonRpcResponse.error()));
-			}
-			else {
-				if (typeRef.getType().equals(Void.class)) {
-					sink.complete();
-				}
-				else {
-					sink.next(this.transport.unmarshalFrom(jsonRpcResponse.result(), typeRef));
-				}
-			}
-		});
-	}
-
-	@Override
-	public Mono<Void> sendNotification(String method, Object params) {
-		McpSchema.JSONRPCNotification jsonrpcNotification = new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION,
-				method, params);
-		return this.transport.sendMessage(jsonrpcNotification);
-	}
-
-	/**
-	 * Called by the {@link McpServerTransportProvider} once the session is determined.
-	 * The purpose of this method is to dispatch the message to an appropriate handler as
-	 * specified by the MCP server implementation
-	 * ({@link io.modelcontextprotocol.server.McpAsyncServer} or
-	 * {@link io.modelcontextprotocol.server.McpSyncServer}) via
-	 * {@link McpServerSession.Factory} that the server creates.
-	 * @param message the incoming JSON-RPC message
-	 * @return a Mono that completes when the message is processed
-	 */
-	public Mono<Void> handle(McpSchema.JSONRPCMessage message) {
-		return Mono.defer(() -> {
-			// TODO handle errors for communication to without initialization happening
-			// first
-			if (message instanceof McpSchema.JSONRPCResponse response) {
-				logger.debug("Received Response: {}", response);
-				var sink = pendingResponses.remove(response.id());
-				if (sink == null) {
-					logger.warn("Unexpected response for unknown id {}", response.id());
-				}
-				else {
-					sink.success(response);
-				}
-				return Mono.empty();
-			}
-			else if (message instanceof McpSchema.JSONRPCRequest request) {
-				logger.debug("Received request: {}", request);
-				return handleIncomingRequest(request).onErrorResume(error -> {
-					var errorResponse = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), null,
-							new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INTERNAL_ERROR,
-									error.getMessage(), null));
-					// TODO: Should the error go to SSE or back as POST return?
-					return this.transport.sendMessage(errorResponse).then(Mono.empty());
-				}).flatMap(this.transport::sendMessage);
-			}
-			else if (message instanceof McpSchema.JSONRPCNotification notification) {
-				// TODO handle errors for communication to without initialization
-				// happening first
-				logger.debug("Received notification: {}", notification);
-				// TODO: in case of error, should the POST request be signalled?
-				return handleIncomingNotification(notification)
-					.doOnError(error -> logger.error("Error handling notification: {}", error.getMessage()));
-			}
-			else {
-				logger.warn("Received unknown message type: {}", message);
-				return Mono.empty();
-			}
-		});
-	}
-
-	/**
-	 * Handles an incoming JSON-RPC request by routing it to the appropriate handler.
-	 * @param request The incoming JSON-RPC request
-	 * @return A Mono containing the JSON-RPC response
-	 */
-	private Mono<McpSchema.JSONRPCResponse> handleIncomingRequest(McpSchema.JSONRPCRequest request) {
-		return Mono.defer(() -> {
-			Mono<?> resultMono;
-			if (McpSchema.METHOD_INITIALIZE.equals(request.method())) {
-				// TODO handle situation where already initialized!
-				McpSchema.InitializeRequest initializeRequest = transport.unmarshalFrom(request.params(),
-						new TypeReference<McpSchema.InitializeRequest>() {
-						});
-
-				this.state.lazySet(STATE_INITIALIZING);
-				this.init(initializeRequest.capabilities(), initializeRequest.clientInfo());
-				resultMono = this.initRequestHandler.handle(initializeRequest);
-			}
-			else {
-				// TODO handle errors for communication to this session without
-				// initialization happening first
-				var handler = this.requestHandlers.get(request.method());
-				if (handler == null) {
-					MethodNotFoundError error = getMethodNotFoundError(request.method());
-					return Mono.just(new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), null,
-							new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.METHOD_NOT_FOUND,
-									error.message(), error.data())));
-				}
-
-				resultMono = this.exchangeSink.asMono().flatMap(exchange -> handler.handle(exchange, request.params()));
-			}
-			return resultMono
-				.map(result -> new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), result, null))
-				.onErrorResume(error -> Mono.just(new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(),
-						null, new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INTERNAL_ERROR,
-								error.getMessage(), null)))); // TODO: add error message
-																// through the data field
-		});
-	}
-
-	/**
-	 * Handles an incoming JSON-RPC notification by routing it to the appropriate handler.
-	 * @param notification The incoming JSON-RPC notification
-	 * @return A Mono that completes when the notification is processed
-	 */
-	private Mono<Void> handleIncomingNotification(McpSchema.JSONRPCNotification notification) {
-		return Mono.defer(() -> {
-			if (McpSchema.METHOD_NOTIFICATION_INITIALIZED.equals(notification.method())) {
-				this.state.lazySet(STATE_INITIALIZED);
-				exchangeSink.tryEmitValue(new McpAsyncServerExchange(this, clientCapabilities.get(), clientInfo.get()));
-				return this.initNotificationHandler.handle();
-			}
-
-			var handler = notificationHandlers.get(notification.method());
-			if (handler == null) {
-				logger.error("No handler registered for notification method: {}", notification.method());
-				return Mono.empty();
-			}
-			return this.exchangeSink.asMono().flatMap(exchange -> handler.handle(exchange, notification.params()));
-		});
-	}
-
-	record MethodNotFoundError(String method, String message, Object data) {
-	}
-
-	private MethodNotFoundError getMethodNotFoundError(String method) {
-		return new MethodNotFoundError(method, "Method not found: " + method, null);
-	}
-
-	@Override
-	public Mono<Void> closeGracefully() {
-		return this.transport.closeGracefully();
-	}
-
-	@Override
-	public void close() {
-		this.transport.close();
-	}
-
-	/**
-	 * Request handler for the initialization request.
-	 */
-	public interface InitRequestHandler {
-
-		/**
-		 * Handles the initialization request.
-		 * @param initializeRequest the initialization request by the client
-		 * @return a Mono that will emit the result of the initialization
-		 */
-		Mono<McpSchema.InitializeResult> handle(McpSchema.InitializeRequest initializeRequest);
-
-	}
-
-	/**
-	 * Notification handler for the initialization notification from the client.
-	 */
-	public interface InitNotificationHandler {
-
-		/**
-		 * Specifies an action to take upon successful initialization.
-		 * @return a Mono that will complete when the initialization is acted upon.
-		 */
-		Mono<Void> handle();
-
-	}
-
-	/**
-	 * A handler for client-initiated notifications.
-	 */
-	public interface NotificationHandler {
-
-		/**
-		 * Handles a notification from the client.
-		 * @param exchange the exchange associated with the client that allows calling
-		 * back to the connected client or inspecting its capabilities.
-		 * @param params the parameters of the notification.
-		 * @return a Mono that completes once the notification is handled.
-		 */
-		Mono<Void> handle(McpAsyncServerExchange exchange, Object params);
-
-	}
-
-	/**
-	 * A handler for client-initiated requests.
-	 *
-	 * @param <T> the type of the response that is expected as a result of handling the
-	 * request.
-	 */
-	public interface RequestHandler<T> {
-
-		/**
-		 * Handles a request from the client.
-		 * @param exchange the exchange associated with the client that allows calling
-		 * back to the connected client or inspecting its capabilities.
-		 * @param params the parameters of the request.
-		 * @return a Mono that will emit the response to the request.
-		 */
-		Mono<T> handle(McpAsyncServerExchange exchange, Object params);
-
-	}
-
-	/**
-	 * Factory for creating server sessions which delegate to a provided 1:1 transport
-	 * with a connected client.
-	 */
-	@FunctionalInterface
-	public interface Factory {
-
-		/**
-		 * Creates a new 1:1 representation of the client-server interaction.
-		 * @param sessionTransport the transport to use for communication with the client.
-		 * @return a new server session.
-		 */
-		McpServerSession create(McpServerTransport sessionTransport);
-
-	}
-
+  }
 }

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerSessionImpl.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerSessionImpl.java
@@ -273,4 +273,5 @@ public class McpServerSessionImpl implements McpServerSession {
 	public void close() {
 		this.transport.close();
 	}
+
 }

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerSessionImpl.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerSessionImpl.java
@@ -1,0 +1,276 @@
+package io.modelcontextprotocol.spec;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.modelcontextprotocol.server.McpAsyncServerExchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoSink;
+import reactor.core.publisher.Sinks;
+
+/**
+ * Represents a Model Control Protocol (MCP) session on the server side. It manages
+ * bidirectional JSON-RPC communication with the client.
+ */
+public class McpServerSessionImpl implements McpServerSession {
+
+	private static final Logger logger = LoggerFactory.getLogger(McpServerSessionImpl.class);
+
+	private final ConcurrentHashMap<Object, MonoSink<McpSchema.JSONRPCResponse>> pendingResponses = new ConcurrentHashMap<>();
+
+	private final String id;
+
+	/** Duration to wait for request responses before timing out */
+	private final Duration requestTimeout;
+
+	private final AtomicLong requestCounter = new AtomicLong(0);
+
+	private final InitRequestHandler initRequestHandler;
+
+	private final InitNotificationHandler initNotificationHandler;
+
+	private final Map<String, RequestHandler<?>> requestHandlers;
+
+	private final Map<String, NotificationHandler> notificationHandlers;
+
+	private final McpServerTransport transport;
+
+	private final Sinks.One<McpAsyncServerExchange> exchangeSink = Sinks.one();
+
+	private final AtomicReference<McpSchema.ClientCapabilities> clientCapabilities = new AtomicReference<>();
+
+	private final AtomicReference<McpSchema.Implementation> clientInfo = new AtomicReference<>();
+
+	private static final int STATE_UNINITIALIZED = 0;
+
+	private static final int STATE_INITIALIZING = 1;
+
+	private static final int STATE_INITIALIZED = 2;
+
+	private final AtomicInteger state = new AtomicInteger(STATE_UNINITIALIZED);
+
+	/**
+	 * Creates a new server session with the given parameters and the transport to use.
+	 * @param id session id
+	 * @param transport the transport to use
+	 * @param initHandler called when a
+	 * {@link io.modelcontextprotocol.spec.McpSchema.InitializeRequest} is received by the
+	 * server
+	 * @param initNotificationHandler called when a
+	 * {@link io.modelcontextprotocol.spec.McpSchema#METHOD_NOTIFICATION_INITIALIZED} is
+	 * received.
+	 * @param requestHandlers map of request handlers to use
+	 * @param notificationHandlers map of notification handlers to use
+	 */
+	public McpServerSessionImpl(String id, Duration requestTimeout, McpServerTransport transport,
+			InitRequestHandler initHandler, InitNotificationHandler initNotificationHandler,
+			Map<String, RequestHandler<?>> requestHandlers, Map<String, NotificationHandler> notificationHandlers) {
+		this.id = id;
+		this.requestTimeout = requestTimeout;
+		this.transport = transport;
+		this.initRequestHandler = initHandler;
+		this.initNotificationHandler = initNotificationHandler;
+		this.requestHandlers = requestHandlers;
+		this.notificationHandlers = notificationHandlers;
+	}
+
+	/**
+	 * Retrieve the session id.
+	 * @return session id
+	 */
+	@Override
+	public String getId() {
+		return this.id;
+	}
+
+	/**
+	 * Called upon successful initialization sequence between the client and the server
+	 * with the client capabilities and information.
+	 *
+	 * <a href=
+	 * "https://github.com/modelcontextprotocol/specification/blob/main/docs/specification/basic/lifecycle.md#initialization">Initialization
+	 * Spec</a>
+	 * @param clientCapabilities the capabilities the connected client provides
+	 * @param clientInfo the information about the connected client
+	 */
+	public void init(McpSchema.ClientCapabilities clientCapabilities, McpSchema.Implementation clientInfo) {
+		this.clientCapabilities.lazySet(clientCapabilities);
+		this.clientInfo.lazySet(clientInfo);
+	}
+
+	private String generateRequestId() {
+		return this.id + "-" + this.requestCounter.getAndIncrement();
+	}
+
+	@Override
+	public <T> Mono<T> sendRequest(String method, Object requestParams, TypeReference<T> typeRef) {
+		String requestId = this.generateRequestId();
+
+		return Mono.<McpSchema.JSONRPCResponse>create(sink -> {
+			this.pendingResponses.put(requestId, sink);
+			McpSchema.JSONRPCRequest jsonrpcRequest = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, method,
+					requestId, requestParams);
+			this.transport.sendMessage(jsonrpcRequest).subscribe(v -> {
+			}, error -> {
+				this.pendingResponses.remove(requestId);
+				sink.error(error);
+			});
+		}).timeout(requestTimeout).handle((jsonRpcResponse, sink) -> {
+			if (jsonRpcResponse.error() != null) {
+				sink.error(new McpError(jsonRpcResponse.error()));
+			}
+			else {
+				if (typeRef.getType().equals(Void.class)) {
+					sink.complete();
+				}
+				else {
+					sink.next(this.transport.unmarshalFrom(jsonRpcResponse.result(), typeRef));
+				}
+			}
+		});
+	}
+
+	@Override
+	public Mono<Void> sendNotification(String method, Object params) {
+		McpSchema.JSONRPCNotification jsonrpcNotification = new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION,
+				method, params);
+		return this.transport.sendMessage(jsonrpcNotification);
+	}
+
+	/**
+	 * Called by the {@link McpServerTransportProvider} once the session is determined.
+	 * The purpose of this method is to dispatch the message to an appropriate handler as
+	 * specified by the MCP server implementation
+	 * ({@link io.modelcontextprotocol.server.McpAsyncServer} or
+	 * {@link io.modelcontextprotocol.server.McpSyncServer}) via
+	 * {@link McpServerSession.Factory} that the server creates.
+	 * @param message the incoming JSON-RPC message
+	 * @return a Mono that completes when the message is processed
+	 */
+	@Override
+	public Mono<Void> handle(McpSchema.JSONRPCMessage message) {
+		return Mono.defer(() -> {
+			// TODO handle errors for communication to without initialization happening
+			// first
+			if (message instanceof McpSchema.JSONRPCResponse response) {
+				logger.debug("Received Response: {}", response);
+				var sink = pendingResponses.remove(response.id());
+				if (sink == null) {
+					logger.warn("Unexpected response for unknown id {}", response.id());
+				}
+				else {
+					sink.success(response);
+				}
+				return Mono.empty();
+			}
+			else if (message instanceof McpSchema.JSONRPCRequest request) {
+				logger.debug("Received request: {}", request);
+				return handleIncomingRequest(request).onErrorResume(error -> {
+					var errorResponse = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), null,
+							new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INTERNAL_ERROR,
+									error.getMessage(), null));
+					// TODO: Should the error go to SSE or back as POST return?
+					return this.transport.sendMessage(errorResponse).then(Mono.empty());
+				}).flatMap(this.transport::sendMessage);
+			}
+			else if (message instanceof McpSchema.JSONRPCNotification notification) {
+				// TODO handle errors for communication to without initialization
+				// happening first
+				logger.debug("Received notification: {}", notification);
+				// TODO: in case of error, should the POST request be signalled?
+				return handleIncomingNotification(notification)
+					.doOnError(error -> logger.error("Error handling notification: {}", error.getMessage()));
+			}
+			else {
+				logger.warn("Received unknown message type: {}", message);
+				return Mono.empty();
+			}
+		});
+	}
+
+	/**
+	 * Handles an incoming JSON-RPC request by routing it to the appropriate handler.
+	 * @param request The incoming JSON-RPC request
+	 * @return A Mono containing the JSON-RPC response
+	 */
+	private Mono<McpSchema.JSONRPCResponse> handleIncomingRequest(McpSchema.JSONRPCRequest request) {
+		return Mono.defer(() -> {
+			Mono<?> resultMono;
+			if (McpSchema.METHOD_INITIALIZE.equals(request.method())) {
+				// TODO handle situation where already initialized!
+				McpSchema.InitializeRequest initializeRequest = transport.unmarshalFrom(request.params(),
+						new TypeReference<McpSchema.InitializeRequest>() {
+						});
+
+				this.state.lazySet(STATE_INITIALIZING);
+				this.init(initializeRequest.capabilities(), initializeRequest.clientInfo());
+				resultMono = this.initRequestHandler.handle(initializeRequest);
+			}
+			else {
+				// TODO handle errors for communication to this session without
+				// initialization happening first
+				var handler = this.requestHandlers.get(request.method());
+				if (handler == null) {
+					MethodNotFoundError error = getMethodNotFoundError(request.method());
+					return Mono.just(new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), null,
+							new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.METHOD_NOT_FOUND,
+									error.message(), error.data())));
+				}
+
+				resultMono = this.exchangeSink.asMono().flatMap(exchange -> handler.handle(exchange, request.params()));
+			}
+			return resultMono
+				.map(result -> new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), result, null))
+				.onErrorResume(error -> Mono.just(new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(),
+						null, new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INTERNAL_ERROR,
+								error.getMessage(), null)))); // TODO: add error message
+																// through the data field
+		});
+	}
+
+	/**
+	 * Handles an incoming JSON-RPC notification by routing it to the appropriate handler.
+	 * @param notification The incoming JSON-RPC notification
+	 * @return A Mono that completes when the notification is processed
+	 */
+	private Mono<Void> handleIncomingNotification(McpSchema.JSONRPCNotification notification) {
+		return Mono.defer(() -> {
+			if (McpSchema.METHOD_NOTIFICATION_INITIALIZED.equals(notification.method())) {
+				this.state.lazySet(STATE_INITIALIZED);
+				exchangeSink.tryEmitValue(new McpAsyncServerExchange(this, clientCapabilities.get(), clientInfo.get()));
+				return this.initNotificationHandler.handle();
+			}
+
+			var handler = notificationHandlers.get(notification.method());
+			if (handler == null) {
+				logger.error("No handler registered for notification method: {}", notification.method());
+				return Mono.empty();
+			}
+			return this.exchangeSink.asMono().flatMap(exchange -> handler.handle(exchange, notification.params()));
+		});
+	}
+
+	record MethodNotFoundError(String method, String message, Object data) {
+	}
+
+	private MethodNotFoundError getMethodNotFoundError(String method) {
+		return new MethodNotFoundError(method, "Method not found: " + method, null);
+	}
+
+	@Override
+	public Mono<Void> closeGracefully() {
+		return this.transport.closeGracefully();
+	}
+
+	@Override
+	public void close() {
+		this.transport.close();
+	}
+}

--- a/mcp/src/test/java/io/modelcontextprotocol/MockMcpServerTransportProvider.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/MockMcpServerTransportProvider.java
@@ -15,8 +15,6 @@
 */
 package io.modelcontextprotocol;
 
-import java.util.Map;
-
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpServerSession;
 import io.modelcontextprotocol.spec.McpServerSession.Factory;

--- a/mcp/src/test/java/io/modelcontextprotocol/server/transport/StdioServerTransportProviderTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/transport/StdioServerTransportProviderTests.java
@@ -4,6 +4,17 @@
 
 package io.modelcontextprotocol.server.transport;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpServerSession;
+import io.modelcontextprotocol.spec.McpServerTransport;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
@@ -13,24 +24,12 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.modelcontextprotocol.spec.McpError;
-import io.modelcontextprotocol.spec.McpSchema;
-import io.modelcontextprotocol.spec.McpServerSession;
-import io.modelcontextprotocol.spec.McpServerTransport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link StdioServerTransportProvider}.
@@ -52,9 +51,9 @@ class StdioServerTransportProviderTests {
 
 	private ObjectMapper objectMapper;
 
-	private McpServerSession.Factory sessionFactory;
+  private McpServerSession.Factory sessionFactory;
 
-	private McpServerSession mockSession;
+  private McpServerSession mockSession;
 
 	@BeforeEach
 	void setUp() {
@@ -66,9 +65,9 @@ class StdioServerTransportProviderTests {
 
 		objectMapper = new ObjectMapper();
 
-		// Create mocks for session factory and session
-		mockSession = mock(McpServerSession.class);
-		sessionFactory = mock(McpServerSession.Factory.class);
+    // Create mocks for session factory and session
+    mockSession = mock(McpServerSession.class);
+    sessionFactory = mock(McpServerSession.Factory.class);
 
 		// Configure mock behavior
 		when(sessionFactory.create(any(McpServerTransport.class))).thenReturn(mockSession);
@@ -110,16 +109,19 @@ class StdioServerTransportProviderTests {
 		AtomicReference<McpSchema.JSONRPCMessage> capturedMessage = new AtomicReference<>();
 		CountDownLatch messageLatch = new CountDownLatch(1);
 
-		McpServerSession.Factory realSessionFactory = transport -> {
-			McpServerSession session = mock(McpServerSession.class);
-			when(session.handle(any())).thenAnswer(invocation -> {
-				capturedMessage.set(invocation.getArgument(0));
-				messageLatch.countDown();
-				return Mono.empty();
-			});
-			when(session.closeGracefully()).thenReturn(Mono.empty());
-			return session;
-		};
+    McpServerSession.Factory realSessionFactory =
+        transport -> {
+          McpServerSession session = mock(McpServerSession.class);
+          when(session.handle(any()))
+              .thenAnswer(
+                  invocation -> {
+                    capturedMessage.set(invocation.getArgument(0));
+                    messageLatch.countDown();
+                    return Mono.empty();
+                  });
+          when(session.closeGracefully()).thenReturn(Mono.empty());
+          return session;
+        };
 
 		// Set session factory
 		transportProvider.setSessionFactory(realSessionFactory);

--- a/mcp/src/test/java/io/modelcontextprotocol/server/transport/StdioServerTransportProviderTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/transport/StdioServerTransportProviderTests.java
@@ -51,9 +51,9 @@ class StdioServerTransportProviderTests {
 
 	private ObjectMapper objectMapper;
 
-  private McpServerSession.Factory sessionFactory;
+	private McpServerSession.Factory sessionFactory;
 
-  private McpServerSession mockSession;
+	private McpServerSession mockSession;
 
 	@BeforeEach
 	void setUp() {
@@ -65,9 +65,9 @@ class StdioServerTransportProviderTests {
 
 		objectMapper = new ObjectMapper();
 
-    // Create mocks for session factory and session
-    mockSession = mock(McpServerSession.class);
-    sessionFactory = mock(McpServerSession.Factory.class);
+		// Create mocks for session factory and session
+		mockSession = mock(McpServerSession.class);
+		sessionFactory = mock(McpServerSession.Factory.class);
 
 		// Configure mock behavior
 		when(sessionFactory.create(any(McpServerTransport.class))).thenReturn(mockSession);
@@ -109,19 +109,16 @@ class StdioServerTransportProviderTests {
 		AtomicReference<McpSchema.JSONRPCMessage> capturedMessage = new AtomicReference<>();
 		CountDownLatch messageLatch = new CountDownLatch(1);
 
-    McpServerSession.Factory realSessionFactory =
-        transport -> {
-          McpServerSession session = mock(McpServerSession.class);
-          when(session.handle(any()))
-              .thenAnswer(
-                  invocation -> {
-                    capturedMessage.set(invocation.getArgument(0));
-                    messageLatch.countDown();
-                    return Mono.empty();
-                  });
-          when(session.closeGracefully()).thenReturn(Mono.empty());
-          return session;
-        };
+		McpServerSession.Factory realSessionFactory = transport -> {
+			McpServerSession session = mock(McpServerSession.class);
+			when(session.handle(any())).thenAnswer(invocation -> {
+				capturedMessage.set(invocation.getArgument(0));
+				messageLatch.countDown();
+				return Mono.empty();
+			});
+			when(session.closeGracefully()).thenReturn(Mono.empty());
+			return session;
+		};
 
 		// Set session factory
 		transportProvider.setSessionFactory(realSessionFactory);


### PR DESCRIPTION
Having an interface rather than a concrete class
can help with extensibility of the McpServerSession class. This PR implements that and changes usages around the code to only mention the interface rather than the implementation class

## Motivation and Context
I was doing a hack project at my company and we were using the `HttpServletSseServerTransportProvider` when
we realized that we couldn't really add some functionalities (in this case it was mainly logging) to active
sessions by creating a delegate because the `McpServerSession` class was a concrete
class rather than an interface and `McpServerSession.Factory` implementations returned said
concrete implementation.
If we use and interface there, we could make the code more flexible and extendible.

## How Has This Been Tested?
`mvn clean verify`

## Breaking Changes
It should be transparent to users given that the interface has the same name the concrete class had.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
