### PR TITLE
fix: Resolve URIs

### DIFF
--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxSseServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxSseServerTransportProvider.java
@@ -154,6 +154,10 @@ public class WebFluxSseServerTransportProvider implements McpServerTransportProv
 		Assert.notNull(messageEndpoint, "Message endpoint must not be null");
 		Assert.notNull(sseEndpoint, "SSE endpoint must not be null");
 
+		if (baseUrl.endsWith("/")) {
+			baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+		}
+
 		this.objectMapper = objectMapper;
 		this.baseUrl = baseUrl;
 		this.messageEndpoint = messageEndpoint;

--- a/mcp-spring/mcp-spring-webmvc/pom.xml
+++ b/mcp-spring/mcp-spring-webmvc/pom.xml
@@ -72,6 +72,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<version>${mockito.version}</version>
@@ -128,7 +134,7 @@
 			<scope>test</scope>
 		</dependency>
 
-	</dependencies>
+    </dependencies>
 
 
 </project>

--- a/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransportProvider.java
@@ -6,6 +6,7 @@ package io.modelcontextprotocol.server.transport;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -152,7 +153,13 @@ public class WebMvcSseServerTransportProvider implements McpServerTransportProvi
 		Assert.notNull(objectMapper, "ObjectMapper must not be null");
 		Assert.notNull(baseUrl, "Message base URL must not be null");
 		Assert.notNull(messageEndpoint, "Message endpoint must not be null");
+		Assert.hasText(messageEndpoint, "Message endpoint must not be empty");
 		Assert.notNull(sseEndpoint, "SSE endpoint must not be null");
+		Assert.hasText(sseEndpoint, "SSE endpoint must not be empty");
+
+		if (baseUrl.endsWith("/")) {
+			baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+		}
 
 		this.objectMapper = objectMapper;
 		this.baseUrl = baseUrl;

--- a/mcp-spring/mcp-spring-webmvc/src/test/java/io/modelcontextprotocol/server/WebMvcSseCustomContextPathTests.java
+++ b/mcp-spring/mcp-spring-webmvc/src/test/java/io/modelcontextprotocol/server/WebMvcSseCustomContextPathTests.java
@@ -49,8 +49,8 @@ class WebMvcSseCustomContextPathTests {
 			throw new RuntimeException("Failed to start Tomcat", e);
 		}
 
-		var clientTransport = HttpClientSseClientTransport.builder("http://localhost:" + PORT)
-			.sseEndpoint(CUSTOM_CONTEXT_PATH + WebMvcSseServerTransportProvider.DEFAULT_SSE_ENDPOINT)
+		var clientTransport = HttpClientSseClientTransport.builder("http://localhost:" + PORT + CUSTOM_CONTEXT_PATH)
+			.sseEndpoint(WebMvcSseServerTransportProvider.DEFAULT_SSE_ENDPOINT)
 			.build();
 
 		clientBuilder = McpClient.sync(clientTransport);

--- a/mcp-spring/mcp-spring-webmvc/src/test/java/io/modelcontextprotocol/server/WebMvcSseCustomPathIntegrationTests.java
+++ b/mcp-spring/mcp-spring-webmvc/src/test/java/io/modelcontextprotocol/server/WebMvcSseCustomPathIntegrationTests.java
@@ -1,0 +1,145 @@
+package io.modelcontextprotocol.server;
+
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.server.transport.WebMvcSseServerTransportProvider;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import reactor.core.publisher.Mono;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.LifecycleState;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class WebMvcSseCustomPathIntegrationTests {
+
+	private static final int PORT = TestUtil.findAvailablePort();
+
+	private WebMvcSseServerTransportProvider mcpServerTransportProvider;
+
+	McpClient.SyncSpec clientBuilder;
+
+	private TomcatTestUtil.TomcatServer tomcatServer;
+
+	String emptyJsonSchema = """
+			{
+				"$schema": "http://json-schema.org/draft-07/schema#",
+				"type": "object",
+				"properties": {}
+			}
+			""";
+
+	@Configuration
+	@EnableWebMvc
+	static class TestConfig {
+
+		@Bean
+		public WebMvcSseServerTransportProvider transportProvider(org.springframework.core.env.Environment env) {
+			String baseUrl = env.getProperty("test.baseUrl");
+			String messageEndpoint = env.getProperty("test.messageEndpoint");
+			String sseEndpoint = env.getProperty("test.sseEndpoint");
+
+			return new WebMvcSseServerTransportProvider(new ObjectMapper(), baseUrl, messageEndpoint, sseEndpoint);
+		}
+
+		@Bean
+		public RouterFunction<ServerResponse> routerFunction(WebMvcSseServerTransportProvider transportProvider) {
+			return transportProvider.getRouterFunction();
+		}
+
+	}
+
+	@ParameterizedTest(name = "baseUrl = \"{0}\" messageEndpoint = \"{1}\" sseEndpoint = \"{2}\" : {displayName} ")
+	@MethodSource("provideCustomEndpoints")
+	public void testCustomizedEndpoints(String baseUrl, String messageEndpoint, String sseEndpoint) {
+		System.setProperty("test.baseUrl", baseUrl);
+		System.setProperty("test.messageEndpoint", messageEndpoint);
+		System.setProperty("test.sseEndpoint", sseEndpoint);
+
+		tomcatServer = TomcatTestUtil.createTomcatServer(baseUrl, PORT, TestConfig.class);
+
+		try {
+			tomcatServer.tomcat().start();
+			assertThat(tomcatServer.tomcat().getServer().getState()).isEqualTo(LifecycleState.STARTED);
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Failed to start Tomcat", e);
+		}
+
+		clientBuilder = McpClient.sync(HttpClientSseClientTransport.builder("http://localhost:" + PORT + baseUrl)
+			.sseEndpoint(sseEndpoint)
+			.build());
+
+		McpSchema.CallToolResult callResponse = new McpSchema.CallToolResult(
+				List.of(new McpSchema.TextContent("CALL RESPONSE")), null);
+
+		McpServerFeatures.AsyncToolSpecification tool1 = new McpServerFeatures.AsyncToolSpecification(
+				new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema),
+				(exchange, request) -> Mono.just(callResponse));
+
+		mcpServerTransportProvider = tomcatServer.appContext().getBean(WebMvcSseServerTransportProvider.class);
+
+		var server = McpServer.async(mcpServerTransportProvider)
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
+			.tools(tool1)
+			.build();
+
+		try (var client = clientBuilder.clientInfo(new McpSchema.Implementation("Sample client", "0.0.0")).build()) {
+			assertThat(client.initialize()).isNotNull();
+			assertThat(client.listTools().tools()).contains(tool1.tool());
+
+			McpSchema.CallToolResult response = client.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
+			assertThat(response).isNotNull().isEqualTo(callResponse);
+		}
+
+		server.close();
+	}
+
+	private static Stream<Arguments> provideCustomEndpoints() {
+		String[] baseUrls = { "", "/v1", "/api/v1", "/", "/v1/", "/api/v1/" };
+		String[] messageEndpoints = { "/message", "/another/sse", "/" };
+		String[] sseEndpoints = { "/sse", "/another/sse", "/" };
+		String[] contextPath = { "", "/v1", "/api/v1", "/", "/v1/", "/api/v1/" };
+
+		return Stream.of(baseUrls)
+			.flatMap(baseUrl -> Stream.of(messageEndpoints)
+				.flatMap(messageEndpoint -> Stream.of(sseEndpoints)
+					.map(sseEndpoint -> Arguments.of(baseUrl, messageEndpoint, sseEndpoint))
+
+				));
+	}
+
+	@AfterEach
+	public void after() {
+		if (mcpServerTransportProvider != null) {
+			mcpServerTransportProvider.closeGracefully().block();
+		}
+		if (tomcatServer.appContext() != null) {
+			tomcatServer.appContext().close();
+		}
+		if (tomcatServer.tomcat() != null) {
+			try {
+				tomcatServer.tomcat().stop();
+				tomcatServer.tomcat().destroy();
+			}
+			catch (LifecycleException e) {
+				throw new RuntimeException("Failed to stop Tomcat", e);
+			}
+		}
+	}
+
+}

--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
@@ -175,9 +175,9 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 	HttpClientSseClientTransport(HttpClient httpClient, HttpRequest.Builder requestBuilder, String baseUri,
 			String sseEndpoint, ObjectMapper objectMapper) {
 		Assert.notNull(objectMapper, "ObjectMapper must not be null");
-		Assert.hasText(baseUri, "baseUri must not be empty");
-		Assert.hasText(sseEndpoint, "sseEndpoint must not be empty");
-		Assert.notNull(httpClient, "httpClient must not be null");
+		Assert.notNull(baseUri, "baseUri must not be null");
+		Assert.notNull(sseEndpoint, "SSE endpoint must not be null");
+		Assert.hasText(sseEndpoint, "SSE endpoint must not be empty");
 		Assert.notNull(requestBuilder, "requestBuilder must not be null");
 		this.baseUri = URI.create(baseUri);
 		this.sseEndpoint = sseEndpoint;
@@ -341,7 +341,8 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 		CompletableFuture<Void> future = new CompletableFuture<>();
 		connectionFuture.set(future);
 
-		URI clientUri = Utils.resolveUri(this.baseUri, this.sseEndpoint);
+		URI clientUri = Utils.resolveSseUri(this.baseUri, this.sseEndpoint);
+		logger.debug("Subscribing to {}", clientUri);
 		sseClient.subscribe(clientUri.toString(), new FlowSseClient.SseEventHandler() {
 			@Override
 			public void onEvent(SseEvent event) {

--- a/mcp/src/main/java/io/modelcontextprotocol/util/Utils.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/util/Utils.java
@@ -4,6 +4,7 @@
 
 package io.modelcontextprotocol.util;
 
+import java.net.URL;
 import reactor.util.annotation.Nullable;
 
 import java.net.URI;
@@ -76,6 +77,26 @@ public final class Utils {
 		else {
 			return baseUrl.resolve(endpointUri);
 		}
+	}
+
+	public static URI resolveSseUri(URI baseUrl, String endpointUrl) {
+		String sanitizedEndpoint = stripLeadingSlash(endpointUrl);
+		URI endpointUri = URI.create(sanitizedEndpoint);
+		if (endpointUri.isAbsolute() && !isUnderBaseUri(baseUrl, endpointUri)) {
+			throw new IllegalArgumentException("Absolute endpoint URL does not match the base URL.");
+		}
+
+		URI res = ensureTrailingSlash(baseUrl).resolve(endpointUri);
+		return res;
+	}
+
+	private static String stripLeadingSlash(String url) {
+		return url.startsWith("/") ? url.substring(1) : url;
+	}
+
+	private static URI ensureTrailingSlash(URI uri) {
+		String uriString = uri.toString();
+		return !uriString.endsWith("/") ? URI.create(uriString.concat("/")) : uri;
 	}
 
 	/**


### PR DESCRIPTION
## Motivation and Context

Currently, the URL resolving is broken under different circumstances when adding a base URL to the path.

There are quite a few issues regarding this in this repo, but also in the Spring AI repos. Example: https://github.com/modelcontextprotocol/java-sdk/issues/261

Basically, the main issue is that the `resolveUri` method works for the message endpoint, but not for the SSE endpoint. So an URL resolver for the SSE endpoint is added.

## How Has This Been Tested?
See `WebMvcSseCustomPathIntegrationTests`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Open questions

This PR is currently **WIP**, because for now it is a little bit unclear for how to handle the context path.
I guess this is _not_ the same as the `baseUrl`, but the main path of the servlet to reach? As an example, for SSE we would get:

```
http://localhost + PORT + CONTEXT_PATH + BASE_URL + SSE
```

If this is correct, then some additional changes need to be made to support this.