### PR TITLE
Set the default encoding of request in mcp client to UTF-8  .(#260)

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
@@ -416,6 +416,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 			String jsonText = this.objectMapper.writeValueAsString(message);
 			URI requestUri = Utils.resolveUri(baseUri, endpoint);
 			HttpRequest request = this.requestBuilder.uri(requestUri)
+				.setHeader("Content-Type", "application/json;charset=UTF-8")
 				.POST(HttpRequest.BodyPublishers.ofString(jsonText))
 				.build();
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
Fix the tool call failed problem when tool name is Chinese.
So set the default encoding of request in mcp client to UTF-8.

## How Has This Been Tested?
Just add a tool name with a Chinese name. Then new a mcp client to invoke call tool.

## Breaking Changes
no

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
