### PR TITLE
Fix typo &  Remove a useless instance and finalize the injecting property

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -117,11 +117,11 @@ public class McpAsyncServer {
 	 * @param objectMapper The ObjectMapper to use for JSON serialization/deserialization
 	 */
 	McpAsyncServer(
-			McpServerTransportProvider mcpTransportProvider,
-			ObjectMapper objectMapper,
-			McpServerFeatures.Async features,
-			Duration requestTimeout,
-			McpUriTemplateManagerFactory uriTemplateManagerFactory
+		McpServerTransportProvider mcpTransportProvider,
+		ObjectMapper objectMapper,
+		McpServerFeatures.Async features,
+		Duration requestTimeout,
+		McpUriTemplateManagerFactory uriTemplateManagerFactory
 	) {
 		this.mcpTransportProvider = mcpTransportProvider;
 		this.objectMapper = objectMapper;

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -28,7 +28,7 @@ import io.modelcontextprotocol.spec.McpSchema.SetLevelRequest;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import io.modelcontextprotocol.spec.McpServerSession;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
-import io.modelcontextprotocol.util.DeafaultMcpUriTemplateManagerFactory;
+import io.modelcontextprotocol.util.DefaultMcpUriTemplateManagerFactory;
 import io.modelcontextprotocol.util.McpUriTemplateManagerFactory;
 import io.modelcontextprotocol.util.Utils;
 import org.slf4j.Logger;
@@ -108,7 +108,7 @@ public class McpAsyncServer {
 
 	private List<String> protocolVersions = List.of(McpSchema.LATEST_PROTOCOL_VERSION);
 
-	private McpUriTemplateManagerFactory uriTemplateManagerFactory = new DeafaultMcpUriTemplateManagerFactory();
+	private McpUriTemplateManagerFactory uriTemplateManagerFactory = new DefaultMcpUriTemplateManagerFactory();
 
 	/**
 	 * Create a new McpAsyncServer with the given transport provider and capabilities.
@@ -117,9 +117,13 @@ public class McpAsyncServer {
 	 * @param features The MCP server supported features.
 	 * @param objectMapper The ObjectMapper to use for JSON serialization/deserialization
 	 */
-	McpAsyncServer(McpServerTransportProvider mcpTransportProvider, ObjectMapper objectMapper,
-			McpServerFeatures.Async features, Duration requestTimeout,
-			McpUriTemplateManagerFactory uriTemplateManagerFactory) {
+	McpAsyncServer(
+			McpServerTransportProvider mcpTransportProvider,
+			ObjectMapper objectMapper,
+			McpServerFeatures.Async features,
+			Duration requestTimeout,
+			McpUriTemplateManagerFactory uriTemplateManagerFactory
+	) {
 		this.mcpTransportProvider = mcpTransportProvider;
 		this.objectMapper = objectMapper;
 		this.serverInfo = features.serverInfo();

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -28,7 +28,6 @@ import io.modelcontextprotocol.spec.McpSchema.SetLevelRequest;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import io.modelcontextprotocol.spec.McpServerSession;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
-import io.modelcontextprotocol.util.DefaultMcpUriTemplateManagerFactory;
 import io.modelcontextprotocol.util.McpUriTemplateManagerFactory;
 import io.modelcontextprotocol.util.Utils;
 import org.slf4j.Logger;
@@ -108,7 +107,7 @@ public class McpAsyncServer {
 
 	private List<String> protocolVersions = List.of(McpSchema.LATEST_PROTOCOL_VERSION);
 
-	private McpUriTemplateManagerFactory uriTemplateManagerFactory = new DefaultMcpUriTemplateManagerFactory();
+	private final McpUriTemplateManagerFactory uriTemplateManagerFactory;
 
 	/**
 	 * Create a new McpAsyncServer with the given transport provider and capabilities.

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpServer.java
@@ -19,7 +19,7 @@ import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.ResourceTemplate;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
 import io.modelcontextprotocol.util.Assert;
-import io.modelcontextprotocol.util.DeafaultMcpUriTemplateManagerFactory;
+import io.modelcontextprotocol.util.DefaultMcpUriTemplateManagerFactory;
 import io.modelcontextprotocol.util.McpUriTemplateManagerFactory;
 import reactor.core.publisher.Mono;
 
@@ -158,7 +158,7 @@ public interface McpServer {
 
 		private final McpServerTransportProvider transportProvider;
 
-		private McpUriTemplateManagerFactory uriTemplateManagerFactory = new DeafaultMcpUriTemplateManagerFactory();
+		private McpUriTemplateManagerFactory uriTemplateManagerFactory = new DefaultMcpUriTemplateManagerFactory();
 
 		private ObjectMapper objectMapper;
 
@@ -648,7 +648,7 @@ public interface McpServer {
 		private static final McpSchema.Implementation DEFAULT_SERVER_INFO = new McpSchema.Implementation("mcp-server",
 				"1.0.0");
 
-		private McpUriTemplateManagerFactory uriTemplateManagerFactory = new DeafaultMcpUriTemplateManagerFactory();
+		private McpUriTemplateManagerFactory uriTemplateManagerFactory = new DefaultMcpUriTemplateManagerFactory();
 
 		private final McpServerTransportProvider transportProvider;
 

--- a/mcp/src/main/java/io/modelcontextprotocol/util/DeafaultMcpUriTemplateManagerFactory.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/util/DeafaultMcpUriTemplateManagerFactory.java
@@ -1,0 +1,26 @@
+/*
+* Copyright 2025 - 2025 the original author or authors.
+*/
+package io.modelcontextprotocol.util;
+
+/**
+ * @deprecated Use {@link DefaultMcpUriTemplateManagerFactory} instead. This
+ * class will be removed in future versions.
+ * @author Christian Tzolov
+ */
+@Deprecated
+public class DeafaultMcpUriTemplateManagerFactory implements McpUriTemplateManagerFactory {
+
+    /**
+     * Creates a new instance of {@link McpUriTemplateManager} with the specified URI
+     * template.
+     *
+     * @param uriTemplate The URI template to be used for variable extraction
+     * @return A new instance of {@link McpUriTemplateManager}
+     * @throws IllegalArgumentException if the URI template is null or empty
+     */
+    @Override
+    public McpUriTemplateManager create(String uriTemplate) {
+        return new DefaultMcpUriTemplateManager(uriTemplate);
+    }
+}

--- a/mcp/src/main/java/io/modelcontextprotocol/util/DefaultMcpUriTemplateManagerFactory.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/util/DefaultMcpUriTemplateManagerFactory.java
@@ -6,7 +6,7 @@ package io.modelcontextprotocol.util;
 /**
  * @author Christian Tzolov
  */
-public class DeafaultMcpUriTemplateManagerFactory implements McpUriTemplateManagerFactory {
+public class DefaultMcpUriTemplateManagerFactory implements McpUriTemplateManagerFactory {
 
 	/**
 	 * Creates a new instance of {@link McpUriTemplateManager} with the specified URI

--- a/mcp/src/test/java/io/modelcontextprotocol/McpUriTemplateManagerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/McpUriTemplateManagerTests.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Map;
 
-import io.modelcontextprotocol.util.DeafaultMcpUriTemplateManagerFactory;
+import io.modelcontextprotocol.util.DefaultMcpUriTemplateManagerFactory;
 import io.modelcontextprotocol.util.McpUriTemplateManager;
 import io.modelcontextprotocol.util.McpUriTemplateManagerFactory;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,7 +29,7 @@ public class McpUriTemplateManagerTests {
 
 	@BeforeEach
 	void setUp() {
-		this.uriTemplateFactory = new DeafaultMcpUriTemplateManagerFactory();
+		this.uriTemplateFactory = new DefaultMcpUriTemplateManagerFactory();
 	}
 
 	@Test


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Fix typo `deafault..` into `default`.
Remove a useless instance and finalize the injecting property.

I remain wrong class for backward capabilities as deprecated

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Correcting a typo to maintain consistency and avoid any potential misunderstanding.
Replacing field with constructor injection and marked the property as final for better immutability and testability.


## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
I test initiate server sync and async both. It was run correctly.


## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
