### PR TITLE
Improve error handling for message enqueue failure

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
@@ -9,9 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.io.Reader;
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -148,14 +146,12 @@ public class StdioServerTransportProvider implements McpServerTransportProvider 
 
 		@Override
 		public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
-
 			return Mono.zip(inboundReady.asMono(), outboundReady.asMono()).then(Mono.defer(() -> {
-				if (outboundSink.tryEmitNext(message).isSuccess()) {
+				Sinks.EmitResult result = outboundSink.tryEmitNext(message);
+				if (result.isSuccess()) {
 					return Mono.empty();
 				}
-				else {
-					return Mono.error(new RuntimeException("Failed to enqueue message"));
-				}
+				return Mono.error(new RuntimeException("Failed to enqueue message: " + message + ", due to " + result));
 			}));
 		}
 


### PR DESCRIPTION
- Update sendMessage method to provide more detailed error information
- Remove unnecessary imports and improve code readability

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

While debugging an MCP server in STDIO mode, I encountered `RuntimeException: Failed to enqueue message`. The exception stack trace pointed to `StdioMcpSessionTransport#sendMessage()` but without more error details, I can only see that `outboundSink.tryEmitNext(message).isSuccess()` actually return `false` but there is no more helpful info to locate the root cause what results in this `false`. I think the return value of `tryEmitNext(message)` is needed to be included in the error message to make it more clear.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Yes, I tested this in my local MCP server example application.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

No breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

No additional context
