### PR TITLE
Add support for DNS rebinding protections

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/DnsRebindingProtectionConfig.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/DnsRebindingProtectionConfig.java
@@ -1,0 +1,108 @@
+package io.modelcontextprotocol.server.transport;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Configuration for DNS rebinding protection in SSE server transports. Provides
+ * validation for Host and Origin headers to prevent DNS rebinding attacks.
+ */
+public class DnsRebindingProtectionConfig {
+
+	private final Set<String> allowedHosts;
+
+	private final Set<String> allowedOrigins;
+
+	private final boolean enableDnsRebindingProtection;
+
+	private DnsRebindingProtectionConfig(Builder builder) {
+		this.allowedHosts = Collections.unmodifiableSet(new HashSet<>(builder.allowedHosts));
+		this.allowedOrigins = Collections.unmodifiableSet(new HashSet<>(builder.allowedOrigins));
+		this.enableDnsRebindingProtection = builder.enableDnsRebindingProtection;
+	}
+
+	/**
+	 * Validates Host and Origin headers for DNS rebinding protection. Returns true if the
+	 * headers are valid, false otherwise.
+	 * @param hostHeader The value of the Host header (may be null)
+	 * @param originHeader The value of the Origin header (may be null)
+	 * @return true if the headers are valid, false otherwise
+	 */
+	public boolean validate(String hostHeader, String originHeader) {
+		// Skip validation if protection is not enabled
+		if (!enableDnsRebindingProtection) {
+			return true;
+		}
+
+		// Validate Host header
+		if (hostHeader != null) {
+			String lowerHost = hostHeader.toLowerCase();
+			if (!allowedHosts.contains(lowerHost)) {
+				return false;
+			}
+		}
+
+		// Validate Origin header
+		if (originHeader != null) {
+			String lowerOrigin = originHeader.toLowerCase();
+			if (!allowedOrigins.contains(lowerOrigin)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static class Builder {
+
+		private final Set<String> allowedHosts = new HashSet<>();
+
+		private final Set<String> allowedOrigins = new HashSet<>();
+
+		private boolean enableDnsRebindingProtection = true;
+
+		public Builder allowedHost(String host) {
+			if (host != null) {
+				this.allowedHosts.add(host.toLowerCase());
+			}
+			return this;
+		}
+
+		public Builder allowedHosts(Set<String> hosts) {
+			if (hosts != null) {
+				hosts.forEach(this::allowedHost);
+			}
+			return this;
+		}
+
+		public Builder allowedOrigin(String origin) {
+			if (origin != null) {
+				this.allowedOrigins.add(origin.toLowerCase());
+			}
+			return this;
+		}
+
+		public Builder allowedOrigins(Set<String> origins) {
+			if (origins != null) {
+				origins.forEach(this::allowedOrigin);
+			}
+			return this;
+		}
+
+		public Builder enableDnsRebindingProtection(boolean enable) {
+			this.enableDnsRebindingProtection = enable;
+			return this;
+		}
+
+		public DnsRebindingProtectionConfig build() {
+			return new DnsRebindingProtectionConfig(this);
+		}
+
+	}
+
+}

--- a/mcp/src/test/java/io/modelcontextprotocol/server/transport/DnsRebindingProtectionConfigTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/transport/DnsRebindingProtectionConfigTests.java
@@ -1,0 +1,157 @@
+package io.modelcontextprotocol.server.transport;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for DNS rebinding protection configuration.
+ */
+public class DnsRebindingProtectionConfigTests {
+
+	@Test
+	void testDefaultConfiguration() {
+		DnsRebindingProtectionConfig config = DnsRebindingProtectionConfig.builder().build();
+
+		// Test default behavior - when allowed lists are empty and headers are provided,
+		// validation fails because the headers are not in the (empty) allowed lists
+		assertThat(config.validate("any.host.com", "http://any.origin.com")).isFalse();
+		assertThat(config.validate("localhost", null)).isFalse();
+		assertThat(config.validate(null, "http://example.com")).isFalse();
+		// Null values are allowed when lists are empty
+		assertThat(config.validate(null, null)).isTrue();
+	}
+
+	@Test
+	void testDisableDnsRebindingProtection() {
+		DnsRebindingProtectionConfig config = DnsRebindingProtectionConfig.builder()
+			.enableDnsRebindingProtection(false)
+			.allowedHost("localhost") // Should be ignored when protection is disabled
+			.allowedOrigin("http://localhost") // Should be ignored when protection is
+												// disabled
+			.build();
+
+		// When protection is disabled, all hosts and origins should be allowed
+		assertThat(config.validate("evil.com", "http://evil.com")).isTrue();
+		assertThat(config.validate("any.host", "http://any.origin")).isTrue();
+		assertThat(config.validate(null, null)).isTrue();
+	}
+
+	@Test
+	void testHostValidation() {
+		DnsRebindingProtectionConfig config = DnsRebindingProtectionConfig.builder()
+			.allowedHost("localhost")
+			.allowedHost("127.0.0.1")
+			.build();
+
+		// Valid hosts
+		assertThat(config.validate("localhost", null)).isTrue();
+		assertThat(config.validate("127.0.0.1", null)).isTrue();
+
+		// Invalid hosts
+		assertThat(config.validate("evil.com", null)).isFalse();
+
+		// Null host is allowed when no specific hosts are being checked
+		assertThat(config.validate(null, null)).isTrue();
+	}
+
+	@Test
+	void testOriginValidation() {
+		DnsRebindingProtectionConfig config = DnsRebindingProtectionConfig.builder()
+			.allowedOrigin("http://localhost:8080")
+			.allowedOrigin("https://app.example.com")
+			.build();
+
+		// Valid origins
+		assertThat(config.validate(null, "http://localhost:8080")).isTrue();
+		assertThat(config.validate(null, "https://app.example.com")).isTrue();
+
+		// Invalid origins
+		assertThat(config.validate(null, "http://evil.com")).isFalse();
+
+		// Null origin is allowed when no specific origins are being checked
+		assertThat(config.validate(null, null)).isTrue();
+	}
+
+	@Test
+	void testCombinedHostAndOriginValidation() {
+		DnsRebindingProtectionConfig config = DnsRebindingProtectionConfig.builder()
+			.allowedHost("localhost")
+			.allowedOrigin("http://localhost:8080")
+			.build();
+
+		// Both valid
+		assertThat(config.validate("localhost", "http://localhost:8080")).isTrue();
+
+		// Host valid, origin invalid
+		assertThat(config.validate("localhost", "http://evil.com")).isFalse();
+
+		// Host invalid, origin valid
+		assertThat(config.validate("evil.com", "http://localhost:8080")).isFalse();
+
+		// Both invalid
+		assertThat(config.validate("evil.com", "http://evil.com")).isFalse();
+	}
+
+	@Test
+	void testCaseInsensitiveHostAndOrigin() {
+		DnsRebindingProtectionConfig config = DnsRebindingProtectionConfig.builder()
+			.allowedHost("LOCALHOST")
+			.allowedOrigin("HTTP://LOCALHOST:8080")
+			.build();
+
+		// Case insensitive matching
+		assertThat(config.validate("localhost", null)).isTrue();
+		assertThat(config.validate("LOCALHOST", null)).isTrue();
+		assertThat(config.validate("LoCaLhOsT", null)).isTrue();
+
+		assertThat(config.validate(null, "http://localhost:8080")).isTrue();
+		assertThat(config.validate(null, "HTTP://LOCALHOST:8080")).isTrue();
+	}
+
+	@Test
+	void testEmptyAllowedListsDenyNonNull() {
+		DnsRebindingProtectionConfig config = DnsRebindingProtectionConfig.builder().build();
+
+		// When allowed lists are empty and headers are provided, validation fails
+		assertThat(config.validate("any.host.com", "http://any.origin.com")).isFalse();
+		assertThat(config.validate("random.host", "http://random.origin")).isFalse();
+		// But null values are allowed
+		assertThat(config.validate(null, null)).isTrue();
+	}
+
+	@Test
+	void testBuilderWithSets() {
+		Set<String> hosts = Set.of("host1.com", "host2.com");
+		Set<String> origins = Set.of("http://origin1.com", "http://origin2.com");
+
+		DnsRebindingProtectionConfig config = DnsRebindingProtectionConfig.builder()
+			.allowedHosts(hosts)
+			.allowedOrigins(origins)
+			.build();
+
+		assertThat(config.validate("host1.com", null)).isTrue();
+		assertThat(config.validate("host2.com", null)).isTrue();
+		assertThat(config.validate("host3.com", null)).isFalse();
+
+		assertThat(config.validate(null, "http://origin1.com")).isTrue();
+		assertThat(config.validate(null, "http://origin2.com")).isTrue();
+		assertThat(config.validate(null, "http://origin3.com")).isFalse();
+	}
+
+	@Test
+	void testNullValuesWithConfiguredLists() {
+		DnsRebindingProtectionConfig config = DnsRebindingProtectionConfig.builder()
+			.allowedHost("localhost")
+			.allowedOrigin("http://localhost")
+			.build();
+
+		// Null values should be allowed when no check is needed for that header
+		assertThat(config.validate(null, "http://localhost")).isTrue();
+		assertThat(config.validate("localhost", null)).isTrue();
+		assertThat(config.validate(null, null)).isTrue();
+	}
+
+}

--- a/mcp/src/test/java/io/modelcontextprotocol/server/transport/HttpServletSseHeaderValidationTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/transport/HttpServletSseHeaderValidationTests.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2024 - 2024 the original author or authors.
+ */
+package io.modelcontextprotocol.server.transport;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.LifecycleState;
+import org.apache.catalina.startup.Tomcat;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.CompletionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Integration tests for header validation in
+ * {@link HttpServletSseServerTransportProvider}.
+ */
+class HttpServletSseHeaderValidationTests {
+
+	private static final int PORT = TomcatTestUtil.findAvailablePort();
+
+	private static final String MESSAGE_ENDPOINT = "/mcp/message";
+
+	private static final String SSE_ENDPOINT = "/sse";
+
+	private Tomcat tomcat;
+
+	private HttpServletSseServerTransportProvider transportProvider;
+
+	private McpSyncServer server;
+
+	@AfterEach
+	void tearDown() {
+		if (server != null) {
+			server.close();
+		}
+		if (transportProvider != null) {
+			transportProvider.closeGracefully().block();
+		}
+		if (tomcat != null) {
+			try {
+				tomcat.stop();
+				tomcat.destroy();
+			}
+			catch (LifecycleException e) {
+				throw new RuntimeException("Failed to stop Tomcat", e);
+			}
+		}
+	}
+
+	@Test
+	void testConnectionSucceedsWithValidHeaders() {
+		// Create DNS rebinding protection config that validates API key
+		DnsRebindingProtectionConfig dnsRebindingProtectionConfig = DnsRebindingProtectionConfig.builder()
+			.enableDnsRebindingProtection(false) // Disable Host/Origin validation for
+													// this test
+			.build();
+
+		// For this test, we'll need to use a custom transport provider implementation
+		// since DnsRebindingProtectionConfig doesn't support custom header validation
+		transportProvider = HttpServletSseServerTransportProvider.builder()
+			.objectMapper(new ObjectMapper())
+			.messageEndpoint(MESSAGE_ENDPOINT)
+			.sseEndpoint(SSE_ENDPOINT)
+			.dnsRebindingProtectionConfig(dnsRebindingProtectionConfig)
+			.build();
+
+		startServer();
+
+		// Create client - should succeed since DNS rebinding protection is disabled
+		try (var client = McpClient
+			.sync(HttpClientSseClientTransport.builder("http://localhost:" + PORT).sseEndpoint(SSE_ENDPOINT).build())
+			.build()) {
+
+			// Connection should succeed
+			McpSchema.InitializeResult result = client.initialize();
+			assertThat(result).isNotNull();
+			assertThat(result.serverInfo().name()).isEqualTo("test-server");
+		}
+	}
+
+	@Test
+	void testConnectionFailsWithInvalidHeaders() {
+		// Create DNS rebinding protection config with restricted hosts
+		DnsRebindingProtectionConfig dnsRebindingProtectionConfig = DnsRebindingProtectionConfig.builder()
+			.allowedHost("valid-host.com")
+			.build();
+
+		// Create server with header validation
+		transportProvider = HttpServletSseServerTransportProvider.builder()
+			.objectMapper(new ObjectMapper())
+			.messageEndpoint(MESSAGE_ENDPOINT)
+			.sseEndpoint(SSE_ENDPOINT)
+			.dnsRebindingProtectionConfig(dnsRebindingProtectionConfig)
+			.build();
+
+		startServer();
+
+		// Create client with localhost which won't match the allowed host
+		// The Host header will be "localhost:PORT" which won't match "valid-host.com"
+		var clientTransport = HttpClientSseClientTransport.builder("http://localhost:" + PORT)
+			.sseEndpoint(SSE_ENDPOINT)
+			.build();
+
+		// Connection should fail during initialization
+		assertThatThrownBy(() -> {
+			try (var client = McpClient.sync(clientTransport).build()) {
+				client.initialize();
+			}
+		}).isInstanceOf(RuntimeException.class);
+	}
+
+	@Test
+	void testConnectionFailsWithEmptyAllowedHostsButProvidedHost() {
+		// Create DNS rebinding protection config with specific allowed origin but no
+		// allowed hosts
+		// This means any non-null host will be rejected
+		DnsRebindingProtectionConfig dnsRebindingProtectionConfig = DnsRebindingProtectionConfig.builder()
+			.allowedOrigin("http://allowed-origin.com")
+			.build();
+
+		// Create server with header validation
+		transportProvider = HttpServletSseServerTransportProvider.builder()
+			.objectMapper(new ObjectMapper())
+			.messageEndpoint(MESSAGE_ENDPOINT)
+			.sseEndpoint(SSE_ENDPOINT)
+			.dnsRebindingProtectionConfig(dnsRebindingProtectionConfig)
+			.build();
+
+		startServer();
+
+		// Create client - the client will send a Host header like "localhost:PORT"
+		// Since allowedHosts is empty, any non-null host will be rejected
+		var clientTransport = HttpClientSseClientTransport.builder("http://localhost:" + PORT)
+			.sseEndpoint(SSE_ENDPOINT)
+			.build();
+
+		// With the new behavior, a non-null Host header is rejected when allowedHosts is
+		// empty
+		assertThatThrownBy(() -> {
+			try (var client = McpClient.sync(clientTransport).build()) {
+				client.initialize();
+			}
+		}).isInstanceOf(RuntimeException.class);
+	}
+
+	@Test
+	void testComplexHeaderValidation() {
+		// Create DNS rebinding protection config with specific allowed hosts and origins
+		// Note: The Host header will include the port, so we need to allow
+		// "localhost:PORT"
+		DnsRebindingProtectionConfig dnsRebindingProtectionConfig = DnsRebindingProtectionConfig.builder()
+			.allowedHost("localhost:" + PORT)
+			.allowedOrigin("http://localhost:" + PORT)
+			.build();
+
+		// Create server with DNS rebinding protection
+		transportProvider = HttpServletSseServerTransportProvider.builder()
+			.objectMapper(new ObjectMapper())
+			.messageEndpoint(MESSAGE_ENDPOINT)
+			.sseEndpoint(SSE_ENDPOINT)
+			.dnsRebindingProtectionConfig(dnsRebindingProtectionConfig)
+			.build();
+
+		startServer();
+
+		// Test with valid headers (localhost is allowed)
+		try (var client = McpClient
+			.sync(HttpClientSseClientTransport.builder("http://localhost:" + PORT).sseEndpoint(SSE_ENDPOINT).build())
+			.build()) {
+
+			McpSchema.InitializeResult result = client.initialize();
+			assertThat(result).isNotNull();
+		}
+
+		// Test with different host (should fail)
+		var invalidHostTransport = HttpClientSseClientTransport.builder("http://127.0.0.1:" + PORT)
+			.sseEndpoint(SSE_ENDPOINT)
+			.build();
+
+		assertThatThrownBy(() -> {
+			try (var client = McpClient.sync(invalidHostTransport).build()) {
+				client.initialize();
+			}
+		}).isInstanceOf(RuntimeException.class);
+	}
+
+	@Test
+	void testDefaultValidatorAllowsAllHeaders() {
+		// Create server without specifying a DNS rebinding protection config (no
+		// validation)
+		transportProvider = HttpServletSseServerTransportProvider.builder()
+			.objectMapper(new ObjectMapper())
+			.messageEndpoint(MESSAGE_ENDPOINT)
+			.sseEndpoint(SSE_ENDPOINT)
+			.build();
+
+		startServer();
+
+		// Create client with arbitrary headers
+		try (var client = McpClient.sync(HttpClientSseClientTransport.builder("http://localhost:" + PORT)
+			.sseEndpoint(SSE_ENDPOINT)
+			.customizeRequest(requestBuilder -> {
+				requestBuilder.header("X-Random-Header", "random-value");
+				requestBuilder.header("X-Another-Header", "another-value");
+			})
+			.build()).build()) {
+
+			// Connection should succeed with any headers
+			McpSchema.InitializeResult result = client.initialize();
+			assertThat(result).isNotNull();
+		}
+	}
+
+	private void startServer() {
+		tomcat = TomcatTestUtil.createTomcatServer("", PORT, transportProvider);
+		try {
+			tomcat.start();
+			assertThat(tomcat.getServer().getState()).isEqualTo(LifecycleState.STARTED);
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Failed to start Tomcat", e);
+		}
+
+		server = McpServer.sync(transportProvider).serverInfo("test-server", "1.0.0").build();
+	}
+
+}


### PR DESCRIPTION

## Motivation and Context
This implements the mitigations described [here](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#security-warning). To avoid breaking existing applications this doesn't enable any changes by-default, but enabling this feature is heavily encouraged for any local MCP servers using the SSE transport. 

## How Has This Been Tested?
Tested via unit tests. 

## Breaking Changes
To avoid introducing any breaking changes, the DNS rebinding protections are disabled by default. Ideally we should find a way to enable them by default. But for now, adding them as disabled is a good first step. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
