### PR TITLE
feat: Add Tool.outputSchema and CallToolResult.structuredContent

### DIFF
--- a/mcp-test/src/main/java/io/modelcontextprotocol/server/.LCKAbstractMcpSyncServerTests.java~
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/server/.LCKAbstractMcpSyncServerTests.java~
@@ -1,0 +1,1 @@
+/local/home/pantanur/workspace/java-sdk/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java

--- a/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
@@ -4,6 +4,7 @@
 
 package io.modelcontextprotocol.server;
 
+import java.util.HashMap;
 import java.util.List;
 
 import io.modelcontextprotocol.spec.McpError;
@@ -17,6 +18,7 @@ import io.modelcontextprotocol.spec.McpSchema.Resource;
 import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -125,7 +127,7 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testAddDuplicateTool() {
-		Tool duplicateTool = new McpSchema.Tool(TEST_TOOL_NAME, "Duplicate tool", emptyJsonSchema);
+		Tool duplicateTool = new McpSchema.Tool(TEST_TOOL_NAME, "Duplicate tool", emptyJsonSchema, emptyJsonSchema);
 
 		var mcpSyncServer = McpServer.sync(createMcpTransportProvider())
 			.serverInfo("test-server", "1.0.0")
@@ -134,7 +136,7 @@ public abstract class AbstractMcpSyncServerTests {
 			.build();
 
 		assertThatThrownBy(() -> mcpSyncServer.addTool(new McpServerFeatures.SyncToolSpecification(duplicateTool,
-				(exchange, args) -> new CallToolResult(List.of(), false))))
+				(exchange, args) -> new CallToolResult(List.of(), false, new HashMap<String, Object>()))))
 			.isInstanceOf(McpError.class)
 			.hasMessage("Tool with name '" + TEST_TOOL_NAME + "' already exists");
 

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -202,6 +202,13 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- Json validator dependency -->
+		<dependency>
+			<groupId>com.networknt</groupId>
+			<artifactId>json-schema-validator</artifactId>
+			<version>1.5.7</version>
+		</dependency>
+
 	</dependencies>
 
 

--- a/mcp/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
@@ -14,6 +14,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+
 import io.modelcontextprotocol.spec.McpClientSession;
 import io.modelcontextprotocol.spec.McpClientSession.NotificationHandler;
 import io.modelcontextprotocol.spec.McpClientSession.RequestHandler;
@@ -33,8 +34,11 @@ import io.modelcontextprotocol.spec.McpSchema.Root;
 import io.modelcontextprotocol.spec.McpTransport;
 import io.modelcontextprotocol.util.Assert;
 import io.modelcontextprotocol.util.Utils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.modelcontextprotocol.server.McpServerFeatures;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
@@ -124,6 +128,11 @@ public class McpAsyncClient {
 	private McpSchema.Implementation serverInfo;
 
 	/**
+	 * Cached tool output schemas.
+	 */
+	private final HashMap<String, McpSchema.JsonSchema> toolsOutputSchemaCache;
+
+	/**
 	 * Roots define the boundaries of where servers can operate within the filesystem,
 	 * allowing them to understand which directories and files they have access to.
 	 * Servers can request the list of roots from supporting clients and receive
@@ -171,6 +180,7 @@ public class McpAsyncClient {
 		this.transport = transport;
 		this.roots = new ConcurrentHashMap<>(features.roots());
 		this.initializationTimeout = initializationTimeout;
+		this.toolsOutputSchemaCache = new HashMap<>();
 
 		// Request Handlers
 		Map<String, RequestHandler<?>> requestHandlers = new HashMap<>();
@@ -285,6 +295,14 @@ public class McpAsyncClient {
 	 */
 	public McpSchema.Implementation getClientInfo() {
 		return this.clientInfo;
+	}
+
+	/**
+	 * Get the cached tool output schemas.
+	 * @return The cached tool output schemas
+	 */
+	public HashMap<String, McpSchema.JsonSchema> getToolsOutputSchemaCache() {
+		return this.toolsOutputSchemaCache;
 	}
 
 	/**
@@ -525,7 +543,13 @@ public class McpAsyncClient {
 			if (this.serverCapabilities.tools() == null) {
 				return Mono.error(new McpError("Server does not provide tools capability"));
 			}
-			return this.mcpSession.sendRequest(McpSchema.METHOD_TOOLS_CALL, callToolRequest, CALL_TOOL_RESULT_TYPE_REF);
+			// Refresh tool output schema cache, if necessary, prior to making tool call
+			Mono<Void> refreshCacheMono = Mono.empty();
+			if (!this.toolsOutputSchemaCache.containsKey(callToolRequest.name())) {
+				refreshCacheMono = refreshToolOutputSchemaCache();
+			}
+			return refreshCacheMono.then(this.mcpSession.sendRequest(McpSchema.METHOD_TOOLS_CALL, callToolRequest,
+					CALL_TOOL_RESULT_TYPE_REF));
 		});
 	}
 
@@ -547,8 +571,34 @@ public class McpAsyncClient {
 			if (this.serverCapabilities.tools() == null) {
 				return Mono.error(new McpError("Server does not provide tools capability"));
 			}
-			return this.mcpSession.sendRequest(McpSchema.METHOD_TOOLS_LIST, new McpSchema.PaginatedRequest(cursor),
-					LIST_TOOLS_RESULT_TYPE_REF);
+			return this.mcpSession
+				.sendRequest(McpSchema.METHOD_TOOLS_LIST, new McpSchema.PaginatedRequest(cursor),
+						LIST_TOOLS_RESULT_TYPE_REF)
+				.doOnNext(result -> {
+					// Cache tools output schema
+					if (result.tools() != null) {
+						// Cache tools output schema
+						result.tools()
+							.forEach(tool -> this.toolsOutputSchemaCache.put(tool.name(), tool.outputSchema()));
+					}
+				});
+		});
+	}
+
+	/**
+	 * Refreshes the tool output schema cache by fetching all tools from the server.
+	 * @return A Mono that completes when all tool output schemas have been cached
+	 */
+	private Mono<Void> refreshToolOutputSchemaCache() {
+		return this.withInitializationCheck("refreshing tool output schema cache", initializedResult -> {
+
+			// Use expand operator to handle pagination in a reactive way
+			return this.listTools(null).expand(result -> {
+				if (result.nextCursor() != null) {
+					return this.listTools(result.nextCursor());
+				}
+				return Mono.empty();
+			}).then();
 		});
 	}
 

--- a/mcp/src/main/java/io/modelcontextprotocol/client/McpSyncClient.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/McpSyncClient.java
@@ -5,15 +5,28 @@
 package io.modelcontextprotocol.client;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.ClientCapabilities;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptRequest;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptResult;
 import io.modelcontextprotocol.spec.McpSchema.ListPromptsResult;
 import io.modelcontextprotocol.util.Assert;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A synchronous client implementation for the Model Context Protocol (MCP) that wraps an
@@ -54,6 +67,8 @@ import org.slf4j.LoggerFactory;
 public class McpSyncClient implements AutoCloseable {
 
 	private static final Logger logger = LoggerFactory.getLogger(McpSyncClient.class);
+
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
 	// TODO: Consider providing a client config to set this properly
 	// this is currently a concern only because AutoCloseable is used - perhaps it
@@ -206,7 +221,8 @@ public class McpSyncClient implements AutoCloseable {
 	/**
 	 * Calls a tool provided by the server. Tools enable servers to expose executable
 	 * functionality that can interact with external systems, perform computations, and
-	 * take actions in the real world.
+	 * take actions in the real world. If tool contains an output schema, validates the
+	 * tool result structured content against the output schema.
 	 * @param callToolRequest The request containing: - name: The name of the tool to call
 	 * (must match a tool name from tools/list) - arguments: Arguments that conform to the
 	 * tool's input schema
@@ -215,7 +231,53 @@ public class McpSyncClient implements AutoCloseable {
 	 * Boolean indicating if the execution failed (true) or succeeded (false/absent)
 	 */
 	public McpSchema.CallToolResult callTool(McpSchema.CallToolRequest callToolRequest) {
-		return this.delegate.callTool(callToolRequest).block();
+		McpSchema.CallToolResult result = this.delegate.callTool(callToolRequest).block();
+		HashMap<String, McpSchema.JsonSchema> toolsOutputSchemaCache = this.delegate.getToolsOutputSchemaCache();
+		// Should not be triggered but added for completeness
+		if (!toolsOutputSchemaCache.containsKey(callToolRequest.name())) {
+			throw new McpError("Tool with name '" + callToolRequest.name() + "' not found");
+		}
+		if (result != null && toolsOutputSchemaCache.get(callToolRequest.name()) != null) {
+			if (result.structuredContent() == null) {
+				throw new McpError("CallToolResult validation failed: structuredContent is null and "
+						+ "does not match tool outputSchema.");
+			}
+
+			McpSchema.JsonSchema outputSchema = toolsOutputSchemaCache.get(callToolRequest.name());
+
+			try {
+				// Convert outputSchema to string
+				String outputSchemaString = OBJECT_MAPPER.writeValueAsString(outputSchema);
+
+				// Create JsonSchema validator
+				ObjectNode schemaNode = (ObjectNode) OBJECT_MAPPER.readTree(outputSchemaString);
+				// Set additional properties to false if not specified in output schema
+				if (!schemaNode.has("additionalProperties")) {
+					schemaNode.put("additionalProperties", false);
+				}
+				JsonSchema schema = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
+					.getSchema(schemaNode);
+
+				// Convert structured content in reult to JsonNode
+				JsonNode jsonNode = OBJECT_MAPPER.valueToTree(result.structuredContent());
+
+				// Validate outputSchema against structuredContent
+				Set<ValidationMessage> validationResult = schema.validate(jsonNode);
+
+				// Check if validation passed
+				if (!validationResult.isEmpty()) {
+					// Handle validation errors
+					throw new McpError(
+							"CallToolResult validation failed: structuredContent does not match tool outputSchema.");
+				}
+			}
+			catch (JsonProcessingException e) {
+				// Log error if output schema can't be parsed to prevent erroring out for
+				// successful call tool request
+				logger.error("Encountered exception when parsing outputSchema: {}", e);
+			}
+		}
+		return result;
 	}
 
 	/**
@@ -351,6 +413,10 @@ public class McpSyncClient implements AutoCloseable {
 	 */
 	public McpSchema.CompleteResult completeCompletion(McpSchema.CompleteRequest completeRequest) {
 		return this.delegate.completeCompletion(completeRequest).block();
+	}
+
+	private void isStrict(boolean b) {
+		throw new UnsupportedOperationException("Not supported yet.");
 	}
 
 }

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -9,6 +9,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -18,9 +22,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.modelcontextprotocol.util.Assert;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Based on the <a href="http://www.jsonrpc.org/specification">JSON-RPC 2.0
@@ -720,16 +723,25 @@ public final class McpSchema {
 	 * @param inputSchema A JSON Schema object that describes the expected structure of
 	 * the arguments when calling this tool. This allows clients to validate tool
 	 * arguments before sending them to the server.
+	 * @param outputSchema An optional JSON Schema object that describes the expected
+	 * output structure of this tool. If set, the clients must validate that the results
+	 * from that tool contain a `structuredContent` field whose contents validate against
+	 * the declared `outputSchema`.
 	 */
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record Tool( // @formatter:off
 		@JsonProperty("name") String name,
 		@JsonProperty("description") String description,
-		@JsonProperty("inputSchema") JsonSchema inputSchema) {
+		@JsonProperty("inputSchema") JsonSchema inputSchema,
+		@JsonProperty("outputSchema") JsonSchema outputSchema) {
+
+		public Tool(String name, String description, String inputSchema) {
+			this(name, description, parseSchema(inputSchema), null);
+		}
 	
-		public Tool(String name, String description, String schema) {
-			this(name, description, parseSchema(schema));
+		public Tool(String name, String description, String inputSchema, String outputSchema) {
+			this(name, description, parseSchema(inputSchema), parseSchema(outputSchema));
 		}
 			
 	} // @formatter:on
@@ -775,15 +787,19 @@ public final class McpSchema {
 	 * The server's response to a tools/call request from the client.
 	 *
 	 * @param content A list of content items representing the tool's output. Each item can be text, an image,
-	 *                or an embedded resource.
+	 * or an embedded resource.
 	 * @param isError If true, indicates that the tool execution failed and the content contains error information.
-	 *                If false or absent, indicates successful execution.
+	 * If false or absent, indicates successful execution.
+	 * @param structuredContent An optional map of structured content. If present, the client must validate that
+	 * the results from that tool contain a `structuredContent` field whose contents validate against the declared
+	 * `outputSchema`.
 	 */
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record CallToolResult( // @formatter:off
 		@JsonProperty("content") List<Content> content,
-		@JsonProperty("isError") Boolean isError) {
+		@JsonProperty("isError") Boolean isError,
+		@JsonProperty("structuredContent") Map<String, Object> structuredContent) {
 
 		/**
 		 * Creates a new instance of {@link CallToolResult} with a string containing the
@@ -795,7 +811,20 @@ public final class McpSchema {
 		 *                If false or absent, indicates successful execution.
 		 */
 		public CallToolResult(String content, Boolean isError) {
-			this(List.of(new TextContent(content)), isError);
+			this(List.of(new TextContent(content)), isError, null);
+		}
+
+		/**
+		 * Creates a new instance of {@link CallToolResult} with a string containing the
+		 * tool result.
+		 *
+		 * @param content The content of the tool result. This will be mapped to a one-sized list
+		 * 				  with a {@link TextContent} element.
+		 * @param isError If true, indicates that the tool execution failed and the content contains error information.
+		 *                If false or absent, indicates successful execution.
+		 */
+		public CallToolResult(List<Content> content, Boolean isError) {
+			this(content, isError, null);
 		}
 
 		/**
@@ -812,6 +841,7 @@ public final class McpSchema {
 		public static class Builder {
 			private List<Content> content = new ArrayList<>();
 			private Boolean isError;
+			private Map<String, Object> structuredContent;
 
 			/**
 			 * Sets the content list for the tool result.
@@ -834,6 +864,17 @@ public final class McpSchema {
 				textContent.stream()
 					.map(TextContent::new)
 					.forEach(this.content::add);
+				return this;
+			}
+
+			/**
+			 * Sets the structured content for the tool result.
+			 * @param structuredContent the structured content
+			 * @return this builder
+			 */
+			public Builder structuredContent(Map<String, Object> structuredContent) {
+				Assert.notNull(structuredContent, "structuredContent must not be null");
+				this.structuredContent = structuredContent;
 				return this;
 			}
 
@@ -877,7 +918,7 @@ public final class McpSchema {
 			 * @return a new CallToolResult instance
 			 */
 			public CallToolResult build() {
-				return new CallToolResult(content, isError);
+				return new CallToolResult(content, isError, structuredContent);
 			}
 		}
 

--- a/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
@@ -4,7 +4,15 @@
 
 package io.modelcontextprotocol.server;
 
+import java.util.HashMap;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -17,13 +25,6 @@ import io.modelcontextprotocol.spec.McpSchema.Resource;
 import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Test suite for the {@link McpSyncServer} that can be used with different
@@ -124,7 +125,7 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testAddDuplicateTool() {
-		Tool duplicateTool = new McpSchema.Tool(TEST_TOOL_NAME, "Duplicate tool", emptyJsonSchema);
+		Tool duplicateTool = new McpSchema.Tool(TEST_TOOL_NAME, "Duplicate tool", emptyJsonSchema, emptyJsonSchema);
 
 		var mcpSyncServer = McpServer.sync(createMcpTransportProvider())
 			.serverInfo("test-server", "1.0.0")
@@ -133,7 +134,7 @@ public abstract class AbstractMcpSyncServerTests {
 			.build();
 
 		assertThatThrownBy(() -> mcpSyncServer.addTool(new McpServerFeatures.SyncToolSpecification(duplicateTool,
-				(exchange, args) -> new CallToolResult(List.of(), false))))
+				(exchange, args) -> new CallToolResult(List.of(), false, new HashMap<String, Object>()))))
 			.isInstanceOf(McpError.class)
 			.hasMessage("Tool with name '" + TEST_TOOL_NAME + "' already exists");
 

--- a/mcp/src/test/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProviderIntegrationTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProviderIntegrationTests.java
@@ -12,6 +12,19 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.LifecycleState;
+import org.apache.catalina.startup.Tomcat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.awaitility.Awaitility.await;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.mock;
+import org.springframework.web.client.RestClient;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.modelcontextprotocol.client.McpClient;
@@ -30,22 +43,8 @@ import io.modelcontextprotocol.spec.McpSchema.Role;
 import io.modelcontextprotocol.spec.McpSchema.Root;
 import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
-import org.apache.catalina.LifecycleException;
-import org.apache.catalina.LifecycleState;
-import org.apache.catalina.startup.Tomcat;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
-
-import org.springframework.web.client.RestClient;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.awaitility.Awaitility.await;
-import static org.mockito.Mockito.mock;
 
 class HttpServletSseServerTransportProviderIntegrationTests {
 
@@ -611,6 +610,115 @@ class HttpServletSseServerTransportProviderIntegrationTests {
 			});
 		}
 
+		mcpServer.close();
+	}
+
+	@Test
+	void testToolCallStructuredOutputSuccess() {
+		String outputSchema = """
+				{
+					"$schema": "http://json-schema.org/draft-07/schema#",
+					"type": "object",
+					"properties": {
+						"message": {
+							"type": "string"
+						},
+						"count": {
+							"type": "integer"
+						}
+					}
+				}
+				""";
+
+		CallToolResult callResponse = new McpSchema.CallToolResult(null, null, Map.of("message", "mks", "count", 1));
+
+		McpServerFeatures.AsyncToolSpecification toolWithOutputSchema = new McpServerFeatures.AsyncToolSpecification(
+				new McpSchema.Tool("toolWithOutputSchema", "tool1 description", emptyJsonSchema, outputSchema),
+				(exchange, request) -> {
+					return Mono.just(callResponse);
+				});
+
+		var mcpServer = McpServer.async(mcpServerTransportProvider)
+			.serverInfo("test-server", "1.0.0")
+			.tools(toolWithOutputSchema)
+			.build();
+
+		try (var mcpClient = clientBuilder.build()) {
+
+			InitializeResult initResult = mcpClient.initialize();
+			assertThat(initResult).isNotNull();
+
+			assertThat(mcpClient.listTools().tools()).contains(toolWithOutputSchema.tool());
+
+			CallToolResult response = mcpClient
+				.callTool(new McpSchema.CallToolRequest("toolWithOutputSchema", Map.of()));
+
+			assertThat(response).isNotNull();
+			assertThat(response).isEqualTo(callResponse);
+		}
+		mcpServer.close();
+	}
+
+	@Test
+	void testToolCallStructuredOutputValidationFailure() {
+		String outputSchema = """
+				{
+					"$schema": "http://json-schema.org/draft-07/schema#",
+					"type": "object",
+					"properties": {
+						"message": {
+							"type": "string"
+						},
+						"cnt": {
+							"type": "integer"
+						}
+					}
+				}
+				""";
+
+		CallToolResult callResponseWithStructuredContent = new McpSchema.CallToolResult(null, null,
+				Map.of("message", "hello", "count", 1));
+		CallToolResult callResponseWithoutStructuredContent = new McpSchema.CallToolResult(
+				"{\"message\":\"hello\",\"count\":1}", null);
+
+		McpServerFeatures.AsyncToolSpecification toolWithOutputSchema1 = new McpServerFeatures.AsyncToolSpecification(
+				new McpSchema.Tool("toolWithOutputSchema1", "toolWithOutputSchema1 description", emptyJsonSchema,
+						outputSchema),
+				(exchange, request) -> {
+					return Mono.just(callResponseWithStructuredContent);
+				});
+		McpServerFeatures.AsyncToolSpecification toolWithOutputSchema2 = new McpServerFeatures.AsyncToolSpecification(
+				new McpSchema.Tool("toolWithOutputSchema2", "toolWithOutputSchema2 description", emptyJsonSchema,
+						outputSchema),
+				(exchange, request) -> {
+					return Mono.just(callResponseWithoutStructuredContent);
+				});
+
+		var mcpServer = McpServer.async(mcpServerTransportProvider)
+			.serverInfo("test-server", "1.0.0")
+			.tools(toolWithOutputSchema1, toolWithOutputSchema2)
+			.build();
+
+		try (var mcpClient = clientBuilder.build()) {
+
+			InitializeResult initResult = mcpClient.initialize();
+			assertThat(initResult).isNotNull();
+
+			assertThat(mcpClient.listTools().tools()).contains(toolWithOutputSchema1.tool());
+
+			assertThatExceptionOfType(McpError.class).isThrownBy(() -> {
+				mcpClient.callTool(new McpSchema.CallToolRequest("toolWithOutputSchema1", Map.of()));
+			})
+				.withMessageContaining(
+						"CallToolResult validation failed: structuredContent does not match tool outputSchema.");
+
+			assertThatExceptionOfType(McpError.class).isThrownBy(() -> {
+				mcpClient.callTool(new McpSchema.CallToolRequest("toolWithOutputSchema2", Map.of()));
+			})
+				.withMessageContaining(
+						"CallToolResult validation failed: structuredContent is null and does not match tool outputSchema.");
+
+		}
 		mcpServer.close();
 	}
 


### PR DESCRIPTION
## Motivation and Context
This PR adds support for Tool.outputSchema and CallToolResult.structuredContent that was introduced in the specification in https://github.com/modelcontextprotocol/modelcontextprotocol/commit/03dc24b3fed8534bbec9b41ee5ca2c9371852d0e. The changes and scope of work were discussed in issue: #285

Changes in this PR:
- Implement support for outputSchema in Tool and structuredContent in CallToolResult.
- Add a client-side cache that maintains track of all server tools and their output schemas (if any).
- Implement a mechanism to refresh the client side cache when encountering a tool call request for an uncached tool.
- Implement json validation between tool's output schema and result's structured content, when an output schema is specified for the tool.

## How Has This Been Tested?
- Added unit test
- Added integration tests to test success and failure of client-side json validation

## Breaking Changes
A new field for structuredContent was added to CallToolResult as part of the changes. CallToolResult fields were modified from (List\<Content\> content, Boolean isError) -> (List\<Content\>  content, Boolean isError, Map<String, Object> structuredContent).

In order to maintain backward compatibility with earlier initializations of CallToolResult that relied on just specifying (List\<Content\> , Boolean), a new constructor was created that would accept (List\<Content\> , Boolean). This ensured that no further changes were required to the unit tests across java-sdk. There is already a preexisting constructor for CallToolResult that accepts (String, Boolean). 

The addition of the new constructor can lead to constructor ambiguity in case a CallToolResult was created with content set to null (since null can be either String or List<Content>). Example, CallToolResult(null, true). Such initializations would now require explicit typecasting to ensure that they are compiled successfully. This can be treated as a breaking change. I am open to suggestions on a better way to tackle this.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
