### PR TITLE
feat: Add client side handlers to handle pagination + fix: Support pagination in tools change notification handler

### DIFF
--- a/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
@@ -163,6 +163,23 @@ public abstract class AbstractMcpAsyncClientTests {
 	}
 
 	@Test
+	void testListAllTools() {
+		withClient(createMcpTransport(), mcpAsyncClient -> {
+			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listAllTools()))
+				.consumeNextWith(tools -> {
+					assertThat(tools).isNotNull().satisfies(result -> {
+						assertThat(result).isNotEmpty();
+
+						Tool firstTool = result.get(0);
+						assertThat(firstTool.name()).isNotNull();
+						assertThat(firstTool.description()).isNotNull();
+					});
+				})
+				.verifyComplete();
+		});
+	}
+
+	@Test
 	void testPingWithoutInitialization() {
 		verifyCallSucceedsWithImplicitInitialization(client -> client.ping(), "pinging the server");
 	}
@@ -294,6 +311,23 @@ public abstract class AbstractMcpAsyncClientTests {
 	}
 
 	@Test
+	void testListAllResources() {
+		withClient(createMcpTransport(), mcpAsyncClient -> {
+			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listAllResources()))
+				.consumeNextWith(resources -> {
+					assertThat(resources).isNotNull().satisfies(result -> {
+						assertThat(result).isNotEmpty();
+
+						Resource firstResource = result.get(0);
+						assertThat(firstResource.uri()).isNotNull();
+						assertThat(firstResource.name()).isNotNull();
+					});
+				})
+				.verifyComplete();
+		});
+	}
+
+	@Test
 	void testMcpAsyncClientState() {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
 			assertThat(mcpAsyncClient).isNotNull();
@@ -318,6 +352,23 @@ public abstract class AbstractMcpAsyncClientTests {
 							assertThat(firstPrompt.name()).isNotNull();
 							assertThat(firstPrompt.description()).isNotNull();
 						}
+					});
+				})
+				.verifyComplete();
+		});
+	}
+
+	@Test
+	void testListAllPrompts() {
+		withClient(createMcpTransport(), mcpAsyncClient -> {
+			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listAllPrompts()))
+				.consumeNextWith(prompts -> {
+					assertThat(prompts).isNotNull().satisfies(result -> {
+						assertThat(result).isNotEmpty();
+
+						Prompt firstPrompt = result.get(0);
+						assertThat(firstPrompt.name()).isNotNull();
+						assertThat(firstPrompt.description()).isNotNull();
 					});
 				})
 				.verifyComplete();
@@ -434,6 +485,23 @@ public abstract class AbstractMcpAsyncClientTests {
 				.consumeNextWith(result -> {
 					assertThat(result).isNotNull();
 					assertThat(result.resourceTemplates()).isNotNull();
+				})
+				.verifyComplete();
+		});
+	}
+
+	@Test
+	void testListAllResourceTemplates() {
+		withClient(createMcpTransport(), mcpAsyncClient -> {
+			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listAllResourceTemplates()))
+				.consumeNextWith(resourceTemplates -> {
+					assertThat(resourceTemplates).isNotNull().satisfies(result -> {
+						assertThat(result).isNotEmpty();
+
+						McpSchema.ResourceTemplate firstResourceTemplate = result.get(0);
+						assertThat(firstResourceTemplate.name()).isNotNull();
+						assertThat(firstResourceTemplate.description()).isNotNull();
+					});
 				})
 				.verifyComplete();
 		});

--- a/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
@@ -149,13 +149,13 @@ public abstract class AbstractMcpAsyncClientTests {
 
 	@Test
 	void testListToolsWithoutInitialization() {
-		verifyCallSucceedsWithImplicitInitialization(client -> client.listTools(null), "listing tools");
+		verifyCallSucceedsWithImplicitInitialization(client -> client.listTools(McpSchema.FIRST_PAGE), "listing tools");
 	}
 
 	@Test
 	void testListTools() {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
-			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listTools(null)))
+			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listTools(McpSchema.FIRST_PAGE)))
 				.consumeNextWith(result -> {
 					assertThat(result.tools()).isNotNull().isNotEmpty();
 
@@ -170,15 +170,13 @@ public abstract class AbstractMcpAsyncClientTests {
 	@Test
 	void testListAllTools() {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
-			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listAllTools()))
-				.consumeNextWith(tools -> {
-					assertThat(tools).isNotNull().satisfies(result -> {
-						assertThat(result).isNotEmpty();
+			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listTools()))
+				.consumeNextWith(result -> {
+					assertThat(result.tools()).isNotNull().isNotEmpty();
 
-						Tool firstTool = result.get(0);
-						assertThat(firstTool.name()).isNotNull();
-						assertThat(firstTool.description()).isNotNull();
-					});
+					Tool firstTool = result.tools().get(0);
+					assertThat(firstTool.name()).isNotNull();
+					assertThat(firstTool.description()).isNotNull();
 				})
 				.verifyComplete();
 		});
@@ -293,13 +291,14 @@ public abstract class AbstractMcpAsyncClientTests {
 
 	@Test
 	void testListResourcesWithoutInitialization() {
-		verifyCallSucceedsWithImplicitInitialization(client -> client.listResources(null), "listing resources");
+		verifyCallSucceedsWithImplicitInitialization(client -> client.listResources(McpSchema.FIRST_PAGE),
+				"listing resources");
 	}
 
 	@Test
 	void testListResources() {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
-			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listResources(null)))
+			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listResources(McpSchema.FIRST_PAGE)))
 				.consumeNextWith(resources -> {
 					assertThat(resources).isNotNull().satisfies(result -> {
 						assertThat(result.resources()).isNotNull();
@@ -318,14 +317,16 @@ public abstract class AbstractMcpAsyncClientTests {
 	@Test
 	void testListAllResources() {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
-			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listAllResources()))
+			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listResources()))
 				.consumeNextWith(resources -> {
 					assertThat(resources).isNotNull().satisfies(result -> {
-						assertThat(result).isNotEmpty();
+						assertThat(result.resources()).isNotNull();
 
-						Resource firstResource = result.get(0);
-						assertThat(firstResource.uri()).isNotNull();
-						assertThat(firstResource.name()).isNotNull();
+						if (!result.resources().isEmpty()) {
+							Resource firstResource = result.resources().get(0);
+							assertThat(firstResource.uri()).isNotNull();
+							assertThat(firstResource.name()).isNotNull();
+						}
 					});
 				})
 				.verifyComplete();
@@ -341,13 +342,14 @@ public abstract class AbstractMcpAsyncClientTests {
 
 	@Test
 	void testListPromptsWithoutInitialization() {
-		verifyCallSucceedsWithImplicitInitialization(client -> client.listPrompts(null), "listing " + "prompts");
+		verifyCallSucceedsWithImplicitInitialization(client -> client.listPrompts(McpSchema.FIRST_PAGE),
+				"listing " + "prompts");
 	}
 
 	@Test
 	void testListPrompts() {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
-			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listPrompts(null)))
+			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listPrompts(McpSchema.FIRST_PAGE)))
 				.consumeNextWith(prompts -> {
 					assertThat(prompts).isNotNull().satisfies(result -> {
 						assertThat(result.prompts()).isNotNull();
@@ -366,14 +368,16 @@ public abstract class AbstractMcpAsyncClientTests {
 	@Test
 	void testListAllPrompts() {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
-			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listAllPrompts()))
+			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listPrompts()))
 				.consumeNextWith(prompts -> {
 					assertThat(prompts).isNotNull().satisfies(result -> {
-						assertThat(result).isNotEmpty();
+						assertThat(result.prompts()).isNotNull();
 
-						Prompt firstPrompt = result.get(0);
-						assertThat(firstPrompt.name()).isNotNull();
-						assertThat(firstPrompt.description()).isNotNull();
+						if (!result.prompts().isEmpty()) {
+							Prompt firstPrompt = result.prompts().get(0);
+							assertThat(firstPrompt.name()).isNotNull();
+							assertThat(firstPrompt.description()).isNotNull();
+						}
 					});
 				})
 				.verifyComplete();
@@ -520,14 +524,15 @@ public abstract class AbstractMcpAsyncClientTests {
 
 	@Test
 	void testListResourceTemplatesWithoutInitialization() {
-		verifyCallSucceedsWithImplicitInitialization(client -> client.listResourceTemplates(),
+		verifyCallSucceedsWithImplicitInitialization(client -> client.listResourceTemplates(McpSchema.FIRST_PAGE),
 				"listing resource templates");
 	}
 
 	@Test
 	void testListResourceTemplates() {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
-			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listResourceTemplates()))
+			StepVerifier
+				.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listResourceTemplates(McpSchema.FIRST_PAGE)))
 				.consumeNextWith(result -> {
 					assertThat(result).isNotNull();
 					assertThat(result.resourceTemplates()).isNotNull();
@@ -539,15 +544,10 @@ public abstract class AbstractMcpAsyncClientTests {
 	@Test
 	void testListAllResourceTemplates() {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
-			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listAllResourceTemplates()))
-				.consumeNextWith(resourceTemplates -> {
-					assertThat(resourceTemplates).isNotNull().satisfies(result -> {
-						assertThat(result).isNotEmpty();
-
-						McpSchema.ResourceTemplate firstResourceTemplate = result.get(0);
-						assertThat(firstResourceTemplate.name()).isNotNull();
-						assertThat(firstResourceTemplate.description()).isNotNull();
-					});
+			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listResourceTemplates()))
+				.consumeNextWith(result -> {
+					assertThat(result).isNotNull();
+					assertThat(result.resourceTemplates()).isNotNull();
 				})
 				.verifyComplete();
 		});

--- a/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
@@ -162,6 +162,22 @@ public abstract class AbstractMcpSyncClientTests {
 	}
 
 	@Test
+	void testListAllTools() {
+		withClient(createMcpTransport(), mcpSyncClient -> {
+			mcpSyncClient.initialize();
+			List<Tool> tools = mcpSyncClient.listAllTools();
+
+			assertThat(tools).isNotNull().satisfies(result -> {
+				assertThat(result).isNotEmpty();
+
+				Tool firstTool = result.get(0);
+				assertThat(firstTool.name()).isNotNull();
+				assertThat(firstTool.description()).isNotNull();
+			});
+		});
+	}
+
+	@Test
 	void testCallToolsWithoutInitialization() {
 		verifyCallSucceedsWithImplicitInitialization(
 				client -> client.callTool(new CallToolRequest("add", Map.of("a", 3, "b", 4))), "calling tools");
@@ -321,6 +337,22 @@ public abstract class AbstractMcpSyncClientTests {
 	}
 
 	@Test
+	void testListAllResources() {
+		withClient(createMcpTransport(), mcpSyncClient -> {
+			mcpSyncClient.initialize();
+			List<Resource> resources = mcpSyncClient.listAllResources();
+
+			assertThat(resources).isNotNull().satisfies(result -> {
+				assertThat(result).isNotEmpty();
+
+				Resource firstResource = result.get(0);
+				assertThat(firstResource.uri()).isNotNull();
+				assertThat(firstResource.name()).isNotNull();
+			});
+		});
+	}
+
+	@Test
 	void testClientSessionState() {
 		withClient(createMcpTransport(), mcpSyncClient -> {
 			assertThat(mcpSyncClient).isNotNull();
@@ -415,6 +447,22 @@ public abstract class AbstractMcpSyncClientTests {
 
 			assertThat(result).isNotNull();
 			assertThat(result.resourceTemplates()).isNotNull();
+		});
+	}
+
+	@Test
+	void testListAllResourceTemplates() {
+		withClient(createMcpTransport(), mcpSyncClient -> {
+			mcpSyncClient.initialize();
+			List<McpSchema.ResourceTemplate> resourceTemplates = mcpSyncClient.listAllResourceTemplates();
+
+			assertThat(resourceTemplates).isNotNull().satisfies(result -> {
+				assertThat(result).isNotEmpty();
+
+				McpSchema.ResourceTemplate firstResourceTemplate = result.get(0);
+				assertThat(firstResourceTemplate.name()).isNotNull();
+				assertThat(firstResourceTemplate.description()).isNotNull();
+			});
 		});
 	}
 

--- a/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
@@ -151,14 +151,14 @@ public abstract class AbstractMcpSyncClientTests {
 
 	@Test
 	void testListToolsWithoutInitialization() {
-		verifyCallSucceedsWithImplicitInitialization(client -> client.listTools(null), "listing tools");
+		verifyCallSucceedsWithImplicitInitialization(client -> client.listTools(McpSchema.FIRST_PAGE), "listing tools");
 	}
 
 	@Test
 	void testListTools() {
 		withClient(createMcpTransport(), mcpSyncClient -> {
 			mcpSyncClient.initialize();
-			ListToolsResult tools = mcpSyncClient.listTools(null);
+			ListToolsResult tools = mcpSyncClient.listTools(McpSchema.FIRST_PAGE);
 
 			assertThat(tools).isNotNull().satisfies(result -> {
 				assertThat(result.tools()).isNotNull().isNotEmpty();
@@ -174,12 +174,12 @@ public abstract class AbstractMcpSyncClientTests {
 	void testListAllTools() {
 		withClient(createMcpTransport(), mcpSyncClient -> {
 			mcpSyncClient.initialize();
-			List<Tool> tools = mcpSyncClient.listAllTools();
+			ListToolsResult tools = mcpSyncClient.listTools();
 
 			assertThat(tools).isNotNull().satisfies(result -> {
-				assertThat(result).isNotEmpty();
+				assertThat(result.tools()).isNotNull().isNotEmpty();
 
-				Tool firstTool = result.get(0);
+				Tool firstTool = result.tools().get(0);
 				assertThat(firstTool.name()).isNotNull();
 				assertThat(firstTool.description()).isNotNull();
 			});
@@ -324,14 +324,15 @@ public abstract class AbstractMcpSyncClientTests {
 
 	@Test
 	void testListResourcesWithoutInitialization() {
-		verifyCallSucceedsWithImplicitInitialization(client -> client.listResources(null), "listing resources");
+		verifyCallSucceedsWithImplicitInitialization(client -> client.listResources(McpSchema.FIRST_PAGE),
+				"listing resources");
 	}
 
 	@Test
 	void testListResources() {
 		withClient(createMcpTransport(), mcpSyncClient -> {
 			mcpSyncClient.initialize();
-			ListResourcesResult resources = mcpSyncClient.listResources(null);
+			ListResourcesResult resources = mcpSyncClient.listResources(McpSchema.FIRST_PAGE);
 
 			assertThat(resources).isNotNull().satisfies(result -> {
 				assertThat(result.resources()).isNotNull();
@@ -349,14 +350,16 @@ public abstract class AbstractMcpSyncClientTests {
 	void testListAllResources() {
 		withClient(createMcpTransport(), mcpSyncClient -> {
 			mcpSyncClient.initialize();
-			List<Resource> resources = mcpSyncClient.listAllResources();
+			ListResourcesResult resources = mcpSyncClient.listResources();
 
 			assertThat(resources).isNotNull().satisfies(result -> {
-				assertThat(result).isNotEmpty();
+				assertThat(result.resources()).isNotNull();
 
-				Resource firstResource = result.get(0);
-				assertThat(firstResource.uri()).isNotNull();
-				assertThat(firstResource.name()).isNotNull();
+				if (!result.resources().isEmpty()) {
+					Resource firstResource = result.resources().get(0);
+					assertThat(firstResource.uri()).isNotNull();
+					assertThat(firstResource.name()).isNotNull();
+				}
 			});
 		});
 	}
@@ -498,7 +501,7 @@ public abstract class AbstractMcpSyncClientTests {
 
 	@Test
 	void testListResourceTemplatesWithoutInitialization() {
-		verifyCallSucceedsWithImplicitInitialization(client -> client.listResourceTemplates(null),
+		verifyCallSucceedsWithImplicitInitialization(client -> client.listResourceTemplates(McpSchema.FIRST_PAGE),
 				"listing resource templates");
 	}
 
@@ -506,7 +509,7 @@ public abstract class AbstractMcpSyncClientTests {
 	void testListResourceTemplates() {
 		withClient(createMcpTransport(), mcpSyncClient -> {
 			mcpSyncClient.initialize();
-			ListResourceTemplatesResult result = mcpSyncClient.listResourceTemplates(null);
+			ListResourceTemplatesResult result = mcpSyncClient.listResourceTemplates(McpSchema.FIRST_PAGE);
 
 			assertThat(result).isNotNull();
 			assertThat(result.resourceTemplates()).isNotNull();
@@ -517,15 +520,10 @@ public abstract class AbstractMcpSyncClientTests {
 	void testListAllResourceTemplates() {
 		withClient(createMcpTransport(), mcpSyncClient -> {
 			mcpSyncClient.initialize();
-			List<McpSchema.ResourceTemplate> resourceTemplates = mcpSyncClient.listAllResourceTemplates();
+			ListResourceTemplatesResult result = mcpSyncClient.listResourceTemplates();
 
-			assertThat(resourceTemplates).isNotNull().satisfies(result -> {
-				assertThat(result).isNotEmpty();
-
-				McpSchema.ResourceTemplate firstResourceTemplate = result.get(0);
-				assertThat(firstResourceTemplate.name()).isNotNull();
-				assertThat(firstResourceTemplate.description()).isNotNull();
-			});
+			assertThat(result).isNotNull();
+			assertThat(result.resourceTemplates()).isNotNull();
 		});
 	}
 

--- a/mcp/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
@@ -658,8 +658,8 @@ public class McpAsyncClient {
 	}
 
 	/**
-	 * Retrieves list of all tools provided by the server after handling pagination.
-	 * @return A Mono that emits a list of all tools result
+	 * Retrieves the list of all tools provided by the server.
+	 * @return A Mono that emits the list of all tools result
 	 */
 	public Mono<McpSchema.ListToolsResult> listTools() {
 		return this.listTools(McpSchema.FIRST_PAGE).expand(result -> {
@@ -719,7 +719,7 @@ public class McpAsyncClient {
 	 * Retrieves the list of all resources provided by the server. Resources represent any
 	 * kind of UTF-8 encoded data that an MCP server makes available to clients, such as
 	 * database records, API responses, log files, and more.
-	 * @return A Mono that completes with list of all resources result
+	 * @return A Mono that completes with the list of all resources result
 	 * @see McpSchema.ListResourcesResult
 	 * @see #readResource(McpSchema.Resource)
 	 */

--- a/mcp/src/main/java/io/modelcontextprotocol/client/McpSyncClient.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/McpSyncClient.java
@@ -221,9 +221,9 @@ public class McpSyncClient implements AutoCloseable {
 	}
 
 	/**
-	 * Retrieves the first page of tools provided by the server.
-	 * @return The list of tools result containing: - tools: List of available tools, each
-	 * with a name, description, and input schema - nextCursor: Optional cursor for
+	 * Retrieves the list of all tools provided by the server.
+	 * @return The list of all tools result containing: - tools: List of available tools,
+	 * each with a name, description, and input schema - nextCursor: Optional cursor for
 	 * pagination if more tools are available
 	 */
 	public McpSchema.ListToolsResult listTools() {
@@ -241,21 +241,13 @@ public class McpSyncClient implements AutoCloseable {
 		return this.delegate.listTools(cursor).block();
 	}
 
-	/**
-	 * Retrieves the list of all tools provided by the server.
-	 * @return The list of all tools
-	 */
-	public List<McpSchema.Tool> listAllTools() {
-		return this.delegate.listAllTools().block();
-	}
-
 	// --------------------------
 	// Resources
 	// --------------------------
 
 	/**
-	 * Retrieves the first page of resources provided by the server.
-	 * @return The list of resources result
+	 * Retrieves the list of all resources provided by the server.
+	 * @return The list of all resources result
 	 */
 	public McpSchema.ListResourcesResult listResources() {
 		return this.delegate.listResources().block();
@@ -268,14 +260,6 @@ public class McpSyncClient implements AutoCloseable {
 	 */
 	public McpSchema.ListResourcesResult listResources(String cursor) {
 		return this.delegate.listResources(cursor).block();
-	}
-
-	/**
-	 * Retrieves the list of all resources provided by the server.
-	 * @return The list of all resources
-	 */
-	public List<McpSchema.Resource> listAllResources() {
-		return this.delegate.listAllResources().block();
 	}
 
 	/**
@@ -297,8 +281,8 @@ public class McpSyncClient implements AutoCloseable {
 	}
 
 	/**
-	 * Retrieves the first page of resource templates provided by the server.
-	 * @return The list of resource templates result.
+	 * Retrieves the list of all resource templates provided by the server.
+	 * @return The list of all resource templates result.
 	 */
 	public McpSchema.ListResourceTemplatesResult listResourceTemplates() {
 		return this.delegate.listResourceTemplates().block();
@@ -314,14 +298,6 @@ public class McpSyncClient implements AutoCloseable {
 	 */
 	public McpSchema.ListResourceTemplatesResult listResourceTemplates(String cursor) {
 		return this.delegate.listResourceTemplates(cursor).block();
-	}
-
-	/**
-	 * Retrieves the list of all resources provided by the server.
-	 * @return The list of all resource templates
-	 */
-	public List<McpSchema.ResourceTemplate> listAllResourceTemplates() {
-		return this.delegate.listAllResourceTemplates().block();
 	}
 
 	/**
@@ -351,8 +327,8 @@ public class McpSyncClient implements AutoCloseable {
 	// --------------------------
 
 	/**
-	 * Retrieves the first page of prompts provided by the server.
-	 * @return The list of prompts result.
+	 * Retrieves the list of all prompts provided by the server.
+	 * @return The list of all prompts result.
 	 */
 	public ListPromptsResult listPrompts() {
 		return this.delegate.listPrompts().block();
@@ -365,14 +341,6 @@ public class McpSyncClient implements AutoCloseable {
 	 */
 	public ListPromptsResult listPrompts(String cursor) {
 		return this.delegate.listPrompts(cursor).block();
-	}
-
-	/**
-	 * Retrieves the list of all prompts provided by the server.
-	 * @return The list of all prompts
-	 */
-	public List<McpSchema.Prompt> listAllPrompts() {
-		return this.delegate.listAllPrompts().block();
 	}
 
 	public GetPromptResult getPrompt(GetPromptRequest getPromptRequest) {

--- a/mcp/src/main/java/io/modelcontextprotocol/client/McpSyncClient.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/McpSyncClient.java
@@ -5,6 +5,10 @@
 package io.modelcontextprotocol.client;
 
 import java.time.Duration;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.ClientCapabilities;
@@ -12,8 +16,6 @@ import io.modelcontextprotocol.spec.McpSchema.GetPromptRequest;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptResult;
 import io.modelcontextprotocol.spec.McpSchema.ListPromptsResult;
 import io.modelcontextprotocol.util.Assert;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A synchronous client implementation for the Model Context Protocol (MCP) that wraps an
@@ -219,7 +221,7 @@ public class McpSyncClient implements AutoCloseable {
 	}
 
 	/**
-	 * Retrieves the list of all tools provided by the server.
+	 * Retrieves the first page of tools provided by the server.
 	 * @return The list of tools result containing: - tools: List of available tools, each
 	 * with a name, description, and input schema - nextCursor: Optional cursor for
 	 * pagination if more tools are available
@@ -239,25 +241,41 @@ public class McpSyncClient implements AutoCloseable {
 		return this.delegate.listTools(cursor).block();
 	}
 
+	/**
+	 * Retrieves the list of all tools provided by the server.
+	 * @return The list of all tools
+	 */
+	public List<McpSchema.Tool> listAllTools() {
+		return this.delegate.listAllTools().block();
+	}
+
 	// --------------------------
 	// Resources
 	// --------------------------
 
 	/**
-	 * Send a resources/list request.
-	 * @param cursor the cursor
-	 * @return the list of resources result.
+	 * Retrieves the first page of resources provided by the server.
+	 * @return The list of resources result
+	 */
+	public McpSchema.ListResourcesResult listResources() {
+		return this.delegate.listResources().block();
+	}
+
+	/**
+	 * Retrieves a paginated list of resources provided by the server.
+	 * @param cursor Optional pagination cursor from a previous list request
+	 * @return The list of resources result
 	 */
 	public McpSchema.ListResourcesResult listResources(String cursor) {
 		return this.delegate.listResources(cursor).block();
 	}
 
 	/**
-	 * Send a resources/list request.
-	 * @return the list of resources result.
+	 * Retrieves the list of all resources provided by the server.
+	 * @return The list of all resources
 	 */
-	public McpSchema.ListResourcesResult listResources() {
-		return this.delegate.listResources().block();
+	public List<McpSchema.Resource> listAllResources() {
+		return this.delegate.listAllResources().block();
 	}
 
 	/**
@@ -279,23 +297,31 @@ public class McpSyncClient implements AutoCloseable {
 	}
 
 	/**
+	 * Retrieves the first page of resource templates provided by the server.
+	 * @return The list of resource templates result.
+	 */
+	public McpSchema.ListResourceTemplatesResult listResourceTemplates() {
+		return this.delegate.listResourceTemplates().block();
+	}
+
+	/**
 	 * Resource templates allow servers to expose parameterized resources using URI
 	 * templates. Arguments may be auto-completed through the completion API.
 	 *
-	 * Request a list of resource templates the server has.
-	 * @param cursor the cursor
-	 * @return the list of resource templates result.
+	 * Retrieves a paginated list of resource templates provided by the server.
+	 * @param cursor Optional pagination cursor from a previous list request
+	 * @return The list of resource templates result.
 	 */
 	public McpSchema.ListResourceTemplatesResult listResourceTemplates(String cursor) {
 		return this.delegate.listResourceTemplates(cursor).block();
 	}
 
 	/**
-	 * Request a list of resource templates the server has.
-	 * @return the list of resource templates result.
+	 * Retrieves the list of all resources provided by the server.
+	 * @return The list of all resource templates
 	 */
-	public McpSchema.ListResourceTemplatesResult listResourceTemplates() {
-		return this.delegate.listResourceTemplates().block();
+	public List<McpSchema.ResourceTemplate> listAllResourceTemplates() {
+		return this.delegate.listAllResourceTemplates().block();
 	}
 
 	/**
@@ -323,12 +349,30 @@ public class McpSyncClient implements AutoCloseable {
 	// --------------------------
 	// Prompts
 	// --------------------------
+
+	/**
+	 * Retrieves the first page of prompts provided by the server.
+	 * @return The list of prompts result.
+	 */
+	public ListPromptsResult listPrompts() {
+		return this.delegate.listPrompts().block();
+	}
+
+	/**
+	 * Retrieves a paginated list of prompts provided by the server.
+	 * @param cursor Optional pagination cursor from a previous list request
+	 * @return The list of prompts result.
+	 */
 	public ListPromptsResult listPrompts(String cursor) {
 		return this.delegate.listPrompts(cursor).block();
 	}
 
-	public ListPromptsResult listPrompts() {
-		return this.delegate.listPrompts().block();
+	/**
+	 * Retrieves the list of all prompts provided by the server.
+	 * @return The list of all prompts
+	 */
+	public List<McpSchema.Prompt> listAllPrompts() {
+		return this.delegate.listAllPrompts().block();
 	}
 
 	public GetPromptResult getPrompt(GetPromptRequest getPromptRequest) {

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -41,6 +41,8 @@ public final class McpSchema {
 
 	public static final String JSONRPC_VERSION = "2.0";
 
+	public static final String FIRST_PAGE = null;
+
 	// ---------------------------
 	// Method Names
 	// ---------------------------

--- a/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
@@ -20,12 +20,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -156,13 +150,13 @@ public abstract class AbstractMcpAsyncClientTests {
 
 	@Test
 	void testListToolsWithoutInitialization() {
-		verifyCallSucceedsWithImplicitInitialization(client -> client.listTools(null), "listing tools");
+		verifyCallSucceedsWithImplicitInitialization(client -> client.listTools(McpSchema.FIRST_PAGE), "listing tools");
 	}
 
 	@Test
 	void testListTools() {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
-			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listTools(null)))
+			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listTools(McpSchema.FIRST_PAGE)))
 				.consumeNextWith(result -> {
 					assertThat(result.tools()).isNotNull().isNotEmpty();
 
@@ -177,15 +171,13 @@ public abstract class AbstractMcpAsyncClientTests {
 	@Test
 	void testListAllTools() {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
-			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listAllTools()))
-				.consumeNextWith(tools -> {
-					assertThat(tools).isNotNull().satisfies(result -> {
-						assertThat(result).isNotEmpty();
+			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listTools()))
+				.consumeNextWith(result -> {
+					assertThat(result.tools()).isNotNull().isNotEmpty();
 
-						Tool firstTool = result.get(0);
-						assertThat(firstTool.name()).isNotNull();
-						assertThat(firstTool.description()).isNotNull();
-					});
+					Tool firstTool = result.tools().get(0);
+					assertThat(firstTool.name()).isNotNull();
+					assertThat(firstTool.description()).isNotNull();
 				})
 				.verifyComplete();
 		});
@@ -300,13 +292,14 @@ public abstract class AbstractMcpAsyncClientTests {
 
 	@Test
 	void testListResourcesWithoutInitialization() {
-		verifyCallSucceedsWithImplicitInitialization(client -> client.listResources(null), "listing resources");
+		verifyCallSucceedsWithImplicitInitialization(client -> client.listResources(McpSchema.FIRST_PAGE),
+				"listing resources");
 	}
 
 	@Test
 	void testListResources() {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
-			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listResources(null)))
+			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listResources(McpSchema.FIRST_PAGE)))
 				.consumeNextWith(resources -> {
 					assertThat(resources).isNotNull().satisfies(result -> {
 						assertThat(result.resources()).isNotNull();
@@ -325,14 +318,16 @@ public abstract class AbstractMcpAsyncClientTests {
 	@Test
 	void testListAllResources() {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
-			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listAllResources()))
+			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listResources()))
 				.consumeNextWith(resources -> {
 					assertThat(resources).isNotNull().satisfies(result -> {
-						assertThat(result).isNotEmpty();
+						assertThat(result.resources()).isNotNull();
 
-						Resource firstResource = result.get(0);
-						assertThat(firstResource.uri()).isNotNull();
-						assertThat(firstResource.name()).isNotNull();
+						if (!result.resources().isEmpty()) {
+							Resource firstResource = result.resources().get(0);
+							assertThat(firstResource.uri()).isNotNull();
+							assertThat(firstResource.name()).isNotNull();
+						}
 					});
 				})
 				.verifyComplete();
@@ -348,13 +343,14 @@ public abstract class AbstractMcpAsyncClientTests {
 
 	@Test
 	void testListPromptsWithoutInitialization() {
-		verifyCallSucceedsWithImplicitInitialization(client -> client.listPrompts(null), "listing " + "prompts");
+		verifyCallSucceedsWithImplicitInitialization(client -> client.listPrompts(McpSchema.FIRST_PAGE),
+				"listing " + "prompts");
 	}
 
 	@Test
 	void testListPrompts() {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
-			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listPrompts(null)))
+			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listPrompts(McpSchema.FIRST_PAGE)))
 				.consumeNextWith(prompts -> {
 					assertThat(prompts).isNotNull().satisfies(result -> {
 						assertThat(result.prompts()).isNotNull();
@@ -373,14 +369,16 @@ public abstract class AbstractMcpAsyncClientTests {
 	@Test
 	void testListAllPrompts() {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
-			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listAllPrompts()))
+			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listPrompts()))
 				.consumeNextWith(prompts -> {
 					assertThat(prompts).isNotNull().satisfies(result -> {
-						assertThat(result).isNotEmpty();
+						assertThat(result.prompts()).isNotNull();
 
-						Prompt firstPrompt = result.get(0);
-						assertThat(firstPrompt.name()).isNotNull();
-						assertThat(firstPrompt.description()).isNotNull();
+						if (!result.prompts().isEmpty()) {
+							Prompt firstPrompt = result.prompts().get(0);
+							assertThat(firstPrompt.name()).isNotNull();
+							assertThat(firstPrompt.description()).isNotNull();
+						}
 					});
 				})
 				.verifyComplete();
@@ -527,14 +525,15 @@ public abstract class AbstractMcpAsyncClientTests {
 
 	@Test
 	void testListResourceTemplatesWithoutInitialization() {
-		verifyCallSucceedsWithImplicitInitialization(client -> client.listResourceTemplates(),
+		verifyCallSucceedsWithImplicitInitialization(client -> client.listResourceTemplates(McpSchema.FIRST_PAGE),
 				"listing resource templates");
 	}
 
 	@Test
 	void testListResourceTemplates() {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
-			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listResourceTemplates()))
+			StepVerifier
+				.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listResourceTemplates(McpSchema.FIRST_PAGE)))
 				.consumeNextWith(result -> {
 					assertThat(result).isNotNull();
 					assertThat(result.resourceTemplates()).isNotNull();
@@ -546,15 +545,10 @@ public abstract class AbstractMcpAsyncClientTests {
 	@Test
 	void testListAllResourceTemplates() {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
-			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listAllResourceTemplates()))
-				.consumeNextWith(resourceTemplates -> {
-					assertThat(resourceTemplates).isNotNull().satisfies(result -> {
-						assertThat(result).isNotEmpty();
-
-						McpSchema.ResourceTemplate firstResourceTemplate = result.get(0);
-						assertThat(firstResourceTemplate.name()).isNotNull();
-						assertThat(firstResourceTemplate.description()).isNotNull();
-					});
+			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listResourceTemplates()))
+				.consumeNextWith(result -> {
+					assertThat(result).isNotNull();
+					assertThat(result.resourceTemplates()).isNotNull();
 				})
 				.verifyComplete();
 		});
@@ -653,6 +647,7 @@ public abstract class AbstractMcpAsyncClientTests {
 	// ---------------------------------------
 	// Logging Tests
 	// ---------------------------------------
+
 	@Test
 	void testLoggingLevelsWithoutInitialization() {
 		verifyNotificationSucceedsWithImplicitInitialization(

--- a/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
@@ -13,6 +13,18 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -30,21 +42,9 @@ import io.modelcontextprotocol.spec.McpSchema.SubscribeRequest;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import io.modelcontextprotocol.spec.McpSchema.UnsubscribeRequest;
 import io.modelcontextprotocol.spec.McpTransport;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
  * Test suite for the {@link McpAsyncClient} that can be used with different
@@ -158,6 +158,23 @@ public abstract class AbstractMcpAsyncClientTests {
 					Tool firstTool = result.tools().get(0);
 					assertThat(firstTool.name()).isNotNull();
 					assertThat(firstTool.description()).isNotNull();
+				})
+				.verifyComplete();
+		});
+	}
+
+	@Test
+	void testListAllTools() {
+		withClient(createMcpTransport(), mcpAsyncClient -> {
+			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listAllTools()))
+				.consumeNextWith(tools -> {
+					assertThat(tools).isNotNull().satisfies(result -> {
+						assertThat(result).isNotEmpty();
+
+						Tool firstTool = result.get(0);
+						assertThat(firstTool.name()).isNotNull();
+						assertThat(firstTool.description()).isNotNull();
+					});
 				})
 				.verifyComplete();
 		});
@@ -295,6 +312,23 @@ public abstract class AbstractMcpAsyncClientTests {
 	}
 
 	@Test
+	void testListAllResources() {
+		withClient(createMcpTransport(), mcpAsyncClient -> {
+			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listAllResources()))
+				.consumeNextWith(resources -> {
+					assertThat(resources).isNotNull().satisfies(result -> {
+						assertThat(result).isNotEmpty();
+
+						Resource firstResource = result.get(0);
+						assertThat(firstResource.uri()).isNotNull();
+						assertThat(firstResource.name()).isNotNull();
+					});
+				})
+				.verifyComplete();
+		});
+	}
+
+	@Test
 	void testMcpAsyncClientState() {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
 			assertThat(mcpAsyncClient).isNotNull();
@@ -319,6 +353,23 @@ public abstract class AbstractMcpAsyncClientTests {
 							assertThat(firstPrompt.name()).isNotNull();
 							assertThat(firstPrompt.description()).isNotNull();
 						}
+					});
+				})
+				.verifyComplete();
+		});
+	}
+
+	@Test
+	void testListAllPrompts() {
+		withClient(createMcpTransport(), mcpAsyncClient -> {
+			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listAllPrompts()))
+				.consumeNextWith(prompts -> {
+					assertThat(prompts).isNotNull().satisfies(result -> {
+						assertThat(result).isNotEmpty();
+
+						Prompt firstPrompt = result.get(0);
+						assertThat(firstPrompt.name()).isNotNull();
+						assertThat(firstPrompt.description()).isNotNull();
 					});
 				})
 				.verifyComplete();
@@ -435,6 +486,23 @@ public abstract class AbstractMcpAsyncClientTests {
 				.consumeNextWith(result -> {
 					assertThat(result).isNotNull();
 					assertThat(result.resourceTemplates()).isNotNull();
+				})
+				.verifyComplete();
+		});
+	}
+
+	@Test
+	void testListAllResourceTemplates() {
+		withClient(createMcpTransport(), mcpAsyncClient -> {
+			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.listAllResourceTemplates()))
+				.consumeNextWith(resourceTemplates -> {
+					assertThat(resourceTemplates).isNotNull().satisfies(result -> {
+						assertThat(result).isNotEmpty();
+
+						McpSchema.ResourceTemplate firstResourceTemplate = result.get(0);
+						assertThat(firstResourceTemplate.name()).isNotNull();
+						assertThat(firstResourceTemplate.description()).isNotNull();
+					});
 				})
 				.verifyComplete();
 		});

--- a/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
@@ -152,14 +152,14 @@ public abstract class AbstractMcpSyncClientTests {
 
 	@Test
 	void testListToolsWithoutInitialization() {
-		verifyCallSucceedsWithImplicitInitialization(client -> client.listTools(null), "listing tools");
+		verifyCallSucceedsWithImplicitInitialization(client -> client.listTools(McpSchema.FIRST_PAGE), "listing tools");
 	}
 
 	@Test
 	void testListTools() {
 		withClient(createMcpTransport(), mcpSyncClient -> {
 			mcpSyncClient.initialize();
-			ListToolsResult tools = mcpSyncClient.listTools(null);
+			ListToolsResult tools = mcpSyncClient.listTools(McpSchema.FIRST_PAGE);
 
 			assertThat(tools).isNotNull().satisfies(result -> {
 				assertThat(result.tools()).isNotNull().isNotEmpty();
@@ -175,12 +175,12 @@ public abstract class AbstractMcpSyncClientTests {
 	void testListAllTools() {
 		withClient(createMcpTransport(), mcpSyncClient -> {
 			mcpSyncClient.initialize();
-			List<Tool> tools = mcpSyncClient.listAllTools();
+			ListToolsResult tools = mcpSyncClient.listTools();
 
 			assertThat(tools).isNotNull().satisfies(result -> {
-				assertThat(result).isNotEmpty();
+				assertThat(result.tools()).isNotNull().isNotEmpty();
 
-				Tool firstTool = result.get(0);
+				Tool firstTool = result.tools().get(0);
 				assertThat(firstTool.name()).isNotNull();
 				assertThat(firstTool.description()).isNotNull();
 			});
@@ -325,14 +325,15 @@ public abstract class AbstractMcpSyncClientTests {
 
 	@Test
 	void testListResourcesWithoutInitialization() {
-		verifyCallSucceedsWithImplicitInitialization(client -> client.listResources(null), "listing resources");
+		verifyCallSucceedsWithImplicitInitialization(client -> client.listResources(McpSchema.FIRST_PAGE),
+				"listing resources");
 	}
 
 	@Test
 	void testListResources() {
 		withClient(createMcpTransport(), mcpSyncClient -> {
 			mcpSyncClient.initialize();
-			ListResourcesResult resources = mcpSyncClient.listResources(null);
+			ListResourcesResult resources = mcpSyncClient.listResources(McpSchema.FIRST_PAGE);
 
 			assertThat(resources).isNotNull().satisfies(result -> {
 				assertThat(result.resources()).isNotNull();
@@ -350,14 +351,16 @@ public abstract class AbstractMcpSyncClientTests {
 	void testListAllResources() {
 		withClient(createMcpTransport(), mcpSyncClient -> {
 			mcpSyncClient.initialize();
-			List<Resource> resources = mcpSyncClient.listAllResources();
+			ListResourcesResult resources = mcpSyncClient.listResources();
 
 			assertThat(resources).isNotNull().satisfies(result -> {
-				assertThat(result).isNotEmpty();
+				assertThat(result.resources()).isNotNull();
 
-				Resource firstResource = result.get(0);
-				assertThat(firstResource.uri()).isNotNull();
-				assertThat(firstResource.name()).isNotNull();
+				if (!result.resources().isEmpty()) {
+					Resource firstResource = result.resources().get(0);
+					assertThat(firstResource.uri()).isNotNull();
+					assertThat(firstResource.name()).isNotNull();
+				}
 			});
 		});
 	}
@@ -499,7 +502,7 @@ public abstract class AbstractMcpSyncClientTests {
 
 	@Test
 	void testListResourceTemplatesWithoutInitialization() {
-		verifyCallSucceedsWithImplicitInitialization(client -> client.listResourceTemplates(null),
+		verifyCallSucceedsWithImplicitInitialization(client -> client.listResourceTemplates(McpSchema.FIRST_PAGE),
 				"listing resource templates");
 	}
 
@@ -507,7 +510,7 @@ public abstract class AbstractMcpSyncClientTests {
 	void testListResourceTemplates() {
 		withClient(createMcpTransport(), mcpSyncClient -> {
 			mcpSyncClient.initialize();
-			ListResourceTemplatesResult result = mcpSyncClient.listResourceTemplates(null);
+			ListResourceTemplatesResult result = mcpSyncClient.listResourceTemplates(McpSchema.FIRST_PAGE);
 
 			assertThat(result).isNotNull();
 			assertThat(result.resourceTemplates()).isNotNull();
@@ -518,15 +521,10 @@ public abstract class AbstractMcpSyncClientTests {
 	void testListAllResourceTemplates() {
 		withClient(createMcpTransport(), mcpSyncClient -> {
 			mcpSyncClient.initialize();
-			List<McpSchema.ResourceTemplate> resourceTemplates = mcpSyncClient.listAllResourceTemplates();
+			ListResourceTemplatesResult result = mcpSyncClient.listResourceTemplates();
 
-			assertThat(resourceTemplates).isNotNull().satisfies(result -> {
-				assertThat(result).isNotEmpty();
-
-				McpSchema.ResourceTemplate firstResourceTemplate = result.get(0);
-				assertThat(firstResourceTemplate.name()).isNotNull();
-				assertThat(firstResourceTemplate.description()).isNotNull();
-			});
+			assertThat(result).isNotNull();
+			assertThat(result.resourceTemplates()).isNotNull();
 		});
 	}
 

--- a/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
@@ -42,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
+import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
@@ -158,6 +159,22 @@ public abstract class AbstractMcpSyncClientTests {
 				assertThat(result.tools()).isNotNull().isNotEmpty();
 
 				Tool firstTool = result.tools().get(0);
+				assertThat(firstTool.name()).isNotNull();
+				assertThat(firstTool.description()).isNotNull();
+			});
+		});
+	}
+
+	@Test
+	void testListAllTools() {
+		withClient(createMcpTransport(), mcpSyncClient -> {
+			mcpSyncClient.initialize();
+			List<Tool> tools = mcpSyncClient.listAllTools();
+
+			assertThat(tools).isNotNull().satisfies(result -> {
+				assertThat(result).isNotEmpty();
+
+				Tool firstTool = result.get(0);
 				assertThat(firstTool.name()).isNotNull();
 				assertThat(firstTool.description()).isNotNull();
 			});
@@ -324,6 +341,22 @@ public abstract class AbstractMcpSyncClientTests {
 	}
 
 	@Test
+	void testListAllResources() {
+		withClient(createMcpTransport(), mcpSyncClient -> {
+			mcpSyncClient.initialize();
+			List<Resource> resources = mcpSyncClient.listAllResources();
+
+			assertThat(resources).isNotNull().satisfies(result -> {
+				assertThat(result).isNotEmpty();
+
+				Resource firstResource = result.get(0);
+				assertThat(firstResource.uri()).isNotNull();
+				assertThat(firstResource.name()).isNotNull();
+			});
+		});
+	}
+
+	@Test
 	void testClientSessionState() {
 		withClient(createMcpTransport(), mcpSyncClient -> {
 			assertThat(mcpSyncClient).isNotNull();
@@ -418,6 +451,22 @@ public abstract class AbstractMcpSyncClientTests {
 
 			assertThat(result).isNotNull();
 			assertThat(result.resourceTemplates()).isNotNull();
+		});
+	}
+
+	@Test
+	void testListAllResourceTemplates() {
+		withClient(createMcpTransport(), mcpSyncClient -> {
+			mcpSyncClient.initialize();
+			List<McpSchema.ResourceTemplate> resourceTemplates = mcpSyncClient.listAllResourceTemplates();
+
+			assertThat(resourceTemplates).isNotNull().satisfies(result -> {
+				assertThat(result).isNotEmpty();
+
+				McpSchema.ResourceTemplate firstResourceTemplate = result.get(0);
+				assertThat(firstResourceTemplate.name()).isNotNull();
+				assertThat(firstResourceTemplate.description()).isNotNull();
+			});
 		});
 	}
 

--- a/mcp/src/test/java/io/modelcontextprotocol/client/McpAsyncClientResponseHandlerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/McpAsyncClientResponseHandlerTests.java
@@ -17,6 +17,7 @@ import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.ClientCapabilities;
 import io.modelcontextprotocol.spec.McpSchema.InitializeResult;
+import io.modelcontextprotocol.spec.McpSchema.PaginatedRequest;
 import io.modelcontextprotocol.spec.McpSchema.Root;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -109,27 +110,52 @@ class McpAsyncClientResponseHandlerTests {
 
 		// Create a mock tools list that the server will return
 		Map<String, Object> inputSchema = Map.of("type", "object", "properties", Map.of(), "required", List.of());
-		McpSchema.Tool mockTool = new McpSchema.Tool("test-tool", "Test Tool Description",
+		McpSchema.Tool mockTool = new McpSchema.Tool("test-tool-1", "Test Tool 1 Description",
 				new ObjectMapper().writeValueAsString(inputSchema));
-		McpSchema.ListToolsResult mockToolsResult = new McpSchema.ListToolsResult(List.of(mockTool), null);
+
+		// Create page 1 response with nextPageToken
+		String nextPageToken = "page2Token";
+		McpSchema.ListToolsResult mockToolsResult1 = new McpSchema.ListToolsResult(List.of(mockTool), nextPageToken);
 
 		// Simulate server sending tools/list_changed notification
 		McpSchema.JSONRPCNotification notification = new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION,
 				McpSchema.METHOD_NOTIFICATION_TOOLS_LIST_CHANGED, null);
 		transport.simulateIncomingMessage(notification);
 
-		// Simulate server response to tools/list request
-		McpSchema.JSONRPCRequest toolsListRequest = transport.getLastSentMessageAsRequest();
-		assertThat(toolsListRequest.method()).isEqualTo(McpSchema.METHOD_TOOLS_LIST);
+		// Simulate server response to first tools/list request
+		McpSchema.JSONRPCRequest toolsListRequest1 = transport.getLastSentMessageAsRequest();
+		assertThat(toolsListRequest1.method()).isEqualTo(McpSchema.METHOD_TOOLS_LIST);
 
-		McpSchema.JSONRPCResponse toolsListResponse = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION,
-				toolsListRequest.id(), mockToolsResult, null);
-		transport.simulateIncomingMessage(toolsListResponse);
+		McpSchema.JSONRPCResponse toolsListResponse1 = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION,
+				toolsListRequest1.id(), mockToolsResult1, null);
+		transport.simulateIncomingMessage(toolsListResponse1);
 
-		// Verify the consumer received the expected tools
-		assertThat(receivedTools).hasSize(1);
-		assertThat(receivedTools.get(0).name()).isEqualTo("test-tool");
-		assertThat(receivedTools.get(0).description()).isEqualTo("Test Tool Description");
+		// Create mock tools for page 2
+		McpSchema.Tool mockTool2 = new McpSchema.Tool("test-tool-2", "Test Tool 2 Description",
+				new ObjectMapper().writeValueAsString(inputSchema));
+
+		// Create page 2 response with no nextPageToken (last page)
+		McpSchema.ListToolsResult mockToolsResult2 = new McpSchema.ListToolsResult(List.of(mockTool2), null);
+
+		// Simulate server response to second tools/list request with page token
+		McpSchema.JSONRPCRequest toolsListRequest2 = transport.getLastSentMessageAsRequest();
+		assertThat(toolsListRequest2.method()).isEqualTo(McpSchema.METHOD_TOOLS_LIST);
+
+		// Verify the page token was included in the request
+		PaginatedRequest params = (PaginatedRequest) toolsListRequest2.params();
+		assertThat(params).isNotNull();
+		assertThat(params.cursor()).isEqualTo(nextPageToken);
+
+		McpSchema.JSONRPCResponse toolsListResponse2 = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION,
+				toolsListRequest2.id(), mockToolsResult2, null);
+		transport.simulateIncomingMessage(toolsListResponse2);
+
+		// Verify the consumer received all expected tools from both pages
+		assertThat(receivedTools).hasSize(2);
+		assertThat(receivedTools.get(0).name()).isEqualTo("test-tool-1");
+		assertThat(receivedTools.get(0).description()).isEqualTo("Test Tool 1 Description");
+		assertThat(receivedTools.get(1).name()).isEqualTo("test-tool-2");
+		assertThat(receivedTools.get(1).description()).isEqualTo("Test Tool 2 Description");
 
 		asyncMcpClient.closeGracefully();
 	}


### PR DESCRIPTION
## Motivation and Context
Tools change notification handler is meant to send the updated list of tools to all consumers (clients) who have signed up for tools change notifications. In the current implementation in java-sdk, this would only return the first page of tools to the consumer. This PR:

1. Introduces a fix to ensure that the tools change notification handler deals with the pagination for list tools and returns a list of all tools across pages back to the consumer.
2. Introduces list handlers for the MCP client that can be used to obtain a list of all tools, resources, prompts and resource templates respectively without making multiple list calls to deal with pagination.

## How Has This Been Tested?
Wrote a unit test that broke down list tools result across pages. Tested with the code before and after the change introduced in the PR. The old code (without the PR change) fails to return the complete list of tools. The new code (with the change) successfully returns all the tools across all pages.

## Breaking Changes
None

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed