### PR TITLE
test: enhance resource reading tests

### DIFF
--- a/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/WebClientStreamableHttpAsyncClientTests.java
+++ b/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/WebClientStreamableHttpAsyncClientTests.java
@@ -1,13 +1,12 @@
 package io.modelcontextprotocol.client;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.client.transport.WebClientStreamableHttpTransport;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import org.junit.jupiter.api.Timeout;
-import org.springframework.web.reactive.function.client.WebClient;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.images.builder.ImageFromDockerfile;
+
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Timeout(15)
 public class WebClientStreamableHttpAsyncClientTests extends AbstractMcpAsyncClientTests {

--- a/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
@@ -19,6 +19,8 @@ import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.ClientCapabilities;
 import io.modelcontextprotocol.spec.McpSchema.CreateMessageRequest;
 import io.modelcontextprotocol.spec.McpSchema.CreateMessageResult;
+import io.modelcontextprotocol.spec.McpSchema.ElicitRequest;
+import io.modelcontextprotocol.spec.McpSchema.ElicitResult;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptRequest;
 import io.modelcontextprotocol.spec.McpSchema.Prompt;
 import io.modelcontextprotocol.spec.McpSchema.Resource;
@@ -38,6 +40,7 @@ import reactor.test.StepVerifier;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
  * Test suite for the {@link McpAsyncClient} that can be used with different
@@ -339,18 +342,36 @@ public abstract class AbstractMcpAsyncClientTests {
 	}
 
 	@Test
-	@Disabled
 	void testReadResource() {
-		withClient(createMcpTransport(), mcpAsyncClient -> {
-			StepVerifier.create(mcpAsyncClient.listResources()).consumeNextWith(resources -> {
-				if (!resources.resources().isEmpty()) {
-					Resource firstResource = resources.resources().get(0);
-					StepVerifier.create(mcpAsyncClient.readResource(firstResource)).consumeNextWith(result -> {
-						assertThat(result).isNotNull();
-						assertThat(result.contents()).isNotNull();
-					}).verifyComplete();
-				}
-			}).verifyComplete();
+		withClient(createMcpTransport(), client -> {
+			Flux<McpSchema.ReadResourceResult> resources = client.initialize()
+				.then(client.listResources(null))
+				.flatMapMany(r -> Flux.fromIterable(r.resources()))
+				.flatMap(r -> client.readResource(r));
+
+			StepVerifier.create(resources).consumeNextWith(resourceResult -> {
+				assertThat(resourceResult.contents()).allSatisfy(content -> {
+					if (content.mimeType().equals("text/plain")) {
+						McpSchema.TextResourceContents text = assertInstanceOf(McpSchema.TextResourceContents.class,
+								content);
+						assertThat(text.mimeType()).isEqualTo("text/plain");
+						assertThat(text.uri()).isNotEmpty();
+						assertThat(text.text()).isNotEmpty();
+					}
+					else if (content.mimeType().equals("application/octet-stream")) {
+						McpSchema.BlobResourceContents blob = assertInstanceOf(McpSchema.BlobResourceContents.class,
+								content);
+						assertThat(blob.mimeType()).isEqualTo("application/octet-stream");
+						assertThat(blob.uri()).isNotEmpty();
+						assertThat(blob.blob()).isNotEmpty();
+					}
+					else {
+						throw new IllegalArgumentException("Unexpected content type: " + content.mimeType());
+					}
+				});
+			})
+				.expectNextCount(9) // Expect 9 more elements
+				.verifyComplete();
 		});
 	}
 
@@ -425,6 +446,20 @@ public abstract class AbstractMcpAsyncClientTests {
 	}
 
 	@Test
+	void testInitializeWithElicitationCapability() {
+		ClientCapabilities capabilities = ClientCapabilities.builder().elicitation().build();
+		ElicitResult elicitResult = ElicitResult.builder()
+			.message(ElicitResult.Action.ACCEPT)
+			.content(Map.of("foo", "bar"))
+			.build();
+		withClient(createMcpTransport(),
+				builder -> builder.capabilities(capabilities).elicitation(request -> Mono.just(elicitResult)),
+				client -> {
+					StepVerifier.create(client.initialize()).expectNextMatches(Objects::nonNull).verifyComplete();
+				});
+	}
+
+	@Test
 	void testInitializeWithAllCapabilities() {
 		var capabilities = ClientCapabilities.builder()
 			.experimental(Map.of("feature", "test"))
@@ -435,7 +470,11 @@ public abstract class AbstractMcpAsyncClientTests {
 		Function<CreateMessageRequest, Mono<CreateMessageResult>> samplingHandler = request -> Mono
 			.just(CreateMessageResult.builder().message("test").model("test-model").build());
 
-		withClient(createMcpTransport(), builder -> builder.capabilities(capabilities).sampling(samplingHandler),
+		Function<ElicitRequest, Mono<ElicitResult>> elicitationHandler = request -> Mono
+			.just(ElicitResult.builder().message(ElicitResult.Action.ACCEPT).content(Map.of("foo", "bar")).build());
+
+		withClient(createMcpTransport(),
+				builder -> builder.capabilities(capabilities).sampling(samplingHandler).elicitation(elicitationHandler),
 				client ->
 
 				StepVerifier.create(client.initialize()).assertNext(result -> {

--- a/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
@@ -8,12 +8,14 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.BlobResourceContents;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.ClientCapabilities;
@@ -22,22 +24,25 @@ import io.modelcontextprotocol.spec.McpSchema.ListResourcesResult;
 import io.modelcontextprotocol.spec.McpSchema.ListToolsResult;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.spec.McpSchema.Resource;
+import io.modelcontextprotocol.spec.McpSchema.ResourceContents;
 import io.modelcontextprotocol.spec.McpSchema.Root;
 import io.modelcontextprotocol.spec.McpSchema.SubscribeRequest;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import io.modelcontextprotocol.spec.McpSchema.UnsubscribeRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Scheduler;
-import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
  * Unit tests for MCP Client Session functionality.
@@ -46,6 +51,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @author Dariusz Jędrzejczyk
  */
 public abstract class AbstractMcpSyncClientTests {
+
+	private static final Logger logger = LoggerFactory.getLogger(AbstractMcpSyncClientTests.class);
 
 	private static final String TEST_MESSAGE = "Hello MCP Spring AI!";
 
@@ -330,18 +337,72 @@ public abstract class AbstractMcpSyncClientTests {
 
 	@Test
 	void testReadResource() {
+		AtomicInteger readResourceCount = new AtomicInteger(0);
 		withClient(createMcpTransport(), mcpSyncClient -> {
 			mcpSyncClient.initialize();
 			ListResourcesResult resources = mcpSyncClient.listResources(null);
 
-			if (!resources.resources().isEmpty()) {
-				Resource firstResource = resources.resources().get(0);
-				ReadResourceResult result = mcpSyncClient.readResource(firstResource);
+			assertThat(resources).isNotNull();
+			assertThat(resources.resources()).isNotNull();
+
+			if (resources.resources().isEmpty()) {
+				throw new IllegalStateException("No resources available for testing readResource functionality");
+			}
+
+			// Test reading each resource individually for better error isolation
+			for (Resource resource : resources.resources()) {
+				ReadResourceResult result = mcpSyncClient.readResource(resource);
 
 				assertThat(result).isNotNull();
-				assertThat(result.contents()).isNotNull();
+				assertThat(result.contents()).isNotNull().isNotEmpty();
+
+				readResourceCount.incrementAndGet();
+
+				// Validate each content item
+				for (ResourceContents content : result.contents()) {
+					assertThat(content).isNotNull();
+					assertThat(content.uri()).isNotNull().isNotEmpty();
+					assertThat(content.mimeType()).isNotNull().isNotEmpty();
+
+					// Validate content based on its type with more comprehensive
+					// checks
+					switch (content.mimeType()) {
+						case "text/plain" -> {
+							TextResourceContents textContent = assertInstanceOf(TextResourceContents.class, content);
+							assertThat(textContent.text()).isNotNull().isNotEmpty();
+							// Verify URI consistency
+							assertThat(textContent.uri()).isEqualTo(resource.uri());
+						}
+						case "application/octet-stream" -> {
+							BlobResourceContents blobContent = assertInstanceOf(BlobResourceContents.class, content);
+							assertThat(blobContent.blob()).isNotNull().isNotEmpty();
+							// Verify URI consistency
+							assertThat(blobContent.uri()).isEqualTo(resource.uri());
+							// Validate base64 encoding format
+							assertThat(blobContent.blob()).matches("^[A-Za-z0-9+/]*={0,2}$");
+						}
+						default -> {
+							// More flexible handling of additional MIME types
+							// Log the unexpected type for debugging but don't fail
+							// the test
+							logger.warn("Warning: Encountered unexpected MIME type: {} for resource: {}",
+									content.mimeType(), resource.uri());
+
+							// Still validate basic properties
+							if (content instanceof TextResourceContents textContent) {
+								assertThat(textContent.text()).isNotNull();
+							}
+							else if (content instanceof BlobResourceContents blobContent) {
+								assertThat(blobContent.blob()).isNotNull();
+							}
+						}
+					}
+				}
 			}
 		});
+
+		// Assert that we read exactly 10 resources
+		assertThat(readResourceCount.get()).isEqualTo(10);
 	}
 
 	@Test

--- a/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
@@ -8,12 +8,14 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.BlobResourceContents;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.ClientCapabilities;
@@ -22,22 +24,25 @@ import io.modelcontextprotocol.spec.McpSchema.ListResourcesResult;
 import io.modelcontextprotocol.spec.McpSchema.ListToolsResult;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.spec.McpSchema.Resource;
+import io.modelcontextprotocol.spec.McpSchema.ResourceContents;
 import io.modelcontextprotocol.spec.McpSchema.Root;
 import io.modelcontextprotocol.spec.McpSchema.SubscribeRequest;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import io.modelcontextprotocol.spec.McpSchema.UnsubscribeRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Scheduler;
-import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
  * Unit tests for MCP Client Session functionality.
@@ -47,6 +52,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 // KEEP IN SYNC with the class in mcp-test module
 public abstract class AbstractMcpSyncClientTests {
+
+	private static final Logger logger = LoggerFactory.getLogger(AbstractMcpSyncClientTests.class);
 
 	private static final String TEST_MESSAGE = "Hello MCP Spring AI!";
 
@@ -122,9 +129,9 @@ public abstract class AbstractMcpSyncClientTests {
 
 	<T> void verifyCallSucceedsWithImplicitInitialization(Function<McpSyncClient, T> blockingOperation, String action) {
 		withClient(createMcpTransport(), mcpSyncClient -> {
-			StepVerifier.create(Mono.fromSupplier(() -> blockingOperation.apply(mcpSyncClient))
-				// Offload the blocking call to the real scheduler
-				.subscribeOn(Schedulers.boundedElastic())).expectNextCount(1).verifyComplete();
+			StepVerifier.create(Mono.fromSupplier(() -> blockingOperation.apply(mcpSyncClient)))
+				.expectNextCount(1)
+				.verifyComplete();
 		});
 	}
 
@@ -331,18 +338,72 @@ public abstract class AbstractMcpSyncClientTests {
 
 	@Test
 	void testReadResource() {
+		AtomicInteger readResourceCount = new AtomicInteger(0);
 		withClient(createMcpTransport(), mcpSyncClient -> {
 			mcpSyncClient.initialize();
 			ListResourcesResult resources = mcpSyncClient.listResources(null);
 
-			if (!resources.resources().isEmpty()) {
-				Resource firstResource = resources.resources().get(0);
-				ReadResourceResult result = mcpSyncClient.readResource(firstResource);
+			assertThat(resources).isNotNull();
+			assertThat(resources.resources()).isNotNull();
+
+			if (resources.resources().isEmpty()) {
+				throw new IllegalStateException("No resources available for testing readResource functionality");
+			}
+
+			// Test reading each resource individually for better error isolation
+			for (Resource resource : resources.resources()) {
+				ReadResourceResult result = mcpSyncClient.readResource(resource);
 
 				assertThat(result).isNotNull();
-				assertThat(result.contents()).isNotNull();
+				assertThat(result.contents()).isNotNull().isNotEmpty();
+
+				readResourceCount.incrementAndGet();
+
+				// Validate each content item
+				for (ResourceContents content : result.contents()) {
+					assertThat(content).isNotNull();
+					assertThat(content.uri()).isNotNull().isNotEmpty();
+					assertThat(content.mimeType()).isNotNull().isNotEmpty();
+
+					// Validate content based on its type with more comprehensive
+					// checks
+					switch (content.mimeType()) {
+						case "text/plain" -> {
+							TextResourceContents textContent = assertInstanceOf(TextResourceContents.class, content);
+							assertThat(textContent.text()).isNotNull().isNotEmpty();
+							// Verify URI consistency
+							assertThat(textContent.uri()).isEqualTo(resource.uri());
+						}
+						case "application/octet-stream" -> {
+							BlobResourceContents blobContent = assertInstanceOf(BlobResourceContents.class, content);
+							assertThat(blobContent.blob()).isNotNull().isNotEmpty();
+							// Verify URI consistency
+							assertThat(blobContent.uri()).isEqualTo(resource.uri());
+							// Validate base64 encoding format
+							assertThat(blobContent.blob()).matches("^[A-Za-z0-9+/]*={0,2}$");
+						}
+						default -> {
+							// More flexible handling of additional MIME types
+							// Log the unexpected type for debugging but don't fail
+							// the test
+							logger.warn("Warning: Encountered unexpected MIME type: {} for resource: {}",
+									content.mimeType(), resource.uri());
+
+							// Still validate basic properties
+							if (content instanceof TextResourceContents textContent) {
+								assertThat(textContent.text()).isNotNull();
+							}
+							else if (content instanceof BlobResourceContents blobContent) {
+								assertThat(blobContent.blob()).isNotNull();
+							}
+						}
+					}
+				}
 			}
 		});
+
+		// Assert that we read exactly 10 resources
+		assertThat(readResourceCount.get()).isEqualTo(10);
 	}
 
 	@Test


### PR DESCRIPTION
- Implement comprehensive resource content validation for text/plain and application/octet-stream MIME types
- Validate resource count expectations (10 resources)
- Add elicitation capability testing with ElicitRequest/ElicitResult support
- Clean up unused imports (ObjectMapper, ImageFromDockerfile)
