### PR TITLE
fix: resolve duplicate requests caused by concurrent message sending

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/FlowSseClient.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/FlowSseClient.java
@@ -121,7 +121,8 @@ public class FlowSseClient {
 	 * @throws RuntimeException if the connection fails with a non-200 status code
 	 */
 	public void subscribe(String url, SseEventHandler eventHandler) {
-		HttpRequest request = this.requestBuilder.copy().uri(URI.create(url))
+		HttpRequest request = this.requestBuilder.copy()
+			.uri(URI.create(url))
 			.header("Accept", "text/event-stream")
 			.header("Cache-Control", "no-cache")
 			.GET()

--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
@@ -415,7 +415,8 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 		try {
 			String jsonText = this.objectMapper.writeValueAsString(message);
 			URI requestUri = Utils.resolveUri(baseUri, endpoint);
-			HttpRequest request = this.requestBuilder.copy().uri(requestUri)
+			HttpRequest request = this.requestBuilder.copy()
+				.uri(requestUri)
 				.POST(HttpRequest.BodyPublishers.ofString(jsonText))
 				.build();
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
When calling the tools/call method of the same mcp async-client in parallel, we found that the client occasionally sent duplicate messages. We located that the same requestBuilder was used each time a request was made in the SDK, which was thread-unsafe.


## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

```java
        ExecutorService threadPool = Executors.newFixedThreadPool(5);

        var transport = HttpClientSseClientTransport.builder("xxxxxx")
                .sseEndpoint("xxxxxx")
                .build();
        var asyncClient = McpClient.async(transport).build();

        asyncClient.initialize().block(Duration.ofSeconds(10));
        Map<String, Object> arguments = new HashMap<>();
        McpSchema.CallToolRequest request = new McpSchema.CallToolRequest("xxxxxx", arguments);

        Mono<McpSchema.CallToolResult> mono1 = asyncClient.callTool(request)
                .timeout(Duration.ofSeconds(30))
                .doOnSuccess(result -> {
                    System.out.println("--> get success response" + result);
                })
                .doOnError(error -> {
                    System.out.println("failed");
                    System.out.println(error.getMessage());
                });

        Mono<McpSchema.CallToolResult> mono2 = asyncClient.callTool(request)
                .timeout(Duration.ofSeconds(30))
                .doOnSuccess(result -> {
                    System.out.println("--> get success response" + result);
                })
                .doOnError(error -> {
                    System.out.println("failed");
                    System.out.println(error.getMessage());
                });

        Mono<McpSchema.CallToolResult> mono3 = asyncClient.callTool(request)
                .timeout(Duration.ofSeconds(30))
                .doOnSuccess(result -> {
                    System.out.println("--> get success response" + result);
                })
                .doOnError(error -> {
                    System.out.println("failed");
                    System.out.println(error.getMessage());
                });

        Mono<McpSchema.CallToolResult> mono4 = asyncClient.callTool(request)
                .timeout(Duration.ofSeconds(30))
                .doOnSuccess(result -> {
                    System.out.println("--> get success response" + result);
                })
                .doOnError(error -> {
                    System.out.println("failed");
                    System.out.println(error.getMessage());
                });

        Thread.sleep(10000);

        threadPool.submit(() -> {
            mono1.subscribe();
        });

        threadPool.submit(() -> {
            mono2.subscribe();
        });

        threadPool.submit(() -> {
            mono3.subscribe();
        });

        threadPool.submit(() -> {
            mono4.subscribe();
        });
```

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
