### PR TITLE
feat: add pagination support for listRoots operation

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -1615,11 +1615,19 @@ public final class McpSchema {
 	 *
 	 * @param roots An array of Root objects, each representing a root directory or file
 	 * that the server can operate on.
+	 * @param nextCursor An optional cursor for pagination. If present, indicates there
+	 * are more roots available. The client can use this cursor to request the next page
+	 * of results by sending a roots/list request with the cursor parameter set to this
 	 */
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ListRootsResult( // @formatter:off
-		@JsonProperty("roots") List<Root> roots) {
+		@JsonProperty("roots") List<Root> roots,
+		@JsonProperty("nextCursor") String nextCursor) {
+		
+		public ListRootsResult(List<Root> roots) {
+			this(roots, null);
+		}
 	} // @formatter:on
 
 }

--- a/mcp/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
@@ -984,7 +984,7 @@ public class McpSchemaTests {
 
 		McpSchema.Root root2 = new McpSchema.Root("file:///path/to/root2", "Second Root");
 
-		McpSchema.ListRootsResult result = new McpSchema.ListRootsResult(Arrays.asList(root1, root2));
+		McpSchema.ListRootsResult result = new McpSchema.ListRootsResult(Arrays.asList(root1, root2), "next-cursor");
 
 		String value = mapper.writeValueAsString(result);
 
@@ -993,7 +993,7 @@ public class McpSchemaTests {
 			.isObject()
 			.isEqualTo(
 					json("""
-							{"roots":[{"uri":"file:///path/to/root1","name":"First Root"},{"uri":"file:///path/to/root2","name":"Second Root"}]}"""));
+							{"roots":[{"uri":"file:///path/to/root1","name":"First Root"},{"uri":"file:///path/to/root2","name":"Second Root"}],"nextCursor":"next-cursor"}"""));
 
 	}
 


### PR DESCRIPTION
- Add nextCursor field to ListRootsResult for cursor-based pagination
- Implement automatic pagination in McpAsyncServerExchange.listRoots()
- Update tests to verify pagination functionality
- Automatically fetches and combines all pages into single result
