### PR TITLE
feat: implement Streamable HTTP transport and refactor SSE transport to reactive streams

### DIFF
--- a/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/WebClientStreamableHttpSyncClientTests.java
+++ b/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/WebClientStreamableHttpSyncClientTests.java
@@ -1,12 +1,12 @@
 package io.modelcontextprotocol.client;
 
-import io.modelcontextprotocol.client.transport.WebClientStreamableHttpTransport;
-import io.modelcontextprotocol.spec.McpClientTransport;
 import org.junit.jupiter.api.Timeout;
+import org.springframework.web.reactive.function.client.WebClient;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
-import org.springframework.web.reactive.function.client.WebClient;
+import io.modelcontextprotocol.client.transport.WebClientStreamableHttpTransport;
+import io.modelcontextprotocol.spec.McpClientTransport;
 
 @Timeout(15)
 public class WebClientStreamableHttpSyncClientTests extends AbstractMcpSyncClientTests {

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -141,11 +141,11 @@
 
 		<!-- Mockito cannot mock this class: class java.net.http.HttpClient. the bytebuddy helps. -->
 		<dependency>
-            <groupId>net.bytebuddy</groupId>
-            <artifactId>byte-buddy</artifactId>
-            <version>${byte-buddy.version}</version>
-            <scope>test</scope>
-        </dependency>
+			<groupId>net.bytebuddy</groupId>
+			<artifactId>byte-buddy</artifactId>
+			<version>${byte-buddy.version}</version>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-test</artifactId>
@@ -201,6 +201,14 @@
 			<version>${tomcat.version}</version>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>toxiproxy</artifactId>
+			<version>${toxiproxy.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 
 	</dependencies>
 

--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
@@ -9,30 +9,32 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.modelcontextprotocol.client.transport.FlowSseClient.SseEvent;
+
+import io.modelcontextprotocol.client.transport.ResponseSubscribers.ResponseEvent;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.JSONRPCMessage;
 import io.modelcontextprotocol.util.Assert;
 import io.modelcontextprotocol.util.Utils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
 
 /**
  * Server-Sent Events (SSE) implementation of the
  * {@link io.modelcontextprotocol.spec.McpTransport} that follows the MCP HTTP with SSE
- * transport specification, using Java's HttpClient.
+ * transport specification, using Java's HttpClient and FlowSseClient.
  *
  * <p>
  * This transport implementation establishes a bidirectional communication channel between
@@ -75,9 +77,6 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 	/** SSE endpoint path */
 	private final String sseEndpoint;
 
-	/** SSE client for handling server-sent events. Uses the /sse endpoint */
-	private final FlowSseClient sseClient;
-
 	/**
 	 * HTTP client for sending messages to the server. Uses HTTP POST over the message
 	 * endpoint
@@ -93,19 +92,26 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 	/** Flag indicating if the transport is in closing state */
 	private volatile boolean isClosing = false;
 
-	/** Latch for coordinating endpoint discovery */
-	private final CountDownLatch closeLatch = new CountDownLatch(1);
+	// /** Latch for coordinating endpoint discovery */
+	// private final CountDownLatch closeLatch = new CountDownLatch(1);
 
-	/** Holds the discovered message endpoint URL */
-	private final AtomicReference<String> messageEndpoint = new AtomicReference<>();
+	// /** Holds the discovered message endpoint URL */
+	// private final AtomicReference<String> messageEndpoint = new
+	// AtomicReference<>();
 
-	/** Holds the SSE connection future */
-	private final AtomicReference<CompletableFuture<Void>> connectionFuture = new AtomicReference<>();
+	/** Holds the SSE subscription disposable */
+	private final AtomicReference<Disposable> sseSubscription = new AtomicReference<>();
+
+	/**
+	 * Sink for managing the message endpoint URI provided by the server. Stores the most
+	 * recent endpoint URI and makes it available for outbound message processing.
+	 */
+	protected final Sinks.One<String> messageEndpointSink = Sinks.one();
 
 	/**
 	 * Creates a new transport instance with default HTTP client and object mapper.
 	 * @param baseUri the base URI of the MCP server
-	 * @deprecated Use {@link HttpClientSseClientTransport#builder(String)} instead. This
+	 * @deprecated Use {@link HttpClientSseClientTransport2#builder(String)} instead. This
 	 * constructor will be removed in future versions.
 	 */
 	@Deprecated(forRemoval = true)
@@ -119,7 +125,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 	 * @param baseUri the base URI of the MCP server
 	 * @param objectMapper the object mapper for JSON serialization/deserialization
 	 * @throws IllegalArgumentException if objectMapper or clientBuilder is null
-	 * @deprecated Use {@link HttpClientSseClientTransport#builder(String)} instead. This
+	 * @deprecated Use {@link HttpClientSseClientTransport2#builder(String)} instead. This
 	 * constructor will be removed in future versions.
 	 */
 	@Deprecated(forRemoval = true)
@@ -134,7 +140,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 	 * @param sseEndpoint the SSE endpoint path
 	 * @param objectMapper the object mapper for JSON serialization/deserialization
 	 * @throws IllegalArgumentException if objectMapper or clientBuilder is null
-	 * @deprecated Use {@link HttpClientSseClientTransport#builder(String)} instead. This
+	 * @deprecated Use {@link HttpClientSseClientTransport2#builder(String)} instead. This
 	 * constructor will be removed in future versions.
 	 */
 	@Deprecated(forRemoval = true)
@@ -152,7 +158,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 	 * @param sseEndpoint the SSE endpoint path
 	 * @param objectMapper the object mapper for JSON serialization/deserialization
 	 * @throws IllegalArgumentException if objectMapper, clientBuilder, or headers is null
-	 * @deprecated Use {@link HttpClientSseClientTransport#builder(String)} instead. This
+	 * @deprecated Use {@link HttpClientSseClientTransport2#builder(String)} instead. This
 	 * constructor will be removed in future versions.
 	 */
 	@Deprecated(forRemoval = true)
@@ -184,12 +190,10 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 		this.objectMapper = objectMapper;
 		this.httpClient = httpClient;
 		this.requestBuilder = requestBuilder;
-
-		this.sseClient = new FlowSseClient(this.httpClient, requestBuilder);
 	}
 
 	/**
-	 * Creates a new builder for {@link HttpClientSseClientTransport}.
+	 * Creates a new builder for {@link HttpClientSseClientTransport2}.
 	 * @param baseUri the base URI of the MCP server
 	 * @return a new builder instance
 	 */
@@ -198,7 +202,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 	}
 
 	/**
-	 * Builder for {@link HttpClientSseClientTransport}.
+	 * Builder for {@link HttpClientSseClientTransport2}.
 	 */
 	public static class Builder {
 
@@ -225,7 +229,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 		/**
 		 * Creates a new builder with the specified base URI.
 		 * @param baseUri the base URI of the MCP server
-		 * @deprecated Use {@link HttpClientSseClientTransport#builder(String)} instead.
+		 * @deprecated Use {@link HttpClientSseClientTransport2#builder(String)} instead.
 		 * This constructor is deprecated and will be removed or made {@code protected} or
 		 * {@code private} in a future release.
 		 */
@@ -313,7 +317,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 		}
 
 		/**
-		 * Builds a new {@link HttpClientSseClientTransport} instance.
+		 * Builds a new {@link HttpClientSseClientTransport2} instance.
 		 * @return a new transport instance
 		 */
 		public HttpClientSseClientTransport build() {
@@ -323,63 +327,82 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 
 	}
 
-	/**
-	 * Establishes the SSE connection with the server and sets up message handling.
-	 *
-	 * <p>
-	 * This method:
-	 * <ul>
-	 * <li>Initiates the SSE connection</li>
-	 * <li>Handles endpoint discovery events</li>
-	 * <li>Processes incoming JSON-RPC messages</li>
-	 * </ul>
-	 * @param handler the function to process received JSON-RPC messages
-	 * @return a Mono that completes when the connection is established
-	 */
 	@Override
 	public Mono<Void> connect(Function<Mono<JSONRPCMessage>, Mono<JSONRPCMessage>> handler) {
-		CompletableFuture<Void> future = new CompletableFuture<>();
-		connectionFuture.set(future);
 
-		URI clientUri = Utils.resolveUri(this.baseUri, this.sseEndpoint);
-		sseClient.subscribe(clientUri.toString(), new FlowSseClient.SseEventHandler() {
-			@Override
-			public void onEvent(SseEvent event) {
-				if (isClosing) {
-					return;
-				}
+		return Mono.create(sink -> {
 
-				try {
-					if (ENDPOINT_EVENT_TYPE.equals(event.type())) {
-						String endpoint = event.data();
-						messageEndpoint.set(endpoint);
-						closeLatch.countDown();
-						future.complete(null);
-					}
-					else if (MESSAGE_EVENT_TYPE.equals(event.type())) {
-						JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(objectMapper, event.data());
-						handler.apply(Mono.just(message)).subscribe();
-					}
-					else {
-						logger.error("Received unrecognized SSE event type: {}", event.type());
-					}
-				}
-				catch (IOException e) {
-					logger.error("Error processing SSE event", e);
-					future.completeExceptionally(e);
-				}
-			}
+			HttpRequest request = requestBuilder.copy()
+				.uri(Utils.resolveUri(this.baseUri, this.sseEndpoint))
+				.header("Accept", "text/event-stream")
+				.header("Cache-Control", "no-cache")
+				.GET()
+				.build();
 
-			@Override
-			public void onError(Throwable error) {
-				if (!isClosing) {
-					logger.error("SSE connection error", error);
-					future.completeExceptionally(error);
-				}
-			}
+			Disposable connection = Flux
+				.<ResponseEvent>create(sseSink -> this.httpClient.sendAsync(request,
+						responseInfo -> ResponseSubscribers.sseToBodySubscriber(responseInfo, sseSink)))
+				.flatMap(responseEvent -> {
+					if (isClosing) {
+						return Mono.empty();
+					}
+
+					int statusCode = responseEvent.responseInfo().statusCode();
+
+					if (statusCode >= 200 && statusCode < 300) {
+						try {
+							if (ENDPOINT_EVENT_TYPE.equals(responseEvent.sseEvent().event())) {
+								String messageEndpointUri = responseEvent.sseEvent().data();
+								if (this.messageEndpointSink.tryEmitValue(messageEndpointUri).isSuccess()) {
+									sink.success();
+									return Flux.empty(); // No further processing needed
+								}
+								else {
+									sink.error(new McpError("Failed to handle SSE endpoint event"));
+								}
+							}
+							else if (MESSAGE_EVENT_TYPE.equals(responseEvent.sseEvent().event())) {
+								JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(objectMapper,
+										responseEvent.sseEvent().data());
+								sink.success();
+								return Flux.just(message);
+							}
+							else {
+								logger.error("Received unrecognized SSE event type: {}",
+										responseEvent.sseEvent().event());
+								sink.error(new McpError(
+										"Received unrecognized SSE event type: " + responseEvent.sseEvent().event()));
+							}
+						}
+						catch (IOException e) {
+							logger.error("Error processing SSE event", e);
+							sink.error(new McpError("Error processing SSE event"));
+						}
+					}
+					return Flux.<McpSchema.JSONRPCMessage>error(
+							new RuntimeException("Failed to send message: " + responseEvent));
+
+				})
+				.flatMap(jsonRpcMessage -> handler.apply(Mono.just(jsonRpcMessage)))
+				.onErrorResume(t -> {
+					if (!isClosing) {
+						logger.error("SSE connection error", t);
+						sink.error(t);
+					}
+					return Mono.empty();
+
+				})
+				.doFinally(s -> {
+					Disposable ref = this.sseSubscription.getAndSet(null);
+					if (ref != null && !ref.isDisposed()) {
+						ref.dispose();
+					}
+				})
+				.contextWrite(sink.contextView())
+				.subscribe();
+
+			this.sseSubscription.set(connection);
 		});
-
-		return Mono.fromFuture(future);
 	}
 
 	/**
@@ -394,45 +417,58 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 	 */
 	@Override
 	public Mono<Void> sendMessage(JSONRPCMessage message) {
-		if (isClosing) {
-			return Mono.empty();
-		}
 
-		try {
-			if (!closeLatch.await(10, TimeUnit.SECONDS)) {
-				return Mono.error(new McpError("Failed to wait for the message endpoint"));
+		return this.messageEndpointSink.asMono().flatMap(messageEndpointUri -> {
+			if (isClosing) {
+				return Mono.empty();
 			}
-		}
-		catch (InterruptedException e) {
-			return Mono.error(new McpError("Failed to wait for the message endpoint"));
-		}
 
-		String endpoint = messageEndpoint.get();
-		if (endpoint == null) {
-			return Mono.error(new McpError("No message endpoint available"));
-		}
-
-		try {
-			String jsonText = this.objectMapper.writeValueAsString(message);
-			URI requestUri = Utils.resolveUri(baseUri, endpoint);
-			HttpRequest request = this.requestBuilder.copy()
-				.uri(requestUri)
-				.POST(HttpRequest.BodyPublishers.ofString(jsonText))
-				.build();
-
-			return Mono.fromFuture(
-					httpClient.sendAsync(request, HttpResponse.BodyHandlers.discarding()).thenAccept(response -> {
-						if (response.statusCode() != 200 && response.statusCode() != 201 && response.statusCode() != 202
-								&& response.statusCode() != 206) {
-							logger.error("Error sending message: {}", response.statusCode());
+			try {
+				return this.serializeMessage(message)
+					.flatMap(body -> sendHttpPost(messageEndpointUri, body))
+					.doOnNext(this::logIfNotOk)
+					.doOnError(error -> {
+						if (!isClosing) {
+							logger.error("Error sending message: {}", error.getMessage());
 						}
-					}));
-		}
-		catch (IOException e) {
-			if (!isClosing) {
-				return Mono.error(new RuntimeException("Failed to serialize message", e));
+					})
+					.then();
 			}
-			return Mono.empty();
+			catch (Exception e) {
+				if (!isClosing) {
+					return Mono.error(new RuntimeException("Failed to serialize message", e));
+				}
+				return Mono.empty();
+			}
+		}).then();
+
+	}
+
+	private Mono<String> serializeMessage(final JSONRPCMessage message) {
+		return Mono.defer(() -> {
+			try {
+				return Mono.just(objectMapper.writeValueAsString(message));
+			}
+			catch (IOException e) {
+				return Mono.error(new McpError("Failed to serialize message"));
+			}
+		});
+	}
+
+	private Mono<HttpResponse<Void>> sendHttpPost(final String endpoint, final String body) {
+		final URI requestUri = Utils.resolveUri(baseUri, endpoint);
+		final HttpRequest request = this.requestBuilder.copy()
+			.uri(requestUri)
+			.POST(HttpRequest.BodyPublishers.ofString(body))
+			.build();
+
+		return Mono.fromFuture(httpClient.sendAsync(request, HttpResponse.BodyHandlers.discarding()));
+	}
+
+	private void logIfNotOk(final HttpResponse<?> response) {
+		if (response.statusCode() != 200 && response.statusCode() != 201 && response.statusCode() != 202
+				&& response.statusCode() != 206) {
+			logger.error("Error sending message: {}", response.statusCode());
 		}
 	}
 
@@ -440,7 +476,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 	 * Gracefully closes the transport connection.
 	 *
 	 * <p>
-	 * Sets the closing flag and cancels any pending connection future. This prevents new
+	 * Sets the closing flag and disposes of the SSE subscription. This prevents new
 	 * messages from being sent and allows ongoing operations to complete.
 	 * @return a Mono that completes when the closing process is initiated
 	 */
@@ -448,9 +484,9 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 	public Mono<Void> closeGracefully() {
 		return Mono.fromRunnable(() -> {
 			isClosing = true;
-			CompletableFuture<Void> future = connectionFuture.get();
-			if (future != null && !future.isDone()) {
-				future.cancel(true);
+			Disposable subscription = sseSubscription.get();
+			if (subscription != null && !subscription.isDisposed()) {
+				subscription.dispose();
 			}
 		});
 	}

--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
@@ -1,0 +1,668 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ */
+
+package io.modelcontextprotocol.client.transport;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.modelcontextprotocol.client.transport.ResponseSubscribers.ResponseEvent;
+import io.modelcontextprotocol.spec.DefaultMcpTransportSession;
+import io.modelcontextprotocol.spec.DefaultMcpTransportStream;
+import io.modelcontextprotocol.spec.McpClientTransport;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpTransportSession;
+import io.modelcontextprotocol.spec.McpTransportSessionNotFoundException;
+import io.modelcontextprotocol.spec.McpTransportStream;
+import io.modelcontextprotocol.util.Assert;
+import io.modelcontextprotocol.util.Utils;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
+import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
+
+/**
+ * An implementation of the Streamable HTTP protocol as defined by the
+ * <code>2025-03-26</code> version of the MCP specification.
+ *
+ * <p>
+ * The transport is capable of resumability and reconnects. It reacts to transport-level
+ * session invalidation and will propagate {@link McpTransportSessionNotFoundException
+ * appropriate exceptions} to the higher level abstraction layer when needed in order to
+ * allow proper state management. The implementation handles servers that are stateful and
+ * provide session meta information, but can also communicate with stateless servers that
+ * do not provide a session identifier and do not support SSE streams.
+ * </p>
+ * <p>
+ * This implementation does not handle backwards compatibility with the <a href=
+ * "https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#http-with-sse">"HTTP
+ * with SSE" transport</a>. In order to communicate over the phased-out
+ * <code>2024-11-05</code> protocol, use {@link HttpClientSseClientTransport} or
+ * {@link WebFluxSseClientTransport}.
+ * </p>
+ *
+ * @author Christian Tzolov
+ * @see <a href=
+ * "https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http">Streamable
+ * HTTP transport specification</a>
+ */
+public class HttpClientStreamableHttpTransport implements McpClientTransport {
+
+	private static final Logger logger = LoggerFactory.getLogger(HttpClientStreamableHttpTransport.class);
+
+	private static final String DEFAULT_ENDPOINT = "/mcp";
+
+	/**
+	 * HTTP client for sending messages to the server. Uses HTTP POST over the message
+	 * endpoint
+	 */
+	private final HttpClient httpClient;
+
+	/** HTTP request builder for building requests to send messages to the server */
+	private final HttpRequest.Builder requestBuilder;
+
+	/**
+	 * Event type for JSON-RPC messages received through the SSE connection. The server
+	 * sends messages with this event type to transmit JSON-RPC protocol data.
+	 */
+	private static final String MESSAGE_EVENT_TYPE = "message";
+
+	private static final String APPLICATION_JSON = "application/json";
+
+	private static final String TEXT_EVENT_STREAM = "text/event-stream";
+
+	public static int NOT_FOUND = 404;
+
+	public static int METHOD_NOT_ALLOWED = 405;
+
+	public static int BAD_REQUEST = 400;
+
+	private final ObjectMapper objectMapper;
+
+	private final URI baseUri;
+
+	private final String endpoint;
+
+	private final boolean openConnectionOnStartup;
+
+	private final boolean resumableStreams;
+
+	private final AtomicReference<DefaultMcpTransportSession> activeSession = new AtomicReference<>();
+
+	private final AtomicReference<Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>>> handler = new AtomicReference<>();
+
+	private final AtomicReference<Consumer<Throwable>> exceptionHandler = new AtomicReference<>();
+
+	private HttpClientStreamableHttpTransport(ObjectMapper objectMapper, HttpClient httpClient,
+			HttpRequest.Builder requestBuilder, String baseUri, String endpoint, boolean resumableStreams,
+			boolean openConnectionOnStartup) {
+		this.objectMapper = objectMapper;
+		this.httpClient = httpClient;
+		this.requestBuilder = requestBuilder;
+		this.baseUri = URI.create(baseUri);
+		this.endpoint = endpoint;
+		this.resumableStreams = resumableStreams;
+		this.openConnectionOnStartup = openConnectionOnStartup;
+		this.activeSession.set(createTransportSession());
+	}
+
+	public static Builder builder(String baseUri) {
+		return new Builder(baseUri);
+	}
+
+	@Override
+	public Mono<Void> connect(Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>> handler) {
+		return Mono.deferContextual(ctx -> {
+			this.handler.set(handler);
+			if (openConnectionOnStartup) {
+				logger.debug("Eagerly opening connection on startup");
+				return this.reconnect(null).then();
+			}
+			return Mono.empty();
+		});
+	}
+
+	private DefaultMcpTransportSession createTransportSession() {
+		Function<String, Publisher<Void>> onClose = sessionId -> sessionId == null ? Mono.empty()
+				: createDelete(sessionId);
+		return new DefaultMcpTransportSession(onClose);
+	}
+
+	private Publisher<Void> createDelete(String sessionId) {
+
+		return Mono.defer(() -> { // Do we need to defer this?
+
+			HttpRequest request = this.requestBuilder.copy()
+				.uri(Utils.resolveUri(this.baseUri, this.endpoint))
+				.header("Cache-Control", "no-cache")
+				.header("mcp-session-id", sessionId)
+				.DELETE()
+				.build();
+
+			return Mono.fromFuture(() -> this.httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()))
+				.doOnError(e -> logger.warn("Got error when closing transport", e))
+				.then();
+		});
+	}
+
+	@Override
+	public void setExceptionHandler(Consumer<Throwable> handler) {
+		logger.debug("Exception handler registered");
+		this.exceptionHandler.set(handler);
+	}
+
+	private void handleException(Throwable t) {
+		logger.debug("Handling exception for session {}", sessionIdOrPlaceholder(this.activeSession.get()), t);
+		if (t instanceof McpTransportSessionNotFoundException) {
+			McpTransportSession<?> invalidSession = this.activeSession.getAndSet(createTransportSession());
+			logger.warn("Server does not recognize session {}. Invalidating.", invalidSession.sessionId());
+			invalidSession.close();
+		}
+		Consumer<Throwable> handler = this.exceptionHandler.get();
+		if (handler != null) {
+			handler.accept(t);
+		}
+	}
+
+	@Override
+	public Mono<Void> closeGracefully() {
+		return Mono.defer(() -> {
+			logger.debug("Graceful close triggered");
+			DefaultMcpTransportSession currentSession = this.activeSession.getAndSet(createTransportSession());
+			if (currentSession != null) {
+				return currentSession.closeGracefully();
+			}
+			return Mono.empty();
+		});
+	}
+
+	private Mono<Disposable> reconnect(McpTransportStream<Disposable> stream) {
+
+		return Mono.deferContextual(ctx -> {
+
+			if (stream != null) {
+				logger.debug("Reconnecting stream {} with lastId {}", stream.streamId(), stream.lastId());
+			}
+			else {
+				logger.debug("Reconnecting with no prior stream");
+			}
+
+			final AtomicReference<Disposable> disposableRef = new AtomicReference<>();
+			final McpTransportSession<Disposable> transportSession = this.activeSession.get();
+
+			HttpRequest.Builder requestBuilder = this.requestBuilder.copy();
+
+			if (transportSession != null && transportSession.sessionId().isPresent()) {
+				requestBuilder = requestBuilder.header("mcp-session-id", transportSession.sessionId().get());
+			}
+
+			if (stream != null && stream.lastId().isPresent()) {
+				requestBuilder = requestBuilder.header("last-event-id", stream.lastId().get());
+			}
+
+			HttpRequest request = requestBuilder.uri(Utils.resolveUri(this.baseUri, this.endpoint))
+				.header("Accept", TEXT_EVENT_STREAM)
+				.header("Cache-Control", "no-cache")
+				.GET()
+				.build();
+
+			Disposable connection = Flux.<ResponseEvent>create(sseSink -> this.httpClient.sendAsync(request,
+					responseInfo -> ResponseSubscribers.sseToBodySubscriber(responseInfo, sseSink))
+			// .whenComplete((response, throwable) -> {
+			// if (throwable != null) {
+			// sseSink.error(throwable);
+			// } else {
+			// int status = response.statusCode();
+			// if (status == METHOD_NOT_ALLOWED) { // NotAllowed
+			// logger.debug("The server does not support SSE streams, using
+			// request-response mode.");
+			// sseSink.complete();
+			// } else if (status == NOT_FOUND || status == BAD_REQUEST) { // NotFound
+			// String sessionIdRepresentation = sessionIdOrPlaceholder(transportSession);
+			// sseSink.error(new McpTransportSessionNotFoundException(
+			// "Session not found for session ID: " + sessionIdRepresentation));
+			// } else if (!isEventStream(response)) {
+			// String message = "Failed to connect to SSE stream. HTTP " +
+			// response.statusCode();
+			// if (response.body() != null) {
+			// message += ": " + response.body();
+			// }
+			// logger.info("Opening an SSE stream failed. This can be safely ignored." +
+			// message);
+			// sseSink.error(new RuntimeException(message));
+			// }
+			// // If status is OK, the lineSubscriber will handle the
+			// // stream
+			// logger.debug("Established SSE stream via GET");
+			// }
+			// })
+			).flatMap(responseEvent -> {
+				int statusCode = responseEvent.responseInfo().statusCode();
+
+				if (statusCode >= 200 && statusCode < 300) {
+
+					if (MESSAGE_EVENT_TYPE.equals(responseEvent.sseEvent().event())) {
+						try {
+							// We don't support batching ATM and probably won't since the
+							// next version considers removing it.
+							McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(this.objectMapper,
+									responseEvent.sseEvent().data());
+
+							Tuple2<Optional<String>, Iterable<McpSchema.JSONRPCMessage>> idWithMessages = Tuples
+								.of(Optional.ofNullable(responseEvent.sseEvent().id()), List.of(message));
+
+							McpTransportStream<Disposable> sessionStream = stream != null ? stream
+									: new DefaultMcpTransportStream<>(this.resumableStreams, this::reconnect);
+							logger.debug("Connected stream {}", sessionStream.streamId());
+
+							return Flux.from(sessionStream.consumeSseStream(Flux.just(idWithMessages)));
+
+						}
+						catch (IOException ioException) {
+							return Flux.<McpSchema.JSONRPCMessage>error(
+									new McpError("Error parsing JSON-RPC message: " + responseEvent.sseEvent().data()));
+						}
+					}
+				}
+				else if (statusCode == METHOD_NOT_ALLOWED) { // NotAllowed
+					logger.debug("The server does not support SSE streams, using request-response mode.");
+					return Flux.empty();
+				}
+				else if (statusCode == NOT_FOUND) {
+					String sessionIdRepresentation = sessionIdOrPlaceholder(transportSession);
+					McpTransportSessionNotFoundException exception = new McpTransportSessionNotFoundException(
+							"Session not found for session ID: " + sessionIdRepresentation);
+					return Flux.<McpSchema.JSONRPCMessage>error(exception);
+				}
+				else if (statusCode == BAD_REQUEST) {
+					String sessionIdRepresentation = sessionIdOrPlaceholder(transportSession);
+					McpTransportSessionNotFoundException exception = new McpTransportSessionNotFoundException(
+							"Session not found for session ID: " + sessionIdRepresentation);
+					return Flux.<McpSchema.JSONRPCMessage>error(exception);
+				}
+
+				return Flux.<McpSchema.JSONRPCMessage>error(
+						new McpError("Received unrecognized SSE event type: " + responseEvent.sseEvent().event()));
+
+			}).<McpSchema
+					.JSONRPCMessage>flatMap(jsonrpcMessage -> this.handler.get().apply(Mono.just(jsonrpcMessage)))
+				.onErrorComplete(t -> {
+					this.handleException(t);
+					return true;
+				})
+				.doFinally(s -> {
+					Disposable ref = disposableRef.getAndSet(null);
+					if (ref != null) {
+						transportSession.removeConnection(ref);
+					}
+				})
+				.contextWrite(ctx)
+				.subscribe();
+
+			disposableRef.set(connection);
+			transportSession.addConnection(connection);
+			return Mono.just(connection);
+		});
+
+	}
+
+	// private static boolean isEventStream(HttpResponse<Void> response) {
+	// String contentType =
+	// response.headers().firstValue("Content-Type").orElse("").toLowerCase();
+	// return response.statusCode() >= 200 && response.statusCode() < 300 &&
+	// contentType.contains(TEXT_EVENT_STREAM);
+	// }
+
+	private BodyHandler<Void> toSendMessageBodySubscriber(FluxSink<ResponseEvent> sink) {
+
+		BodyHandler<Void> responseBodyHandler = responseInfo -> {
+
+			String contentType = responseInfo.headers().firstValue("Content-Type").orElse("").toLowerCase();
+
+			if (contentType.contains(TEXT_EVENT_STREAM)) {
+				// For SSE streams, use line subscriber that returns Void
+				logger.debug("Received SSE stream response, using line subscriber");
+				return ResponseSubscribers.sseToBodySubscriber(responseInfo, sink);
+			}
+			else if (contentType.contains(APPLICATION_JSON)) {
+				// For JSON responses and others, use string subscriber
+				logger.debug("Received response, using string subscriber");
+				return ResponseSubscribers.jsonoBodySubscriber(responseInfo, sink);
+			}
+
+			logger.debug("Received Bodyless response, using discarding subscriber");
+			// return HttpResponse.BodySubscribers.discarding();
+			return ResponseSubscribers.bodylessBodySubscriber(responseInfo, sink);
+		};
+
+		return responseBodyHandler;
+
+	}
+
+	public String toString(McpSchema.JSONRPCMessage message) {
+		try {
+			return this.objectMapper.writeValueAsString(message);
+		}
+		catch (IOException e) {
+			throw new RuntimeException("Failed to serialize JSON-RPC message", e);
+		}
+	}
+
+	public Mono<Void> sendMessage(McpSchema.JSONRPCMessage sendMessage) {
+		return Mono.create(messageSink -> {
+			logger.debug("Sending message {}", sendMessage);
+
+			final AtomicReference<Disposable> disposableRef = new AtomicReference<>();
+			final McpTransportSession<Disposable> transportSession = this.activeSession.get();
+
+			HttpRequest.Builder requestBuilder = this.requestBuilder.copy();
+
+			if (transportSession != null && transportSession.sessionId().isPresent()) {
+				requestBuilder = requestBuilder.header("mcp-session-id", transportSession.sessionId().get());
+			}
+
+			String jsonBody = this.toString(sendMessage);
+
+			HttpRequest request = requestBuilder.uri(Utils.resolveUri(this.baseUri, this.endpoint))
+				.header("Accept", TEXT_EVENT_STREAM + ", " + APPLICATION_JSON)
+				.header("Content-Type", APPLICATION_JSON)
+				.header("Cache-Control", "no-cache")
+				.POST(HttpRequest.BodyPublishers.ofString(jsonBody))
+				.build();
+
+			Disposable connection = Flux.<ResponseEvent>create(responseEventSink -> {
+
+				// Create the async request with proper body subscriber selection
+				Mono.fromFuture(this.httpClient.sendAsync(request, this.toSendMessageBodySubscriber(responseEventSink))
+				// .whenComplete((res, e) -> {
+				// if (e != null) {
+				// logger.warn("Error sending message", e);
+				// responseEventSink.error(e);
+				// } else if (res.statusCode() == NOT_FOUND) {
+				// String sessionIdRepresentation =
+				// sessionIdOrPlaceholder(transportSession);
+				// McpTransportSessionNotFoundException exception = new
+				// McpTransportSessionNotFoundException(
+				// "Session not found for session ID: " + sessionIdRepresentation);
+				// this.handleException(exception);
+				// responseEventSink.error(exception);
+				// } else if (res.statusCode() == BAD_REQUEST) {
+				// System.out.println("BAD_REQUEST");
+				// } else {
+				// logger.debug("whenComplete complete: resp: {}, reqBode: {}", request,
+				// jsonBody);
+				// }
+				// })).doOnSubscribe(sub -> {
+				// logger.debug("OnSubscribe: {}, Sending message to server: {}", sub,
+				// jsonBody);
+				// }
+				).subscribe();
+
+			}).flatMap(responseEvent -> {
+				if (transportSession.markInitialized(
+						responseEvent.responseInfo().headers().firstValue("mcp-session-id").orElseGet(() -> null))) {
+					// Once we have a session, we try to open an async stream for
+					// the server to send notifications and requests out-of-band.
+
+					reconnect(null).contextWrite(messageSink.contextView()).subscribe();
+				}
+
+				String sessionRepresentation = sessionIdOrPlaceholder(transportSession);
+
+				int statusCode = responseEvent.responseInfo().statusCode();
+
+				if (statusCode >= 200 && statusCode < 300) {
+
+					String contentType = responseEvent.responseInfo()
+						.headers()
+						.firstValue("Content-Type")
+						.orElse("")
+						.toLowerCase();
+
+					if (contentType.isBlank()) {
+						logger.debug("No content type returned for POST in session {}", sessionRepresentation);
+						// No content type means no response body, so we can just return
+						// an empty stream
+						messageSink.success();
+						return Flux.empty();
+					}
+					else if (contentType.contains(TEXT_EVENT_STREAM)) {
+						try {
+							// We don't support batching ATM and probably won't since the
+							// next version considers removing it.
+							McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(this.objectMapper,
+									responseEvent.sseEvent().data());
+
+							Tuple2<Optional<String>, Iterable<McpSchema.JSONRPCMessage>> idWithMessages = Tuples
+								.of(Optional.ofNullable(responseEvent.sseEvent().id()), List.of(message));
+
+							McpTransportStream<Disposable> sessionStream = new DefaultMcpTransportStream<>(
+									this.resumableStreams, this::reconnect);
+
+							logger.debug("Connected stream {}", sessionStream.streamId());
+
+							messageSink.success();
+
+							return Flux.from(sessionStream.consumeSseStream(Flux.just(idWithMessages)));
+
+						}
+						catch (IOException ioException) {
+							return Flux.<McpSchema.JSONRPCMessage>error(
+									new McpError("Error parsing JSON-RPC message: " + responseEvent.sseEvent().data()));
+						}
+					}
+					else if (contentType.contains(APPLICATION_JSON)) {
+						McpSchema.JSONRPCMessage jsonRpcResponse = responseEvent.jsonRpcMessage();
+						messageSink.success();
+						return Flux.just(jsonRpcResponse); // ???
+					}
+					logger.warn("Unknown media type {} returned for POST in session {}", contentType,
+							sessionRepresentation);
+
+					return Flux.<McpSchema.JSONRPCMessage>error(
+							new RuntimeException("Unknown media type returned: " + contentType));
+				}
+				else if (statusCode == NOT_FOUND) {
+					McpTransportSessionNotFoundException exception = new McpTransportSessionNotFoundException(
+							"Session not found for session ID: " + sessionRepresentation);
+					return Flux.<McpSchema.JSONRPCMessage>error(exception);
+				}
+				// Some implementations can return 400 when presented with a
+				// session id that it doesn't know about, so we will
+				// invalidate the session
+				// https://github.com/modelcontextprotocol/typescript-sdk/issues/389
+				else if (statusCode == BAD_REQUEST) {
+					McpTransportSessionNotFoundException exception = new McpTransportSessionNotFoundException(
+							"Session not found for session ID: " + sessionRepresentation);
+					return Flux.<McpSchema.JSONRPCMessage>error(exception);
+				}
+
+				return Flux.<McpSchema.JSONRPCMessage>error(
+						new RuntimeException("Failed to send message: " + responseEvent));
+			}).flatMap(jsonRpcMessage -> this.handler.get().apply(Mono.just(jsonRpcMessage))).onErrorResume(t -> {
+				// handle the error first
+				this.handleException(t);
+				// inform the caller of sendMessage
+				messageSink.error(t);
+				return Flux.empty();
+			}).doFinally(s -> {
+				logger.debug("SendMessage finally: {}", s);
+				Disposable ref = disposableRef.getAndSet(null);
+				if (ref != null) {
+					transportSession.removeConnection(ref);
+				}
+			}).contextWrite(messageSink.contextView()).subscribe();
+
+			disposableRef.set(connection);
+			transportSession.addConnection(connection);
+		});
+	}
+
+	private static String sessionIdOrPlaceholder(McpTransportSession<?> transportSession) {
+		return transportSession.sessionId().orElse("[missing_session_id]");
+	}
+
+	@Override
+	public <T> T unmarshalFrom(Object data, TypeReference<T> typeRef) {
+		return this.objectMapper.convertValue(data, typeRef);
+	}
+
+	/**
+	 * Builder for {@link HttpClientStreamableHttpTransport}.
+	 */
+	public static class Builder {
+
+		private ObjectMapper objectMapper;
+
+		private String baseUri;
+
+		private HttpClient.Builder clientBuilder = HttpClient.newBuilder()
+			.version(HttpClient.Version.HTTP_1_1)
+			.connectTimeout(Duration.ofSeconds(10));
+
+		private String endpoint = DEFAULT_ENDPOINT;
+
+		private boolean resumableStreams = true;
+
+		private boolean openConnectionOnStartup = false;
+
+		private HttpRequest.Builder requestBuilder = HttpRequest.newBuilder();
+
+		/**
+		 * Creates a new builder with the specified base URI.
+		 * @param baseUri the base URI of the MCP server
+		 */
+		private Builder(String baseUri) {
+			Assert.hasText(baseUri, "baseUri must not be empty");
+			this.baseUri = baseUri;
+		}
+
+		/**
+		 * Sets the HTTP client builder.
+		 * @param clientBuilder the HTTP client builder
+		 * @return this builder
+		 */
+		public Builder clientBuilder(HttpClient.Builder clientBuilder) {
+			Assert.notNull(clientBuilder, "clientBuilder must not be null");
+			this.clientBuilder = clientBuilder;
+			return this;
+		}
+
+		/**
+		 * Customizes the HTTP client builder.
+		 * @param clientCustomizer the consumer to customize the HTTP client builder
+		 * @return this builder
+		 */
+		public Builder customizeClient(final Consumer<HttpClient.Builder> clientCustomizer) {
+			Assert.notNull(clientCustomizer, "clientCustomizer must not be null");
+			clientCustomizer.accept(clientBuilder);
+			return this;
+		}
+
+		/**
+		 * Sets the HTTP request builder.
+		 * @param requestBuilder the HTTP request builder
+		 * @return this builder
+		 */
+		public Builder requestBuilder(HttpRequest.Builder requestBuilder) {
+			Assert.notNull(requestBuilder, "requestBuilder must not be null");
+			this.requestBuilder = requestBuilder;
+			return this;
+		}
+
+		/**
+		 * Customizes the HTTP client builder.
+		 * @param requestCustomizer the consumer to customize the HTTP request builder
+		 * @return this builder
+		 */
+		public Builder customizeRequest(final Consumer<HttpRequest.Builder> requestCustomizer) {
+			Assert.notNull(requestCustomizer, "requestCustomizer must not be null");
+			requestCustomizer.accept(requestBuilder);
+			return this;
+		}
+
+		/**
+		 * Configure the {@link ObjectMapper} to use.
+		 * @param objectMapper instance to use
+		 * @return the builder instance
+		 */
+		public Builder objectMapper(ObjectMapper objectMapper) {
+			Assert.notNull(objectMapper, "ObjectMapper must not be null");
+			this.objectMapper = objectMapper;
+			return this;
+		}
+
+		/**
+		 * Configure the endpoint to make HTTP requests against.
+		 * @param endpoint endpoint to use
+		 * @return the builder instance
+		 */
+		public Builder endpoint(String endpoint) {
+			Assert.hasText(endpoint, "endpoint must be a non-empty String");
+			this.endpoint = endpoint;
+			return this;
+		}
+
+		/**
+		 * Configure whether to use the stream resumability feature by keeping track of
+		 * SSE event ids.
+		 * @param resumableStreams if {@code true} event ids will be tracked and upon
+		 * disconnection, the last seen id will be used upon reconnection as a header to
+		 * resume consuming messages.
+		 * @return the builder instance
+		 */
+		public Builder resumableStreams(boolean resumableStreams) {
+			this.resumableStreams = resumableStreams;
+			return this;
+		}
+
+		/**
+		 * Configure whether the client should open an SSE connection upon startup. Not
+		 * all servers support this (although it is in theory possible with the current
+		 * specification), so use with caution. By default, this value is {@code false}.
+		 * @param openConnectionOnStartup if {@code true} the {@link #connect(Function)}
+		 * method call will try to open an SSE connection before sending any JSON-RPC
+		 * request
+		 * @return the builder instance
+		 */
+		public Builder openConnectionOnStartup(boolean openConnectionOnStartup) {
+			this.openConnectionOnStartup = openConnectionOnStartup;
+			return this;
+		}
+
+		/**
+		 * Construct a fresh instance of {@link HttpClientStreamableHttpTransport} using
+		 * the current builder configuration.
+		 * @return a new instance of {@link HttpClientStreamableHttpTransport}
+		 */
+		public HttpClientStreamableHttpTransport build() {
+			ObjectMapper objectMapper = this.objectMapper != null ? this.objectMapper : new ObjectMapper();
+
+			return new HttpClientStreamableHttpTransport(objectMapper, clientBuilder.build(), requestBuilder, baseUri,
+					endpoint, resumableStreams, openConnectionOnStartup);
+		}
+
+	}
+
+}

--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/ResponseSubscribers.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/ResponseSubscribers.java
@@ -1,0 +1,354 @@
+/*
+* Copyright 2024 - 2024 the original author or authors.
+*/
+package io.modelcontextprotocol.client.transport;
+
+import java.io.IOException;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodySubscriber;
+import java.net.http.HttpResponse.ResponseInfo;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+
+import org.reactivestreams.FlowAdapters;
+import org.reactivestreams.Subscription;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.JSONRPCMessage;
+import reactor.core.publisher.BaseSubscriber;
+import reactor.core.publisher.FluxSink;
+
+public class ResponseSubscribers {
+
+	/**
+	 * Represents a Server-Sent Event with its standard fields.
+	 *
+	 * @param id the event ID, may be {@code null}
+	 * @param event the event type, may be {@code null} (defaults to "message")
+	 * @param data the event payload data, never {@code null}
+	 */
+	public static record SseEvent(String id, String event, String data) {
+	}
+
+	public record ResponseEvent(ResponseInfo responseInfo, SseEvent sseEvent, JSONRPCMessage jsonRpcMessage) {
+
+		public ResponseEvent(ResponseInfo responseInfo, SseEvent sseEvent) {
+			this(responseInfo, sseEvent, null);
+		}
+
+		public ResponseEvent(ResponseInfo responseInfo, JSONRPCMessage jsonRpcMessage) {
+			this(responseInfo, null, jsonRpcMessage);
+		}
+	}
+
+	public static BodySubscriber<Void> sseToBodySubscriber(ResponseInfo responseInfo, FluxSink<ResponseEvent> sink) {
+		return HttpResponse.BodySubscribers
+			.fromLineSubscriber(FlowAdapters.toFlowSubscriber(new SseLineSubscriber(responseInfo, sink)));
+	}
+
+	public static BodySubscriber<Void> jsonoBodySubscriber(ResponseInfo responseInfo, FluxSink<ResponseEvent> sink) {
+		return HttpResponse.BodySubscribers
+			.fromLineSubscriber(FlowAdapters.toFlowSubscriber(new JsonLineSubscriber(responseInfo, sink)));
+	}
+
+	public static BodySubscriber<Void> bodylessBodySubscriber(ResponseInfo responseInfo, FluxSink<ResponseEvent> sink) {
+		return HttpResponse.BodySubscribers
+			.fromLineSubscriber(FlowAdapters.toFlowSubscriber(new BodylessResponseLineSubscriber(responseInfo, sink)));
+	}
+
+	public static class SseLineSubscriber extends BaseSubscriber<String> {
+
+		/**
+		 * Pattern to extract data content from SSE "data:" lines.
+		 */
+		private static final Pattern EVENT_DATA_PATTERN = Pattern.compile("^data:(.+)$", Pattern.MULTILINE);
+
+		/**
+		 * Pattern to extract event ID from SSE "id:" lines.
+		 */
+		private static final Pattern EVENT_ID_PATTERN = Pattern.compile("^id:(.+)$", Pattern.MULTILINE);
+
+		/**
+		 * Pattern to extract event type from SSE "event:" lines.
+		 */
+		private static final Pattern EVENT_TYPE_PATTERN = Pattern.compile("^event:(.+)$", Pattern.MULTILINE);
+
+		/**
+		 * The sink for emitting parsed response events.
+		 */
+		private final FluxSink<ResponseEvent> sink;
+
+		/**
+		 * StringBuilder for accumulating multi-line event data.
+		 */
+		private final StringBuilder eventBuilder;
+
+		/**
+		 * Current event's ID, if specified.
+		 */
+		private final AtomicReference<String> currentEventId;
+
+		/**
+		 * Current event's type, if specified.
+		 */
+		private final AtomicReference<String> currentEventType;
+
+		/**
+		 * The response information from the HTTP response. Send with each event to
+		 * provide context.
+		 */
+		private ResponseInfo responseInfo;
+
+		/**
+		 * Creates a new LineSubscriber that will emit parsed SSE events to the provided
+		 * sink.
+		 * @param sink the {@link FluxSink} to emit parsed {@link ResponseEvent} objects
+		 * to
+		 */
+		public SseLineSubscriber(ResponseInfo responseInfo, FluxSink<ResponseEvent> sink) {
+			this.sink = sink;
+			this.eventBuilder = new StringBuilder();
+			this.currentEventId = new AtomicReference<>();
+			this.currentEventType = new AtomicReference<>();
+			this.responseInfo = responseInfo;
+		}
+
+		/**
+		 * Initializes the subscription and sets up disposal callback.
+		 * @param subscription the {@link Subscription} to the upstream line source
+		 */
+		@Override
+		protected void hookOnSubscribe(Subscription subscription) {
+
+			sink.onRequest(n -> {
+				if (subscription != null) {
+					subscription.request(n);
+				}
+			});
+
+			// Register disposal callback to cancel subscription when Flux is disposed
+			sink.onDispose(() -> {
+				if (subscription != null) {
+					subscription.cancel();
+				}
+			});
+		}
+
+		/**
+		 * Processes each line from the SSE stream according to the SSE protocol. Empty
+		 * lines trigger event emission, other lines are parsed for data, id, or event
+		 * type.
+		 * @param line the line to process from the SSE stream
+		 */
+		@Override
+		protected void hookOnNext(String line) {
+			if (line.isEmpty()) {
+				// Empty line means end of event
+				if (this.eventBuilder.length() > 0) {
+					String eventData = this.eventBuilder.toString();
+					SseEvent sseEvent = new SseEvent(currentEventId.get(), currentEventType.get(), eventData.trim());
+
+					this.sink.next(new ResponseEvent(responseInfo, sseEvent));
+					this.eventBuilder.setLength(0);
+				}
+			}
+			else {
+				if (line.startsWith("data:")) {
+					var matcher = EVENT_DATA_PATTERN.matcher(line);
+					if (matcher.find()) {
+						this.eventBuilder.append(matcher.group(1).trim()).append("\n");
+					}
+				}
+				else if (line.startsWith("id:")) {
+					var matcher = EVENT_ID_PATTERN.matcher(line);
+					if (matcher.find()) {
+						this.currentEventId.set(matcher.group(1).trim());
+					}
+				}
+				else if (line.startsWith("event:")) {
+					var matcher = EVENT_TYPE_PATTERN.matcher(line);
+					if (matcher.find()) {
+						this.currentEventType.set(matcher.group(1).trim());
+					}
+				}
+			}
+		}
+
+		/**
+		 * Called when the upstream line source completes normally.
+		 */
+		@Override
+		protected void hookOnComplete() {
+			if (this.eventBuilder.length() > 0) {
+				String eventData = this.eventBuilder.toString();
+				SseEvent sseEvent = new SseEvent(currentEventId.get(), currentEventType.get(), eventData.trim());
+				this.sink.next(new ResponseEvent(responseInfo, sseEvent));
+			}
+			this.sink.complete();
+		}
+
+		/**
+		 * Called when an error occurs in the upstream line source.
+		 * @param throwable the error that occurred
+		 */
+		@Override
+		protected void hookOnError(Throwable throwable) {
+			this.sink.error(throwable);
+		}
+
+	}
+
+	public static class JsonLineSubscriber extends BaseSubscriber<String> {
+
+		private ObjectMapper objectMapper = new ObjectMapper();
+
+		/**
+		 * The sink for emitting parsed response events.
+		 */
+		private final FluxSink<ResponseEvent> sink;
+
+		/**
+		 * StringBuilder for accumulating multi-line event data.
+		 */
+		private final StringBuilder eventBuilder;
+
+		/**
+		 * The response information from the HTTP response. Send with each event to
+		 * provide context.
+		 */
+		private ResponseInfo responseInfo;
+
+		/**
+		 * Creates a new JsonLineSubscriber that will emit parsed JSON-RPC messages.
+		 * @param sink the {@link FluxSink} to emit parsed {@link ResponseEvent} objects
+		 * to
+		 */
+		public JsonLineSubscriber(ResponseInfo responseInfo, FluxSink<ResponseEvent> sink) {
+			this.sink = sink;
+			this.eventBuilder = new StringBuilder();
+			this.responseInfo = responseInfo;
+		}
+
+		/**
+		 * Initializes the subscription and sets up disposal callback.
+		 * @param subscription the {@link Subscription} to the upstream line source
+		 */
+		@Override
+		protected void hookOnSubscribe(Subscription subscription) {
+
+			sink.onRequest(n -> {
+				if (subscription != null) {
+					subscription.request(n);
+				}
+			});
+
+			// Register disposal callback to cancel subscription when Flux is disposed
+			sink.onDispose(() -> {
+				if (subscription != null) {
+					subscription.cancel();
+				}
+			});
+		}
+
+		/**
+		 * Aggregate each line from the Http response.
+		 * @param line next line to process from the Http response
+		 */
+		@Override
+		protected void hookOnNext(String line) {
+			this.eventBuilder.append(line).append("\n");
+		}
+
+		/**
+		 * Called when the upstream line source completes normally.
+		 */
+		@Override
+		protected void hookOnComplete() {
+			if (this.eventBuilder.length() > 0) {
+				String jsonData = this.eventBuilder.toString();
+				try {
+					McpSchema.JSONRPCMessage jsonRpcResponse = McpSchema.deserializeJsonRpcMessage(objectMapper,
+							jsonData);
+					this.sink.next(new ResponseEvent(responseInfo, jsonRpcResponse));
+				}
+				catch (IOException e) {
+					sink.error(e);
+				}
+			}
+			this.sink.complete();
+		}
+
+		/**
+		 * Called when an error occurs in the upstream line source.
+		 * @param throwable the error that occurred
+		 */
+		@Override
+		protected void hookOnError(Throwable throwable) {
+			this.sink.error(throwable);
+		}
+
+	}
+
+	public static class BodylessResponseLineSubscriber extends BaseSubscriber<String> {
+
+		/**
+		 * The sink for emitting parsed response events.
+		 */
+		private final FluxSink<ResponseEvent> sink;
+
+		private final ResponseInfo responseInfo;
+
+		public BodylessResponseLineSubscriber(ResponseInfo responseInfo, FluxSink<ResponseEvent> sink) {
+			this.sink = sink;
+			this.responseInfo = responseInfo;
+		}
+
+		/**
+		 * Initializes the subscription and sets up disposal callback.
+		 * @param subscription the {@link Subscription} to the upstream line source
+		 */
+		@Override
+		protected void hookOnSubscribe(Subscription subscription) {
+
+			sink.onRequest(n -> {
+				if (subscription != null) {
+					subscription.request(n);
+				}
+			});
+
+			// Register disposal callback to cancel subscription when Flux is disposed
+			sink.onDispose(() -> {
+				if (subscription != null) {
+					subscription.cancel();
+				}
+			});
+		}
+
+		@Override
+		protected void hookOnNext(String line) {
+			System.out.println(">>>>>>>>>>>>>> Received line: " + line);
+		}
+
+		/**
+		 * Called when the upstream line source completes normally.
+		 */
+		@Override
+		protected void hookOnComplete() {
+			this.sink.next(new ResponseEvent(responseInfo, new SseEvent(null, null, null)));
+			this.sink.complete();
+		}
+
+		/**
+		 * Called when an error occurs in the upstream line source.
+		 * @param throwable the error that occurred
+		 */
+		@Override
+		protected void hookOnError(Throwable throwable) {
+			this.sink.error(throwable);
+		}
+
+	}
+
+}

--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/StdioClientTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/StdioClientTransport.java
@@ -362,7 +362,7 @@ public class StdioClientTransport implements McpClientTransport {
 			}
 			else {
 				logger.warn("Process not started");
-				return Mono.empty();
+				return Mono.<Process>empty();
 			}
 		})).doOnNext(process -> {
 			if (process.exitValue() != 0) {

--- a/mcp/src/test/java/io/modelcontextprotocol/MockMcpServerTransportProvider.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/MockMcpServerTransportProvider.java
@@ -15,8 +15,6 @@
 */
 package io.modelcontextprotocol;
 
-import java.util.Map;
-
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpServerSession;
 import io.modelcontextprotocol.spec.McpServerSession.Factory;

--- a/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientResiliencyTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientResiliencyTests.java
@@ -1,0 +1,222 @@
+package io.modelcontextprotocol.client;
+
+import eu.rekawek.toxiproxy.Proxy;
+import eu.rekawek.toxiproxy.ToxiproxyClient;
+import eu.rekawek.toxiproxy.model.ToxicDirection;
+import io.modelcontextprotocol.spec.McpClientTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpTransport;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Resiliency test suite for the {@link McpAsyncClient} that can be used with different
+ * {@link McpTransport} implementations that support Streamable HTTP.
+ *
+ * The purpose of these tests is to allow validating the transport layer resiliency
+ * instead of the functionality offered by the logical layer of MCP concepts such as
+ * tools, resources, prompts, etc.
+ *
+ * @author Dariusz Jędrzejczyk
+ */
+public abstract class AbstractMcpAsyncClientResiliencyTests {
+
+	private static final Logger logger = LoggerFactory.getLogger(AbstractMcpAsyncClientResiliencyTests.class);
+
+	static Network network = Network.newNetwork();
+	static String host = "http://localhost:3001";
+
+	// Uses the https://github.com/tzolov/mcp-everything-server-docker-image
+	@SuppressWarnings("resource")
+	static GenericContainer<?> container = new GenericContainer<>("docker.io/tzolov/mcp-everything-server:v2")
+		.withCommand("node dist/index.js streamableHttp")
+		.withLogConsumer(outputFrame -> System.out.println(outputFrame.getUtf8String()))
+		.withNetwork(network)
+		.withNetworkAliases("everything-server")
+		.withExposedPorts(3001)
+		.waitingFor(Wait.forHttp("/").forStatusCode(404));
+
+	static ToxiproxyContainer toxiproxy = new ToxiproxyContainer("ghcr.io/shopify/toxiproxy:2.5.0").withNetwork(network)
+		.withExposedPorts(8474, 3000);
+
+	static Proxy proxy;
+
+	static {
+		container.start();
+
+		toxiproxy.start();
+
+		final ToxiproxyClient toxiproxyClient = new ToxiproxyClient(toxiproxy.getHost(), toxiproxy.getControlPort());
+		try {
+			proxy = toxiproxyClient.createProxy("everything-server", "0.0.0.0:3000", "everything-server:3001");
+		}
+		catch (IOException e) {
+			throw new RuntimeException("Can't create proxy!", e);
+		}
+
+		final String ipAddressViaToxiproxy = toxiproxy.getHost();
+		final int portViaToxiproxy = toxiproxy.getMappedPort(3000);
+
+		host = "http://" + ipAddressViaToxiproxy + ":" + portViaToxiproxy;
+	}
+
+	static void disconnect() {
+		long start = System.nanoTime();
+		try {
+			// disconnect
+			// proxy.toxics().bandwidth("CUT_CONNECTION_DOWNSTREAM",
+			// ToxicDirection.DOWNSTREAM, 0);
+			// proxy.toxics().bandwidth("CUT_CONNECTION_UPSTREAM",
+			// ToxicDirection.UPSTREAM, 0);
+			proxy.toxics().resetPeer("RESET_DOWNSTREAM", ToxicDirection.DOWNSTREAM, 0);
+			proxy.toxics().resetPeer("RESET_UPSTREAM", ToxicDirection.UPSTREAM, 0);
+			logger.info("Disconnect took {} ms", Duration.ofNanos(System.nanoTime() - start).toMillis());
+		}
+		catch (IOException e) {
+			throw new RuntimeException("Failed to disconnect", e);
+		}
+	}
+
+	static void reconnect() {
+		long start = System.nanoTime();
+		try {
+			proxy.toxics().get("RESET_UPSTREAM").remove();
+			proxy.toxics().get("RESET_DOWNSTREAM").remove();
+			// proxy.toxics().get("CUT_CONNECTION_DOWNSTREAM").remove();
+			// proxy.toxics().get("CUT_CONNECTION_UPSTREAM").remove();
+			logger.info("Reconnect took {} ms", Duration.ofNanos(System.nanoTime() - start).toMillis());
+		}
+		catch (IOException e) {
+			throw new RuntimeException("Failed to reconnect", e);
+		}
+	}
+
+	static void restartMcpServer() {
+		container.stop();
+		container.start();
+	}
+
+	abstract McpClientTransport createMcpTransport();
+
+	protected Duration getRequestTimeout() {
+		return Duration.ofSeconds(14);
+	}
+
+	protected Duration getInitializationTimeout() {
+		return Duration.ofSeconds(2);
+	}
+
+	McpAsyncClient client(McpClientTransport transport) {
+		return client(transport, Function.identity());
+	}
+
+	McpAsyncClient client(McpClientTransport transport, Function<McpClient.AsyncSpec, McpClient.AsyncSpec> customizer) {
+		AtomicReference<McpAsyncClient> client = new AtomicReference<>();
+
+		assertThatCode(() -> {
+			McpClient.AsyncSpec builder = McpClient.async(transport)
+				.requestTimeout(getRequestTimeout())
+				.initializationTimeout(getInitializationTimeout())
+				.capabilities(McpSchema.ClientCapabilities.builder().roots(true).build());
+			builder = customizer.apply(builder);
+			client.set(builder.build());
+		}).doesNotThrowAnyException();
+
+		return client.get();
+	}
+
+	void withClient(McpClientTransport transport, Consumer<McpAsyncClient> c) {
+		withClient(transport, Function.identity(), c);
+	}
+
+	void withClient(McpClientTransport transport, Function<McpClient.AsyncSpec, McpClient.AsyncSpec> customizer,
+			Consumer<McpAsyncClient> c) {
+		var client = client(transport, customizer);
+		try {
+			c.accept(client);
+		}
+		finally {
+			StepVerifier.create(client.closeGracefully()).expectComplete().verify(Duration.ofSeconds(10));
+		}
+	}
+
+	@Test
+	void testPing() {
+		withClient(createMcpTransport(), mcpAsyncClient -> {
+			StepVerifier.create(mcpAsyncClient.initialize()).expectNextCount(1).verifyComplete();
+
+			disconnect();
+
+			StepVerifier.create(mcpAsyncClient.ping()).expectError().verify();
+
+			reconnect();
+
+			StepVerifier.create(mcpAsyncClient.ping()).expectNextCount(1).verifyComplete();
+		});
+	}
+
+	@Test
+	void testSessionInvalidation() {
+		withClient(createMcpTransport(), mcpAsyncClient -> {
+			StepVerifier.create(mcpAsyncClient.initialize()).expectNextCount(1).verifyComplete();
+
+			restartMcpServer();
+
+			// The first try will face the session mismatch exception and the second one
+			// will go through the re-initialization process.
+			StepVerifier.create(mcpAsyncClient.ping().retry(1)).expectNextCount(1).verifyComplete();
+		});
+	}
+
+	@Test
+	void testCallTool() {
+		withClient(createMcpTransport(), mcpAsyncClient -> {
+			AtomicReference<List<McpSchema.Tool>> tools = new AtomicReference<>();
+			StepVerifier.create(mcpAsyncClient.initialize()).expectNextCount(1).verifyComplete();
+			StepVerifier.create(mcpAsyncClient.listTools())
+				.consumeNextWith(list -> tools.set(list.tools()))
+				.verifyComplete();
+
+			disconnect();
+
+			String name = tools.get().get(0).name();
+			// Assuming this is the echo tool
+			McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(name, Map.of("message", "hello"));
+			StepVerifier.create(mcpAsyncClient.callTool(request)).expectError().verify();
+
+			reconnect();
+
+			StepVerifier.create(mcpAsyncClient.callTool(request)).expectNextCount(1).verifyComplete();
+		});
+	}
+
+	@Test
+	void testSessionClose() {
+		withClient(createMcpTransport(), mcpAsyncClient -> {
+			StepVerifier.create(mcpAsyncClient.initialize()).expectNextCount(1).verifyComplete();
+			// In case of Streamable HTTP this call should issue a HTTP DELETE request
+			// invalidating the session
+			StepVerifier.create(mcpAsyncClient.closeGracefully()).expectComplete().verify();
+			// The next use should immediately re-initialize with no issue and send the
+			// request without any broken connections.
+			StepVerifier.create(mcpAsyncClient.ping()).expectNextCount(1).verifyComplete();
+		});
+	}
+
+}

--- a/mcp/src/test/java/io/modelcontextprotocol/client/HttpClientStreamableHttpAsyncClientResiliencyTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/HttpClientStreamableHttpAsyncClientResiliencyTests.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ */
+
+package io.modelcontextprotocol.client;
+
+import org.junit.jupiter.api.Timeout;
+
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.spec.McpClientTransport;
+
+@Timeout(15)
+public class HttpClientStreamableHttpAsyncClientResiliencyTests extends AbstractMcpAsyncClientResiliencyTests {
+
+	@Override
+	protected McpClientTransport createMcpTransport() {
+		return HttpClientStreamableHttpTransport.builder(host).build();
+	}
+
+}

--- a/mcp/src/test/java/io/modelcontextprotocol/client/HttpClientStreamableHttpAsyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/HttpClientStreamableHttpAsyncClientTests.java
@@ -1,17 +1,16 @@
 package io.modelcontextprotocol.client;
 
 import org.junit.jupiter.api.Timeout;
-import org.springframework.web.reactive.function.client.WebClient;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
-import io.modelcontextprotocol.client.transport.WebClientStreamableHttpTransport;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
 import io.modelcontextprotocol.spec.McpClientTransport;
 
 @Timeout(15)
-public class WebClientStreamableHttpAsyncClientTests extends AbstractMcpAsyncClientTests {
+public class HttpClientStreamableHttpAsyncClientTests extends AbstractMcpAsyncClientTests {
 
-	static String host = "http://localhost:3001";
+	private String host = "http://localhost:3001";
 
 	// Uses the https://github.com/tzolov/mcp-everything-server-docker-image
 	@SuppressWarnings("resource")
@@ -23,7 +22,8 @@ public class WebClientStreamableHttpAsyncClientTests extends AbstractMcpAsyncCli
 
 	@Override
 	protected McpClientTransport createMcpTransport() {
-		return WebClientStreamableHttpTransport.builder(WebClient.builder().baseUrl(host)).build();
+
+		return HttpClientStreamableHttpTransport.builder(host).build();
 	}
 
 	@Override

--- a/mcp/src/test/java/io/modelcontextprotocol/client/HttpClientStreamableHttpSyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/HttpClientStreamableHttpSyncClientTests.java
@@ -1,15 +1,14 @@
 package io.modelcontextprotocol.client;
 
 import org.junit.jupiter.api.Timeout;
-import org.springframework.web.reactive.function.client.WebClient;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
-import io.modelcontextprotocol.client.transport.WebClientStreamableHttpTransport;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
 import io.modelcontextprotocol.spec.McpClientTransport;
 
 @Timeout(15)
-public class WebClientStreamableHttpAsyncClientTests extends AbstractMcpAsyncClientTests {
+public class HttpClientStreamableHttpSyncClientTests extends AbstractMcpSyncClientTests {
 
 	static String host = "http://localhost:3001";
 
@@ -23,7 +22,7 @@ public class WebClientStreamableHttpAsyncClientTests extends AbstractMcpAsyncCli
 
 	@Override
 	protected McpClientTransport createMcpTransport() {
-		return WebClientStreamableHttpTransport.builder(WebClient.builder().baseUrl(host)).build();
+		return HttpClientStreamableHttpTransport.builder(host).build();
 	}
 
 	@Override

--- a/mcp/src/test/java/io/modelcontextprotocol/client/HttpSseMcpAsyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/HttpSseMcpAsyncClientTests.java
@@ -4,11 +4,12 @@
 
 package io.modelcontextprotocol.client;
 
-import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
-import io.modelcontextprotocol.spec.McpClientTransport;
 import org.junit.jupiter.api.Timeout;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+
+import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.spec.McpClientTransport;
 
 /**
  * Tests for the {@link McpSyncClient} with {@link HttpClientSseClientTransport}.

--- a/mcp/src/test/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransportTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransportTests.java
@@ -7,23 +7,20 @@ package io.modelcontextprotocol.client.transport;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.JSONRPCRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import reactor.core.publisher.Mono;
@@ -34,11 +31,6 @@ import org.springframework.http.codec.ServerSentEvent;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Tests for the {@link HttpClientSseClientTransport} class.
@@ -369,27 +361,6 @@ class HttpClientSseClientTransportTests {
 
 		// Clean up
 		customizedTransport.closeGracefully().block();
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	void testResolvingClientEndpoint() {
-		HttpClient httpClient = Mockito.mock(HttpClient.class);
-		HttpResponse<Void> httpResponse = Mockito.mock(HttpResponse.class);
-		CompletableFuture<HttpResponse<Void>> future = new CompletableFuture<>();
-		future.complete(httpResponse);
-		when(httpClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(future);
-
-		HttpClientSseClientTransport transport = new HttpClientSseClientTransport(httpClient, HttpRequest.newBuilder(),
-				"http://example.com", "http://example.com/sse", new ObjectMapper());
-
-		transport.connect(Function.identity());
-
-		ArgumentCaptor<HttpRequest> httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
-		verify(httpClient).sendAsync(httpRequestCaptor.capture(), any(HttpResponse.BodyHandler.class));
-		assertThat(httpRequestCaptor.getValue().uri()).isEqualTo(URI.create("http://example.com/sse"));
-
-		transport.closeGracefully().block();
 	}
 
 }

--- a/mcp/src/test/resources/logback.xml
+++ b/mcp/src/test/resources/logback.xml
@@ -16,6 +16,9 @@
 
     <!-- Spec package -->
     <logger name="org.springframework.ai.mcp.spec" level="INFO"/>
+    
+    <logger name="io.modelcontextprotocol.spec.McpClientSession" level="DEBUG"/>
+    <logger name="io.modelcontextprotocol.client.transport" level="DEBUG"/>
 
     <!-- Root logger -->
     <root level="INFO">


### PR DESCRIPTION
This change improves the transport layer with reactive patterns and adds support for the latest MCP specification while maintaining backward compatibility with existing SSE transport.

- Add HttpClientStreamableHttpTransport implementing 2025-03-26 MCP Streamable HTTP spec
- Add ResponseSubscribers utility for handling SSE and JSON HTTP responses
- Refactor HttpClientSseClientTransport to use reactive streams instead of CompletableFuture
  - Replace FlowSseClient with direct reactive stream handling
  - Use Disposable-based connection management instead of CountDownLatch
  - Replace message endpoint discovery with Sinks.One approach
- Add resiliency tests using Toxiproxy for network failure scenarios
- Minor type safety improvements in StdioClientTransport and DefaultMcpTransportStream

