### PR TITLE
docs: Fix broken references in Javadoc

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerTransportProvider.java
@@ -44,7 +44,7 @@ public interface McpServerTransportProvider {
 	 * @param method the name of the notification method to be called on the clients
 	 * @param params parameters to be sent with the notification
 	 * @return a Mono that completes when the notification has been broadcast
-	 * @see McpSession#sendNotification(String, Map)
+	 * @see McpSession#sendNotification(String, Object)
 	 */
 	Mono<Void> notifyClients(String method, Object params);
 

--- a/mcp/src/main/java/io/modelcontextprotocol/util/DefaultMcpUriTemplateManager.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/util/DefaultMcpUriTemplateManager.java
@@ -30,7 +30,8 @@ public class DefaultMcpUriTemplateManager implements McpUriTemplateManager {
 
 	/**
 	 * Constructor for DefaultMcpUriTemplateManager.
-	 * @param uriTemplate The URI template to be used for variable extraction
+	 * @param uriTemplate The URI template to be used for variable extraction should be in
+	 * the format {variableName}
 	 */
 	public DefaultMcpUriTemplateManager(String uriTemplate) {
 		if (uriTemplate == null || uriTemplate.isEmpty()) {
@@ -41,8 +42,6 @@ public class DefaultMcpUriTemplateManager implements McpUriTemplateManager {
 
 	/**
 	 * Extract URI variable names from a URI template.
-	 * @param uriTemplate The URI template containing variables in the format
-	 * {variableName}
 	 * @return A list of variable names extracted from the template
 	 * @throws IllegalArgumentException if duplicate variable names are found
 	 */

--- a/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpAsyncServerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpAsyncServerTests.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Test suite for the {@link McpAsyncServer} that can be used with different
- * {@link McpTransportProvider} implementations.
+ * {@link McpServerTransportProvider} implementations.
  *
  * @author Christian Tzolov
  */

--- a/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Test suite for the {@link McpSyncServer} that can be used with different
- * {@link McpTransportProvider} implementations.
+ * {@link McpServerTransportProvider} implementations.
  *
  * @author Christian Tzolov
  */

--- a/mcp/src/test/java/io/modelcontextprotocol/server/StdioMcpAsyncServerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/StdioMcpAsyncServerTests.java
@@ -9,7 +9,7 @@ import io.modelcontextprotocol.spec.McpServerTransportProvider;
 import org.junit.jupiter.api.Timeout;
 
 /**
- * Tests for {@link McpAsyncServer} using {@link StdioServerTransport}.
+ * Tests for {@link McpAsyncServer} using {@link StdioServerTransportProvider}.
  *
  * @author Christian Tzolov
  */


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
1. Fix incorrect links in Javadoc.
2. Move the `uriTemplate` doc to the `DefaultMcpUriTemplateManager` constructor. 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
For point 2, it's because there's no uriTemplate parameter in getVariableNames.

