### PR TITLE
feat: Added optional title field to `resource`, `tool`, `prompt`

### DIFF
--- a/mcp/src/test/java/io/modelcontextprotocol/client/McpAsyncClientResponseHandlerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/McpAsyncClientResponseHandlerTests.java
@@ -207,8 +207,14 @@ class McpAsyncClientResponseHandlerTests {
 		assertThat(asyncMcpClient.initialize().block()).isNotNull();
 
 		// Create a mock resources list that the server will return
-		McpSchema.Resource mockResource = new McpSchema.Resource("test://resource", "Test Resource", "A test resource",
-				"text/plain", null);
+		McpSchema.Resource mockResource = McpSchema.Resource.builder()
+				.uri("test://resource")
+				.name("Test Resource")
+				.title("A Test Resource")
+				.description("A test resource")
+				.mimeType("text/plain")
+				.annotations(null)
+				.build();
 		McpSchema.ListResourcesResult mockResourcesResult = new McpSchema.ListResourcesResult(List.of(mockResource),
 				null);
 
@@ -229,6 +235,7 @@ class McpAsyncClientResponseHandlerTests {
 		assertThat(receivedResources).hasSize(1);
 		assertThat(receivedResources.get(0).uri()).isEqualTo("test://resource");
 		assertThat(receivedResources.get(0).name()).isEqualTo("Test Resource");
+		assertThat(receivedResources.get(0).title()).isEqualTo("A Test Resource");
 		assertThat(receivedResources.get(0).description()).isEqualTo("A test resource");
 
 		asyncMcpClient.closeGracefully();

--- a/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpAsyncServerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpAsyncServerTests.java
@@ -212,8 +212,14 @@ public abstract class AbstractMcpAsyncServerTests {
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
 			.build();
 
-		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "text/plain", "Test resource description",
-				null);
+		Resource resource = Resource.builder()
+				.uri(TEST_RESOURCE_URI)
+				.name("Test Resource")
+				.title("A Test Resource")
+				.mimeType("text/plain")
+				.description("Test resource description")
+				.annotations(null)
+				.build();
 		McpServerFeatures.AsyncResourceSpecification specification = new McpServerFeatures.AsyncResourceSpecification(
 				resource, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
 
@@ -244,8 +250,15 @@ public abstract class AbstractMcpAsyncServerTests {
 			.serverInfo("test-server", "1.0.0")
 			.build();
 
-		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "text/plain", "Test resource description",
-				null);
+		Resource resource = Resource.builder()
+				.uri(TEST_RESOURCE_URI)
+				.name("Test Resource")
+				.title("A Test Resource")
+				.mimeType("text/plain")
+				.description("Test resource description")
+				.annotations(null)
+				.build();
+
 		McpServerFeatures.AsyncResourceSpecification specification = new McpServerFeatures.AsyncResourceSpecification(
 				resource, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
 

--- a/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
@@ -208,8 +208,15 @@ public abstract class AbstractMcpSyncServerTests {
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
 			.build();
 
-		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "text/plain", "Test resource description",
-				null);
+		Resource resource = Resource.builder()
+				.uri(TEST_RESOURCE_URI)
+				.name("Test Resource")
+				.title("A Test Resource")
+				.mimeType("text/plain")
+				.description("Test resource description")
+				.annotations(null)
+				.build();
+
 		McpServerFeatures.SyncResourceSpecification specification = new McpServerFeatures.SyncResourceSpecification(
 				resource, (exchange, req) -> new ReadResourceResult(List.of()));
 
@@ -238,8 +245,15 @@ public abstract class AbstractMcpSyncServerTests {
 			.serverInfo("test-server", "1.0.0")
 			.build();
 
-		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "text/plain", "Test resource description",
-				null);
+		Resource resource = Resource.builder()
+				.uri(TEST_RESOURCE_URI)
+				.name("Test Resource")
+				.title("A Test Resource")
+				.mimeType("text/plain")
+				.description("Test resource description")
+				.annotations(null)
+				.build();
+
 		McpServerFeatures.SyncResourceSpecification specification = new McpServerFeatures.SyncResourceSpecification(
 				resource, (exchange, req) -> new ReadResourceResult(List.of()));
 

--- a/mcp/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
@@ -284,8 +284,14 @@ public class McpSchemaTests {
 		McpSchema.Annotations annotations = new McpSchema.Annotations(
 				Arrays.asList(McpSchema.Role.USER, McpSchema.Role.ASSISTANT), 0.8);
 
-		McpSchema.Resource resource = new McpSchema.Resource("resource://test", "Test Resource", "A test resource",
-				"text/plain", annotations);
+		McpSchema.Resource resource = McpSchema.Resource.builder()
+				.uri("resource://test")
+				.name("Test Resource")
+				.title("A Test Resource")
+				.mimeType("text/plain")
+				.description("A test resource")
+				.annotations(annotations)
+				.build();
 
 		String value = mapper.writeValueAsString(resource);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -293,7 +299,7 @@ public class McpSchemaTests {
 			.isObject()
 			.isEqualTo(
 					json("""
-							{"uri":"resource://test","name":"Test Resource","description":"A test resource","mimeType":"text/plain","annotations":{"audience":["user","assistant"],"priority":0.8}}"""));
+							{"uri":"resource://test","name":"Test Resource","title":"A Test Resource","description":"A test resource","mimeType":"text/plain","annotations":{"audience":["user","assistant"],"priority":0.8}}"""));
 	}
 
 	@Test
@@ -367,11 +373,21 @@ public class McpSchemaTests {
 
 	@Test
 	void testListResourcesResult() throws Exception {
-		McpSchema.Resource resource1 = new McpSchema.Resource("resource://test1", "Test Resource 1",
-				"First test resource", "text/plain", null);
+		McpSchema.Resource resource1 = McpSchema.Resource.builder()
+			.uri("resource://test1")
+			.name("Test Resource 1")
+			.title("The first test resource")
+			.description("First test resource")
+			.mimeType("text/plain")
+			.build();
 
-		McpSchema.Resource resource2 = new McpSchema.Resource("resource://test2", "Test Resource 2",
-				"Second test resource", "application/json", null);
+		McpSchema.Resource resource2 = McpSchema.Resource.builder()
+			.uri("resource://test2")
+			.name("Test Resource 2")
+			.title("The second test resource")
+			.description("Second test resource")
+			.mimeType("application/json")
+			.build();
 
 		McpSchema.ListResourcesResult result = new McpSchema.ListResourcesResult(Arrays.asList(resource1, resource2),
 				"next-cursor");
@@ -382,7 +398,7 @@ public class McpSchemaTests {
 			.isObject()
 			.isEqualTo(
 					json("""
-							{"resources":[{"uri":"resource://test1","name":"Test Resource 1","description":"First test resource","mimeType":"text/plain"},{"uri":"resource://test2","name":"Test Resource 2","description":"Second test resource","mimeType":"application/json"}],"nextCursor":"next-cursor"}"""));
+							{"resources":[{"uri":"resource://test1","name":"Test Resource 1","title":"The first test resource","description":"First test resource","mimeType":"text/plain"},{"uri":"resource://test2","name":"Test Resource 2","title":"The second test resource","description":"Second test resource","mimeType":"application/json"}],"nextCursor":"next-cursor"}"""));
 	}
 
 	@Test


### PR DESCRIPTION
- Added optional title field to `resource`, `tool`, `prompt`
- Use builder pattern for easier field addition in the future


## Motivation and Context
The following MCP spec PR adds a human-readable title field, and it needs to be implemented in the java-sdk.
https://github.com/modelcontextprotocol/modelcontextprotocol/pull/663

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
used unit test

## Breaking Changes
The field is optional.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
