### PR TITLE
feat: add structured output support for MCP tools

### DIFF
--- a/mcp-spring/mcp-spring-webflux/pom.xml
+++ b/mcp-spring/mcp-spring-webflux/pom.xml
@@ -127,6 +127,13 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>net.javacrumbs.json-unit</groupId>
+			<artifactId>json-unit-assertj</artifactId>
+			<version>${json-unit-assertj.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 

--- a/mcp-spring/mcp-spring-webmvc/pom.xml
+++ b/mcp-spring/mcp-spring-webmvc/pom.xml
@@ -128,6 +128,13 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>net.javacrumbs.json-unit</groupId>
+			<artifactId>json-unit-assertj</artifactId>
+			<version>${json-unit-assertj.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 

--- a/mcp-spring/mcp-spring-webmvc/src/test/java/io/modelcontextprotocol/server/WebMvcSseIntegrationTests.java
+++ b/mcp-spring/mcp-spring-webmvc/src/test/java/io/modelcontextprotocol/server/WebMvcSseIntegrationTests.java
@@ -45,6 +45,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 class WebMvcSseIntegrationTests {
 
@@ -860,6 +864,244 @@ class WebMvcSseIntegrationTests {
 		}
 
 		mcpServer.close();
+	}
+
+	// ---------------------------------------
+	// Tool Structured Output Schema Tests
+	// ---------------------------------------
+
+	@Test
+	void testStructuredOutputValidationSuccess() {
+		// Create a tool with output schema
+		Map<String, Object> outputSchema = Map.of(
+				"type", "object", "properties", Map.of("result", Map.of("type", "number"), "operation",
+						Map.of("type", "string"), "timestamp", Map.of("type", "string")),
+				"required", List.of("result", "operation"));
+
+		Tool calculatorTool = new Tool("calculator", "Performs mathematical calculations", (McpSchema.JsonSchema) null,
+				outputSchema, (McpSchema.ToolAnnotations) null);
+
+		McpServerFeatures.SyncToolSpecification tool = new McpServerFeatures.SyncToolSpecification(calculatorTool,
+				(exchange, request) -> {
+					String expression = (String) request.getOrDefault("expression", "2 + 3");
+					double result = evaluateExpression(expression);
+					return CallToolResult.builder()
+						.structuredContent(
+								Map.of("result", result, "operation", expression, "timestamp", "2024-01-01T10:00:00Z"))
+						.build();
+				});
+
+		var mcpServer = McpServer.sync(mcpServerTransportProvider)
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().tools(true).build())
+			.tools(tool)
+			.build();
+
+		try (var mcpClient = clientBuilder.build()) {
+			InitializeResult initResult = mcpClient.initialize();
+			assertThat(initResult).isNotNull();
+
+			// Verify tool is listed with output schema
+			var toolsList = mcpClient.listTools();
+			assertThat(toolsList.tools()).hasSize(1);
+			assertThat(toolsList.tools().get(0).name()).isEqualTo("calculator");
+			// Note: outputSchema might be null in sync server, but validation still works
+
+			// Call tool with valid structured output
+			CallToolResult response = mcpClient
+				.callTool(new McpSchema.CallToolRequest("calculator", Map.of("expression", "2 + 3")));
+
+			assertThat(response).isNotNull();
+			assertThat(response.isError()).isFalse();
+
+			// In WebMVC, structured content is returned properly
+			if (response.structuredContent() != null) {
+				assertThat(response.structuredContent()).containsEntry("result", 5.0)
+					.containsEntry("operation", "2 + 3")
+					.containsEntry("timestamp", "2024-01-01T10:00:00Z");
+			}
+			else {
+				// Fallback to checking content if structured content is not available
+				assertThat(response.content()).isNotEmpty();
+			}
+
+			assertThat(response.structuredContent()).isNotNull();
+			assertThatJson(response.structuredContent()).when(Option.IGNORING_ARRAY_ORDER)
+				.when(Option.IGNORING_EXTRA_ARRAY_ITEMS)
+				.isObject()
+				.isEqualTo(json("""
+						{"result":5.0,"operation":"2 + 3","timestamp":"2024-01-01T10:00:00Z"}"""));
+		}
+
+		mcpServer.close();
+	}
+
+	@Test
+	void testStructuredOutputValidationFailure() {
+		// Create a tool with output schema
+		Map<String, Object> outputSchema = Map.of("type", "object", "properties",
+				Map.of("result", Map.of("type", "number"), "operation", Map.of("type", "string")), "required",
+				List.of("result", "operation"));
+
+		Tool calculatorTool = new Tool("calculator", "Performs mathematical calculations", (McpSchema.JsonSchema) null,
+				outputSchema, (McpSchema.ToolAnnotations) null);
+
+		McpServerFeatures.SyncToolSpecification tool = new McpServerFeatures.SyncToolSpecification(calculatorTool,
+				(exchange, request) -> {
+					// Return invalid structured output. Result should be number, missing
+					// operation
+					return CallToolResult.builder()
+						.addTextContent("Invalid calculation")
+						.structuredContent(Map.of("result", "not-a-number", "extra", "field"))
+						.build();
+				});
+
+		var mcpServer = McpServer.sync(mcpServerTransportProvider)
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().tools(true).build())
+			.tools(tool)
+			.build();
+
+		try (var mcpClient = clientBuilder.build()) {
+			InitializeResult initResult = mcpClient.initialize();
+			assertThat(initResult).isNotNull();
+
+			// Call tool with invalid structured output
+			CallToolResult response = mcpClient
+				.callTool(new McpSchema.CallToolRequest("calculator", Map.of("expression", "2 + 3")));
+
+			assertThat(response).isNotNull();
+			assertThat(response.isError()).isTrue();
+			assertThat(response.content()).hasSize(1);
+			assertThat(response.content().get(0)).isInstanceOf(McpSchema.TextContent.class);
+
+			String errorMessage = ((McpSchema.TextContent) response.content().get(0)).text();
+			assertThat(errorMessage).contains("Validation failed");
+		}
+
+		mcpServer.close();
+	}
+
+	@Test
+	void testStructuredOutputMissingStructuredContent() {
+		// Create a tool with output schema
+		Map<String, Object> outputSchema = Map.of("type", "object", "properties",
+				Map.of("result", Map.of("type", "number")), "required", List.of("result"));
+
+		Tool calculatorTool = new Tool("calculator", "Performs mathematical calculations", (McpSchema.JsonSchema) null,
+				outputSchema, (McpSchema.ToolAnnotations) null);
+
+		McpServerFeatures.SyncToolSpecification tool = new McpServerFeatures.SyncToolSpecification(calculatorTool,
+				(exchange, request) -> {
+					// Return result without structured content but tool has output schema
+					return CallToolResult.builder().addTextContent("Calculation completed").build();
+				});
+
+		var mcpServer = McpServer.sync(mcpServerTransportProvider)
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().tools(true).build())
+			.tools(tool)
+			.build();
+
+		try (var mcpClient = clientBuilder.build()) {
+			InitializeResult initResult = mcpClient.initialize();
+			assertThat(initResult).isNotNull();
+
+			// Call tool that should return structured content but doesn't
+			CallToolResult response = mcpClient
+				.callTool(new McpSchema.CallToolRequest("calculator", Map.of("expression", "2 + 3")));
+
+			assertThat(response).isNotNull();
+			assertThat(response.isError()).isTrue();
+			assertThat(response.content()).hasSize(1);
+			assertThat(response.content().get(0)).isInstanceOf(McpSchema.TextContent.class);
+
+			String errorMessage = ((McpSchema.TextContent) response.content().get(0)).text();
+			assertThat(errorMessage)
+				.isEqualTo("Tool call with non-empty outputSchema must have a result with structured content");
+		}
+
+		mcpServer.close();
+	}
+
+	@Test
+	void testStructuredOutputRuntimeToolAddition() {
+		// Start server without tools
+		var mcpServer = McpServer.sync(mcpServerTransportProvider)
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().tools(true).build())
+			.build();
+
+		try (var mcpClient = clientBuilder.build()) {
+			InitializeResult initResult = mcpClient.initialize();
+			assertThat(initResult).isNotNull();
+
+			// Initially no tools
+			assertThat(mcpClient.listTools().tools()).isEmpty();
+
+			// Add tool with output schema at runtime
+			Map<String, Object> outputSchema = Map.of("type", "object", "properties",
+					Map.of("message", Map.of("type", "string"), "count", Map.of("type", "integer")), "required",
+					List.of("message", "count"));
+
+			Tool dynamicTool = new Tool("dynamic-tool", "Dynamically added tool", (McpSchema.JsonSchema) null,
+					outputSchema, (McpSchema.ToolAnnotations) null);
+
+			McpServerFeatures.SyncToolSpecification toolSpec = new McpServerFeatures.SyncToolSpecification(dynamicTool,
+					(exchange, request) -> {
+						int count = (Integer) request.getOrDefault("count", 1);
+						return CallToolResult.builder()
+							.addTextContent("Dynamic tool executed " + count + " times")
+							.structuredContent(Map.of("message", "Dynamic execution", "count", count))
+							.build();
+					});
+
+			// Add tool to server
+			mcpServer.addTool(toolSpec);
+
+			// Wait for tool list change notification
+			await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+				assertThat(mcpClient.listTools().tools()).hasSize(1);
+			});
+
+			// Verify tool was added with output schema
+			var toolsList = mcpClient.listTools();
+			assertThat(toolsList.tools()).hasSize(1);
+			assertThat(toolsList.tools().get(0).name()).isEqualTo("dynamic-tool");
+			// Note: outputSchema might be null in sync server, but validation still works
+
+			// Call dynamically added tool
+			CallToolResult response = mcpClient
+				.callTool(new McpSchema.CallToolRequest("dynamic-tool", Map.of("count", 3)));
+
+			assertThat(response).isNotNull();
+			assertThat(response.isError()).isFalse();
+
+			assertThat(response.content()).hasSize(1);
+			assertThat(response.content().get(0)).isInstanceOf(McpSchema.TextContent.class);
+			assertThat(((McpSchema.TextContent) response.content().get(0)).text())
+				.isEqualTo("Dynamic tool executed 3 times");
+
+			assertThat(response.structuredContent()).isNotNull();
+			assertThatJson(response.structuredContent()).when(Option.IGNORING_ARRAY_ORDER)
+				.when(Option.IGNORING_EXTRA_ARRAY_ITEMS)
+				.isObject()
+				.isEqualTo(json("""
+						{"count":3,"message":"Dynamic execution"}"""));
+		}
+
+		mcpServer.close();
+	}
+
+	private double evaluateExpression(String expression) {
+		// Simple expression evaluator for testing
+		return switch (expression) {
+			case "2 + 3" -> 5.0;
+			case "10 * 2" -> 20.0;
+			case "7 + 8" -> 15.0;
+			case "5 + 3" -> 8.0;
+			default -> 0.0;
+		};
 	}
 
 }

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -83,6 +83,15 @@
 			<artifactId>reactor-core</artifactId>
 		</dependency>
 
+		<!-- Json validator dependency.  
+		NOTE: If you provide JsonSchemaValidator implementation that does not depend on this library, 
+		you can exclude this dependency from your project. -->
+		<dependency>
+			<groupId>com.networknt</groupId>
+			<artifactId>json-schema-validator</artifactId>
+			<version>${json-schema-validator.version}</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-webmvc</artifactId>

--- a/mcp/src/main/java/io/modelcontextprotocol/server/DefaultJsonSchemaValidator.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/DefaultJsonSchemaValidator.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ */
+package io.modelcontextprotocol.server;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+
+/**
+ * Default implementation of the {@link JsonSchemaValidator} interface. This class
+ * provides methods to validate structured content against a JSON schema. It uses the
+ * NetworkNT JSON Schema Validator library for validation.
+ *
+ * @author Christian Tzolov
+ */
+public class DefaultJsonSchemaValidator implements JsonSchemaValidator {
+
+	private static final Logger logger = LoggerFactory.getLogger(DefaultJsonSchemaValidator.class);
+
+	private ObjectMapper objectMapper = new ObjectMapper();
+
+	public DefaultJsonSchemaValidator() {
+		this.objectMapper = new ObjectMapper();
+	}
+
+	public DefaultJsonSchemaValidator(ObjectMapper objectMapper) {
+		this.objectMapper = objectMapper;
+	}
+
+	@Override
+	public ValidationResponse validate(Map<String, Object> schema, Map<String, Object> structuredContent) {
+
+		try {
+			// Create JsonSchema validator
+			ObjectNode schemaNode = (ObjectNode) this.objectMapper
+				.readTree(this.objectMapper.writeValueAsString(schema));
+
+			// Set additional properties to false if not specified in the schema
+			if (!schemaNode.has("additionalProperties")) {
+				schemaNode.put("additionalProperties", false);
+			}
+
+			JsonSchema jsonSchema = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
+				.getSchema(schemaNode);
+
+			// Convert structured content in reult to JsonNode
+			JsonNode jsonStructuredOutput = this.objectMapper.valueToTree(structuredContent);
+
+			// Validate outputSchema against structuredContent
+			Set<ValidationMessage> validationResult = jsonSchema.validate(jsonStructuredOutput);
+
+			// Check if validation passed
+			if (!validationResult.isEmpty()) {
+				logger.warn("Validation failed: structuredContent does not match tool outputSchema. "
+						+ "Validation errors: {}", validationResult);
+				return ValidationResponse
+					.asInvalid("Validation failed: structuredContent does not match tool outputSchema. "
+							+ "Validation errors: " + validationResult);
+			}
+
+			return ValidationResponse.asValid(jsonStructuredOutput.toString());
+
+		}
+		catch (JsonProcessingException e) {
+			logger.warn("Failed to validate CallToolResult: Error parsing schema: {}", e);
+			return ValidationResponse.asInvalid("Error parsing tool JSON Schema: " + e.getMessage());
+		}
+	}
+
+}

--- a/mcp/src/main/java/io/modelcontextprotocol/server/JsonSchemaValidator.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/JsonSchemaValidator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ */
+package io.modelcontextprotocol.server;
+
+import java.util.Map;
+
+/**
+ * Interface for validating structured content against a JSON schema. This interface
+ * defines a method to validate structured content based on the provided output schema.
+ *
+ * @author Christian Tzolov
+ */
+public interface JsonSchemaValidator {
+
+	/**
+	 * Represents the result of a validation operation.
+	 *
+	 * @param valid Indicates whether the validation was successful.
+	 * @param errorMessage An error message if the validation failed, otherwise null.
+	 * @param jsonStructuredOutput The text structured content in JSON format if the
+	 * validation was successful, otherwise null.
+	 */
+	public record ValidationResponse(boolean valid, String errorMessage, String jsonStructuredOutput) {
+
+		public static ValidationResponse asValid(String jsonStructuredOutput) {
+			return new ValidationResponse(true, null, jsonStructuredOutput);
+		}
+
+		public static ValidationResponse asInvalid(String message) {
+			return new ValidationResponse(false, message, null);
+		}
+	}
+
+	/**
+	 * Validates the structured content against the provided JSON schema.
+	 * @param schema The JSON schema to validate against.
+	 * @param structuredContent The structured content to validate.
+	 * @return A ValidationResponse indicating whether the validation was successful or
+	 * not.
+	 */
+	ValidationResponse validate(Map<String, Object> schema, Map<String, Object> structuredContent);
+
+}

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -15,8 +15,12 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiFunction;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.modelcontextprotocol.spec.McpClientSession;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -28,11 +32,10 @@ import io.modelcontextprotocol.spec.McpSchema.SetLevelRequest;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import io.modelcontextprotocol.spec.McpServerSession;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
+import io.modelcontextprotocol.util.Assert;
 import io.modelcontextprotocol.util.DeafaultMcpUriTemplateManagerFactory;
 import io.modelcontextprotocol.util.McpUriTemplateManagerFactory;
 import io.modelcontextprotocol.util.Utils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -86,6 +89,8 @@ public class McpAsyncServer {
 
 	private final ObjectMapper objectMapper;
 
+	private final JsonSchemaValidator jsonSchemaValidator;
+
 	private final McpSchema.ServerCapabilities serverCapabilities;
 
 	private final McpSchema.Implementation serverInfo;
@@ -119,18 +124,19 @@ public class McpAsyncServer {
 	 */
 	McpAsyncServer(McpServerTransportProvider mcpTransportProvider, ObjectMapper objectMapper,
 			McpServerFeatures.Async features, Duration requestTimeout,
-			McpUriTemplateManagerFactory uriTemplateManagerFactory) {
+			McpUriTemplateManagerFactory uriTemplateManagerFactory, JsonSchemaValidator jsonSchemaValidator) {
 		this.mcpTransportProvider = mcpTransportProvider;
 		this.objectMapper = objectMapper;
 		this.serverInfo = features.serverInfo();
 		this.serverCapabilities = features.serverCapabilities();
 		this.instructions = features.instructions();
-		this.tools.addAll(features.tools());
+		this.tools.addAll(withStructuredOutputHandling(jsonSchemaValidator, features.tools()));
 		this.resources.putAll(features.resources());
 		this.resourceTemplates.addAll(features.resourceTemplates());
 		this.prompts.putAll(features.prompts());
 		this.completions.putAll(features.completions());
 		this.uriTemplateManagerFactory = uriTemplateManagerFactory;
+		this.jsonSchemaValidator = jsonSchemaValidator;
 
 		Map<String, McpServerSession.RequestHandler<?>> requestHandlers = new HashMap<>();
 
@@ -286,21 +292,151 @@ public class McpAsyncServer {
 			return Mono.error(new McpError("Server must be configured with tool capabilities"));
 		}
 
+		var wrappedToolSpecification = withStructuredOutputHandling(this.jsonSchemaValidator, toolSpecification);
+
 		return Mono.defer(() -> {
 			// Check for duplicate tool names
-			if (this.tools.stream().anyMatch(th -> th.tool().name().equals(toolSpecification.tool().name()))) {
-				return Mono
-					.error(new McpError("Tool with name '" + toolSpecification.tool().name() + "' already exists"));
+			if (this.tools.stream().anyMatch(th -> th.tool().name().equals(wrappedToolSpecification.tool().name()))) {
+				return Mono.error(
+						new McpError("Tool with name '" + wrappedToolSpecification.tool().name() + "' already exists"));
 			}
 
-			this.tools.add(toolSpecification);
-			logger.debug("Added tool handler: {}", toolSpecification.tool().name());
+			this.tools.add(wrappedToolSpecification);
+			logger.debug("Added tool handler: {}", wrappedToolSpecification.tool().name());
 
 			if (this.serverCapabilities.tools().listChanged()) {
 				return notifyToolsListChanged();
 			}
 			return Mono.empty();
 		});
+	}
+
+	static class StructuredOutputCallToolHandler
+			implements BiFunction<McpAsyncServerExchange, Map<String, Object>, Mono<McpSchema.CallToolResult>> {
+
+		private final BiFunction<McpAsyncServerExchange, Map<String, Object>, Mono<McpSchema.CallToolResult>> delegateCallToolResult;
+
+		private final JsonSchemaValidator jsonSchemaValidator;
+
+		private final Map<String, Object> outputSchema;
+
+		public StructuredOutputCallToolHandler(JsonSchemaValidator jsonSchemaValidator,
+				Map<String, Object> outputSchema,
+				BiFunction<McpAsyncServerExchange, Map<String, Object>, Mono<McpSchema.CallToolResult>> delegateHandler) {
+
+			Assert.notNull(jsonSchemaValidator, "JsonSchemaValidator must not be null");
+			Assert.notNull(delegateHandler, "Delegate call tool result handler must not be null");
+
+			this.delegateCallToolResult = delegateHandler;
+			this.outputSchema = outputSchema;
+			this.jsonSchemaValidator = jsonSchemaValidator;
+		}
+
+		@Override
+		public Mono<CallToolResult> apply(McpAsyncServerExchange exchange, Map<String, Object> arguments) {
+
+			return this.delegateCallToolResult.apply(exchange, arguments).map(result -> {
+
+				if (outputSchema == null) {
+					if (result.structuredContent() != null) {
+						logger.warn(
+								"Tool call with no outputSchema is not expected to have a result with structured content, but got: {}",
+								result.structuredContent());
+					}
+					// Pass through. No validation is required if no output schema is
+					// provided.
+					return result;
+				}
+
+				// If an output schema is provided, servers MUST provide structured
+				// results that conform to this schema.
+				// https://modelcontextprotocol.io/specification/2025-06-18/server/tools#output-schema
+				if (result.structuredContent() == null) {
+					logger.warn("Tool call with non-empty outputSchema MUST have a result with structured content");
+					// if (!Utils.isEmpty(result.content())) {
+					// // TODO If the tesult.content() contains json text we can try to
+					// // convert it into a structured content (Experimental)
+					// var tc = result.content().stream().filter(c -> c instanceof
+					// McpSchema.TextContent).findFirst();
+					// if (tc.isPresent()) {
+					// try {
+					// Map<String, Object> structuredOutput = new
+					// ObjectMapper().readValue(
+					// ((TextContent) tc.get()).text(), new TypeReference<Map<String,
+					// Object>>() {
+					// });
+
+					// // Overwrite the result with the structured content
+					// // generated from the text content.
+					// result = new CallToolResult(result.content(), result.isError(),
+					// structuredOutput);
+
+					// }
+					// catch (Exception e) {
+					// logger.warn("Failed to parse text content as structured content:
+					// {}", e.getMessage());
+					// return new CallToolResult(
+					// "Failed to parse text content as structured content: " +
+					// e.getMessage(), true);
+					// }
+
+					// }
+					// }
+					return new CallToolResult(
+							"Tool call with non-empty outputSchema must have a result with structured content", true);
+				}
+
+				// Validate the result against the output schema
+				var validation = this.jsonSchemaValidator.validate(outputSchema, result.structuredContent());
+
+				if (!validation.valid()) {
+					logger.warn("Tool call result validation failed: {}", validation.errorMessage());
+					return new CallToolResult(validation.errorMessage(), true);
+				}
+
+				if (Utils.isEmpty(result.content())) {
+					// For backwards compatibility, a tool that returns structured
+					// content SHOULD also return functionally equivalent unstructured
+					// content. (For example, serialized JSON can be returned in a
+					// TextContent block.)
+					// https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content
+
+					return new CallToolResult(List.of(new McpSchema.TextContent(validation.jsonStructuredOutput())),
+							result.isError(), result.structuredContent());
+				}
+
+				return result;
+			});
+		}
+
+	}
+
+	static List<McpServerFeatures.AsyncToolSpecification> withStructuredOutputHandling(
+			JsonSchemaValidator jsonSchemaValidator, List<McpServerFeatures.AsyncToolSpecification> tools) {
+
+		if (Utils.isEmpty(tools)) {
+			return tools;
+		}
+
+		return tools.stream().map(tool -> withStructuredOutputHandling(jsonSchemaValidator, tool)).toList();
+	}
+
+	static McpServerFeatures.AsyncToolSpecification withStructuredOutputHandling(
+			JsonSchemaValidator jsonSchemaValidator, McpServerFeatures.AsyncToolSpecification toolSpecification) {
+
+		if (toolSpecification.call() instanceof StructuredOutputCallToolHandler) {
+			// If the tool is already wrapped, return it as is
+			return toolSpecification;
+		}
+
+		if (toolSpecification.tool().outputSchema() == null) {
+			// If the tool does not have an output schema, return it as is
+			return toolSpecification;
+		}
+
+		return new McpServerFeatures.AsyncToolSpecification(toolSpecification.tool(),
+				new StructuredOutputCallToolHandler(jsonSchemaValidator, toolSpecification.tool().outputSchema(),
+						toolSpecification.call()));
 	}
 
 	/**

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpSyncServerExchange.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpSyncServerExchange.java
@@ -5,7 +5,6 @@
 package io.modelcontextprotocol.server;
 
 import io.modelcontextprotocol.spec.McpSchema;
-import io.modelcontextprotocol.spec.McpSchema.LoggingLevel;
 import io.modelcontextprotocol.spec.McpSchema.LoggingMessageNotification;
 
 /**

--- a/mcp/src/test/java/io/modelcontextprotocol/server/DefaultJsonSchemaValidatorTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/DefaultJsonSchemaValidatorTests.java
@@ -1,0 +1,698 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ */
+package io.modelcontextprotocol.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.modelcontextprotocol.server.JsonSchemaValidator.ValidationResponse;
+
+/**
+ * Tests for {@link DefaultJsonSchemaValidator}.
+ *
+ * @author Christian Tzolov
+ */
+class DefaultJsonSchemaValidatorTests {
+
+	private DefaultJsonSchemaValidator validator;
+
+	private ObjectMapper objectMapper;
+
+	@Mock
+	private ObjectMapper mockObjectMapper;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		validator = new DefaultJsonSchemaValidator();
+		objectMapper = new ObjectMapper();
+	}
+
+	/**
+	 * Utility method to convert JSON string to Map<String, Object>
+	 */
+	private Map<String, Object> toMap(String json) {
+		try {
+			return objectMapper.readValue(json, new TypeReference<Map<String, Object>>() {
+			});
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Failed to parse JSON: " + json, e);
+		}
+	}
+
+	@Test
+	void testDefaultConstructor() {
+		DefaultJsonSchemaValidator defaultValidator = new DefaultJsonSchemaValidator();
+
+		String schemaJson = """
+				{
+					"type": "object",
+					"properties": {
+						"test": {"type": "string"}
+					}
+				}
+				""";
+		String contentJson = """
+				{
+					"test": "value"
+				}
+				""";
+
+		ValidationResponse response = defaultValidator.validate(toMap(schemaJson), toMap(contentJson));
+		assertTrue(response.valid());
+	}
+
+	@Test
+	void testConstructorWithObjectMapper() {
+		ObjectMapper customMapper = new ObjectMapper();
+		DefaultJsonSchemaValidator customValidator = new DefaultJsonSchemaValidator(customMapper);
+
+		String schemaJson = """
+				{
+					"type": "object",
+					"properties": {
+						"test": {"type": "string"}
+					}
+				}
+				""";
+		String contentJson = """
+				{
+					"test": "value"
+				}
+				""";
+
+		ValidationResponse response = customValidator.validate(toMap(schemaJson), toMap(contentJson));
+		assertTrue(response.valid());
+	}
+
+	@Test
+	void testValidateWithValidStringSchema() {
+		String schemaJson = """
+				{
+					"type": "object",
+					"properties": {
+						"name": {"type": "string"},
+						"age": {"type": "integer"}
+					},
+					"required": ["name", "age"]
+				}
+				""";
+
+		String contentJson = """
+				{
+					"name": "John Doe",
+					"age": 30
+				}
+				""";
+
+		Map<String, Object> schema = toMap(schemaJson);
+		Map<String, Object> structuredContent = toMap(contentJson);
+
+		ValidationResponse response = validator.validate(schema, structuredContent);
+
+		assertTrue(response.valid());
+		assertNull(response.errorMessage());
+		assertNotNull(response.jsonStructuredOutput());
+	}
+
+	@Test
+	void testValidateWithValidNumberSchema() {
+		String schemaJson = """
+				{
+					"type": "object",
+					"properties": {
+						"price": {"type": "number", "minimum": 0},
+						"quantity": {"type": "integer", "minimum": 1}
+					},
+					"required": ["price", "quantity"]
+				}
+				""";
+
+		String contentJson = """
+				{
+					"price": 19.99,
+					"quantity": 5
+				}
+				""";
+
+		Map<String, Object> schema = toMap(schemaJson);
+		Map<String, Object> structuredContent = toMap(contentJson);
+
+		ValidationResponse response = validator.validate(schema, structuredContent);
+
+		assertTrue(response.valid());
+		assertNull(response.errorMessage());
+	}
+
+	@Test
+	void testValidateWithValidArraySchema() {
+		String schemaJson = """
+				{
+					"type": "object",
+					"properties": {
+						"items": {
+							"type": "array",
+							"items": {"type": "string"}
+						}
+					},
+					"required": ["items"]
+				}
+				""";
+
+		String contentJson = """
+				{
+					"items": ["apple", "banana", "cherry"]
+				}
+				""";
+
+		Map<String, Object> schema = toMap(schemaJson);
+		Map<String, Object> structuredContent = toMap(contentJson);
+
+		ValidationResponse response = validator.validate(schema, structuredContent);
+
+		assertTrue(response.valid());
+		assertNull(response.errorMessage());
+	}
+
+	@Test
+	void testValidateWithInvalidTypeSchema() {
+		String schemaJson = """
+				{
+					"type": "object",
+					"properties": {
+						"name": {"type": "string"},
+						"age": {"type": "integer"}
+					},
+					"required": ["name", "age"]
+				}
+				""";
+
+		String contentJson = """
+				{
+					"name": "John Doe",
+					"age": "thirty"
+				}
+				""";
+
+		Map<String, Object> schema = toMap(schemaJson);
+		Map<String, Object> structuredContent = toMap(contentJson);
+
+		ValidationResponse response = validator.validate(schema, structuredContent);
+
+		assertFalse(response.valid());
+		assertNotNull(response.errorMessage());
+		assertTrue(response.errorMessage().contains("Validation failed"));
+		assertTrue(response.errorMessage().contains("structuredContent does not match tool outputSchema"));
+	}
+
+	@Test
+	void testValidateWithMissingRequiredField() {
+		String schemaJson = """
+				{
+					"type": "object",
+					"properties": {
+						"name": {"type": "string"},
+						"age": {"type": "integer"}
+					},
+					"required": ["name", "age"]
+				}
+				""";
+
+		String contentJson = """
+				{
+					"name": "John Doe"
+				}
+				""";
+
+		Map<String, Object> schema = toMap(schemaJson);
+		Map<String, Object> structuredContent = toMap(contentJson);
+
+		ValidationResponse response = validator.validate(schema, structuredContent);
+
+		assertFalse(response.valid());
+		assertNotNull(response.errorMessage());
+		assertTrue(response.errorMessage().contains("Validation failed"));
+	}
+
+	@Test
+	void testValidateWithAdditionalPropertiesNotAllowed() {
+		String schemaJson = """
+				{
+					"type": "object",
+					"properties": {
+						"name": {"type": "string"}
+					},
+					"required": ["name"]
+				}
+				""";
+
+		String contentJson = """
+				{
+					"name": "John Doe",
+					"extraField": "should not be allowed"
+				}
+				""";
+
+		Map<String, Object> schema = toMap(schemaJson);
+		Map<String, Object> structuredContent = toMap(contentJson);
+
+		ValidationResponse response = validator.validate(schema, structuredContent);
+
+		assertFalse(response.valid());
+		assertNotNull(response.errorMessage());
+		assertTrue(response.errorMessage().contains("Validation failed"));
+	}
+
+	@Test
+	void testValidateWithAdditionalPropertiesExplicitlyAllowed() {
+		String schemaJson = """
+				{
+					"type": "object",
+					"properties": {
+						"name": {"type": "string"}
+					},
+					"required": ["name"],
+					"additionalProperties": true
+				}
+				""";
+
+		String contentJson = """
+				{
+					"name": "John Doe",
+					"extraField": "should be allowed"
+				}
+				""";
+
+		Map<String, Object> schema = toMap(schemaJson);
+		Map<String, Object> structuredContent = toMap(contentJson);
+
+		ValidationResponse response = validator.validate(schema, structuredContent);
+
+		assertTrue(response.valid());
+		assertNull(response.errorMessage());
+	}
+
+	@Test
+	void testValidateWithAdditionalPropertiesExplicitlyDisallowed() {
+		String schemaJson = """
+				{
+					"type": "object",
+					"properties": {
+						"name": {"type": "string"}
+					},
+					"required": ["name"],
+					"additionalProperties": false
+				}
+				""";
+
+		String contentJson = """
+				{
+					"name": "John Doe",
+					"extraField": "should not be allowed"
+				}
+				""";
+
+		Map<String, Object> schema = toMap(schemaJson);
+		Map<String, Object> structuredContent = toMap(contentJson);
+
+		ValidationResponse response = validator.validate(schema, structuredContent);
+
+		assertFalse(response.valid());
+		assertNotNull(response.errorMessage());
+		assertTrue(response.errorMessage().contains("Validation failed"));
+	}
+
+	@Test
+	void testValidateWithEmptySchema() {
+		String schemaJson = """
+				{
+					"additionalProperties": true
+				}
+				""";
+
+		String contentJson = """
+				{
+					"anything": "goes"
+				}
+				""";
+
+		Map<String, Object> schema = toMap(schemaJson);
+		Map<String, Object> structuredContent = toMap(contentJson);
+
+		ValidationResponse response = validator.validate(schema, structuredContent);
+
+		assertTrue(response.valid());
+		assertNull(response.errorMessage());
+	}
+
+	@Test
+	void testValidateWithEmptyContent() {
+		String schemaJson = """
+				{
+					"type": "object",
+					"properties": {}
+				}
+				""";
+
+		String contentJson = """
+				{}
+				""";
+
+		Map<String, Object> schema = toMap(schemaJson);
+		Map<String, Object> structuredContent = toMap(contentJson);
+
+		ValidationResponse response = validator.validate(schema, structuredContent);
+
+		assertTrue(response.valid());
+		assertNull(response.errorMessage());
+	}
+
+	@Test
+	void testValidateWithNestedObjectSchema() {
+		String schemaJson = """
+				{
+					"type": "object",
+					"properties": {
+						"person": {
+							"type": "object",
+							"properties": {
+								"name": {"type": "string"},
+								"address": {
+									"type": "object",
+									"properties": {
+										"street": {"type": "string"},
+										"city": {"type": "string"}
+									},
+									"required": ["street", "city"]
+								}
+							},
+							"required": ["name", "address"]
+						}
+					},
+					"required": ["person"]
+				}
+				""";
+
+		String contentJson = """
+				{
+					"person": {
+						"name": "John Doe",
+						"address": {
+							"street": "123 Main St",
+							"city": "Anytown"
+						}
+					}
+				}
+				""";
+
+		Map<String, Object> schema = toMap(schemaJson);
+		Map<String, Object> structuredContent = toMap(contentJson);
+
+		ValidationResponse response = validator.validate(schema, structuredContent);
+
+		assertTrue(response.valid());
+		assertNull(response.errorMessage());
+	}
+
+	@Test
+	void testValidateWithInvalidNestedObjectSchema() {
+		String schemaJson = """
+				{
+					"type": "object",
+					"properties": {
+						"person": {
+							"type": "object",
+							"properties": {
+								"name": {"type": "string"},
+								"address": {
+									"type": "object",
+									"properties": {
+										"street": {"type": "string"},
+										"city": {"type": "string"}
+									},
+									"required": ["street", "city"]
+								}
+							},
+							"required": ["name", "address"]
+						}
+					},
+					"required": ["person"]
+				}
+				""";
+
+		String contentJson = """
+				{
+					"person": {
+						"name": "John Doe",
+						"address": {
+							"street": "123 Main St"
+						}
+					}
+				}
+				""";
+
+		Map<String, Object> schema = toMap(schemaJson);
+		Map<String, Object> structuredContent = toMap(contentJson);
+
+		ValidationResponse response = validator.validate(schema, structuredContent);
+
+		assertFalse(response.valid());
+		assertNotNull(response.errorMessage());
+		assertTrue(response.errorMessage().contains("Validation failed"));
+	}
+
+	@Test
+	void testValidateWithJsonProcessingException() throws Exception {
+		DefaultJsonSchemaValidator validatorWithMockMapper = new DefaultJsonSchemaValidator(mockObjectMapper);
+
+		Map<String, Object> schema = Map.of("type", "object");
+		Map<String, Object> structuredContent = Map.of("key", "value");
+
+		when(mockObjectMapper.writeValueAsString(any()))
+			.thenThrow(new com.fasterxml.jackson.core.JsonProcessingException("Mock JSON processing error") {
+			});
+
+		ValidationResponse response = validatorWithMockMapper.validate(schema, structuredContent);
+
+		assertFalse(response.valid());
+		assertNotNull(response.errorMessage());
+		assertTrue(response.errorMessage().contains("Error parsing tool JSON Schema"));
+		assertTrue(response.errorMessage().contains("Mock JSON processing error"));
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideValidSchemaAndContentPairs")
+	void testValidateWithVariousValidInputs(Map<String, Object> schema, Map<String, Object> content) {
+		ValidationResponse response = validator.validate(schema, content);
+
+		assertTrue(response.valid(), "Expected validation to pass for schema: " + schema + " and content: " + content);
+		assertNull(response.errorMessage());
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideInvalidSchemaAndContentPairs")
+	void testValidateWithVariousInvalidInputs(Map<String, Object> schema, Map<String, Object> content) {
+		ValidationResponse response = validator.validate(schema, content);
+
+		assertFalse(response.valid(), "Expected validation to fail for schema: " + schema + " and content: " + content);
+		assertNotNull(response.errorMessage());
+		assertTrue(response.errorMessage().contains("Validation failed"));
+	}
+
+	private static Map<String, Object> staticToMap(String json) {
+		try {
+			ObjectMapper mapper = new ObjectMapper();
+			return mapper.readValue(json, new TypeReference<Map<String, Object>>() {
+			});
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Failed to parse JSON: " + json, e);
+		}
+	}
+
+	private static Stream<Arguments> provideValidSchemaAndContentPairs() {
+		return Stream.of(
+				// Boolean schema
+				Arguments.of(staticToMap("""
+						{
+							"type": "object",
+							"properties": {
+								"flag": {"type": "boolean"}
+							}
+						}
+						"""), staticToMap("""
+						{
+							"flag": true
+						}
+						""")),
+				// String with additional properties allowed
+				Arguments.of(staticToMap("""
+						{
+							"type": "object",
+							"properties": {
+								"name": {"type": "string"}
+							},
+							"additionalProperties": true
+						}
+						"""), staticToMap("""
+						{
+							"name": "test",
+							"extra": "allowed"
+						}
+						""")),
+				// Array with specific items
+				Arguments.of(staticToMap("""
+						{
+							"type": "object",
+							"properties": {
+								"numbers": {
+									"type": "array",
+									"items": {"type": "number"}
+								}
+							}
+						}
+						"""), staticToMap("""
+						{
+							"numbers": [1.0, 2.5, 3.14]
+						}
+						""")),
+				// Enum validation
+				Arguments.of(staticToMap("""
+						{
+							"type": "object",
+							"properties": {
+								"status": {
+									"type": "string",
+									"enum": ["active", "inactive", "pending"]
+								}
+							}
+						}
+						"""), staticToMap("""
+						{
+							"status": "active"
+						}
+						""")));
+	}
+
+	private static Stream<Arguments> provideInvalidSchemaAndContentPairs() {
+		return Stream.of(
+				// Wrong boolean type
+				Arguments.of(staticToMap("""
+						{
+							"type": "object",
+							"properties": {
+								"flag": {"type": "boolean"}
+							}
+						}
+						"""), staticToMap("""
+						{
+							"flag": "true"
+						}
+						""")),
+				// Array with wrong item types
+				Arguments.of(staticToMap("""
+						{
+							"type": "object",
+							"properties": {
+								"numbers": {
+									"type": "array",
+									"items": {"type": "number"}
+								}
+							}
+						}
+						"""), staticToMap("""
+						{
+							"numbers": ["one", "two", "three"]
+						}
+						""")),
+				// Invalid enum value
+				Arguments.of(staticToMap("""
+						{
+							"type": "object",
+							"properties": {
+								"status": {
+									"type": "string",
+									"enum": ["active", "inactive", "pending"]
+								}
+							}
+						}
+						"""), staticToMap("""
+						{
+							"status": "unknown"
+						}
+						""")),
+				// Minimum constraint violation
+				Arguments.of(staticToMap("""
+						{
+							"type": "object",
+							"properties": {
+								"age": {"type": "integer", "minimum": 0}
+							}
+						}
+						"""), staticToMap("""
+						{
+							"age": -5
+						}
+						""")));
+	}
+
+	@Test
+	void testValidationResponseToValid() {
+		String jsonOutput = "{\"test\":\"value\"}";
+		ValidationResponse response = ValidationResponse.asValid(jsonOutput);
+		assertTrue(response.valid());
+		assertNull(response.errorMessage());
+		assertEquals(jsonOutput, response.jsonStructuredOutput());
+	}
+
+	@Test
+	void testValidationResponseToInvalid() {
+		String errorMessage = "Test error message";
+		ValidationResponse response = ValidationResponse.asInvalid(errorMessage);
+		assertFalse(response.valid());
+		assertEquals(errorMessage, response.errorMessage());
+		assertNull(response.jsonStructuredOutput());
+	}
+
+	@Test
+	void testValidationResponseRecord() {
+		ValidationResponse response1 = new ValidationResponse(true, null, "{\"valid\":true}");
+		ValidationResponse response2 = new ValidationResponse(false, "Error", null);
+
+		assertTrue(response1.valid());
+		assertNull(response1.errorMessage());
+		assertEquals("{\"valid\":true}", response1.jsonStructuredOutput());
+
+		assertFalse(response2.valid());
+		assertEquals("Error", response2.errorMessage());
+		assertNull(response2.jsonStructuredOutput());
+
+		// Test equality
+		ValidationResponse response3 = new ValidationResponse(true, null, "{\"valid\":true}");
+		assertEquals(response1, response3);
+		assertNotEquals(response1, response2);
+	}
+
+}

--- a/mcp/src/test/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProviderIntegrationTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProviderIntegrationTests.java
@@ -32,6 +32,8 @@ import io.modelcontextprotocol.spec.McpSchema.Role;
 import io.modelcontextprotocol.spec.McpSchema.Root;
 import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
+import net.javacrumbs.jsonunit.core.Option;
+
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.LifecycleState;
 import org.apache.catalina.startup.Tomcat;
@@ -48,6 +50,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
 
 class HttpServletSseServerTransportProviderIntegrationTests {
 
@@ -956,6 +960,233 @@ class HttpServletSseServerTransportProviderIntegrationTests {
 			});
 		}
 		mcpServer.close();
+	}
+
+	// ---------------------------------------
+	// Tool Structured Output Schema Tests
+	// ---------------------------------------
+
+	@Test
+	void testStructuredOutputValidationSuccess() {
+		// Create a tool with output schema
+		Map<String, Object> outputSchema = Map.of(
+				"type", "object", "properties", Map.of("result", Map.of("type", "number"), "operation",
+						Map.of("type", "string"), "timestamp", Map.of("type", "string")),
+				"required", List.of("result", "operation"));
+
+		Tool calculatorTool = new Tool("calculator", "Performs mathematical calculations", (McpSchema.JsonSchema) null,
+				outputSchema, (McpSchema.ToolAnnotations) null);
+
+		McpServerFeatures.SyncToolSpecification tool = new McpServerFeatures.SyncToolSpecification(calculatorTool,
+				(exchange, request) -> {
+					String expression = (String) request.getOrDefault("expression", "2 + 3");
+					double result = evaluateExpression(expression);
+					return CallToolResult.builder()
+						.structuredContent(
+								Map.of("result", result, "operation", expression, "timestamp", "2024-01-01T10:00:00Z"))
+						.build();
+				});
+
+		var mcpServer = McpServer.sync(mcpServerTransportProvider)
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().tools(true).build())
+			.tools(tool)
+			.build();
+
+		try (var mcpClient = clientBuilder.build()) {
+			InitializeResult initResult = mcpClient.initialize();
+			assertThat(initResult).isNotNull();
+
+			// Verify tool is listed with output schema
+			var toolsList = mcpClient.listTools();
+			assertThat(toolsList.tools()).hasSize(1);
+			assertThat(toolsList.tools().get(0).name()).isEqualTo("calculator");
+			// Note: outputSchema might be null in sync server, but validation still works
+
+			// Call tool with valid structured output
+			CallToolResult response = mcpClient
+				.callTool(new McpSchema.CallToolRequest("calculator", Map.of("expression", "2 + 3")));
+
+			assertThat(response).isNotNull();
+			assertThat(response.isError()).isFalse();
+			assertThat(response.content()).hasSize(1);
+			assertThat(response.content().get(0)).isInstanceOf(McpSchema.TextContent.class);
+
+			assertThatJson(((McpSchema.TextContent) response.content().get(0)).text()).when(Option.IGNORING_ARRAY_ORDER)
+				.when(Option.IGNORING_EXTRA_ARRAY_ITEMS)
+				.isObject()
+				.isEqualTo(json("""
+						{"result":5.0,"operation":"2 + 3","timestamp":"2024-01-01T10:00:00Z"}"""));
+
+			// Verify structured content (may be null in sync server but validation still
+			// works)
+			if (response.structuredContent() != null) {
+				assertThat(response.structuredContent()).containsEntry("result", 5.0)
+					.containsEntry("operation", "2 + 3")
+					.containsEntry("timestamp", "2024-01-01T10:00:00Z");
+			}
+		}
+
+		mcpServer.close();
+	}
+
+	@Test
+	void testStructuredOutputValidationFailure() {
+
+		// Create a tool with output schema
+		Map<String, Object> outputSchema = Map.of("type", "object", "properties",
+				Map.of("result", Map.of("type", "number"), "operation", Map.of("type", "string")), "required",
+				List.of("result", "operation"));
+
+		Tool calculatorTool = new Tool("calculator", "Performs mathematical calculations", (McpSchema.JsonSchema) null,
+				outputSchema, (McpSchema.ToolAnnotations) null);
+
+		McpServerFeatures.SyncToolSpecification tool = new McpServerFeatures.SyncToolSpecification(calculatorTool,
+				(exchange, request) -> {
+					// Return invalid structured output. Result should be number, missing
+					// operation
+					return CallToolResult.builder()
+						.addTextContent("Invalid calculation")
+						.structuredContent(Map.of("result", "not-a-number", "extra", "field"))
+						.build();
+				});
+
+		var mcpServer = McpServer.sync(mcpServerTransportProvider)
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().tools(true).build())
+			.tools(tool)
+			.build();
+
+		try (var mcpClient = clientBuilder.build()) {
+			InitializeResult initResult = mcpClient.initialize();
+			assertThat(initResult).isNotNull();
+
+			// Call tool with invalid structured output
+			CallToolResult response = mcpClient
+				.callTool(new McpSchema.CallToolRequest("calculator", Map.of("expression", "2 + 3")));
+
+			assertThat(response).isNotNull();
+			assertThat(response.isError()).isTrue();
+			assertThat(response.content()).hasSize(1);
+			assertThat(response.content().get(0)).isInstanceOf(McpSchema.TextContent.class);
+
+			String errorMessage = ((McpSchema.TextContent) response.content().get(0)).text();
+			assertThat(errorMessage).contains("Validation failed");
+		}
+
+		mcpServer.close();
+	}
+
+	@Test
+	void testStructuredOutputMissingStructuredContent() {
+		// Create a tool with output schema
+		Map<String, Object> outputSchema = Map.of("type", "object", "properties",
+				Map.of("result", Map.of("type", "number")), "required", List.of("result"));
+
+		Tool calculatorTool = new Tool("calculator", "Performs mathematical calculations", (McpSchema.JsonSchema) null,
+				outputSchema, (McpSchema.ToolAnnotations) null);
+
+		McpServerFeatures.SyncToolSpecification tool = new McpServerFeatures.SyncToolSpecification(calculatorTool,
+				(exchange, request) -> {
+					// Return result without structured content but tool has output schema
+					return CallToolResult.builder().addTextContent("Calculation completed").build();
+				});
+
+		var mcpServer = McpServer.sync(mcpServerTransportProvider)
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().tools(true).build())
+			.tools(tool)
+			.build();
+
+		try (var mcpClient = clientBuilder.build()) {
+			InitializeResult initResult = mcpClient.initialize();
+			assertThat(initResult).isNotNull();
+
+			// Call tool that should return structured content but doesn't
+			CallToolResult response = mcpClient
+				.callTool(new McpSchema.CallToolRequest("calculator", Map.of("expression", "2 + 3")));
+
+			assertThat(response).isNotNull();
+			assertThat(response.isError()).isTrue();
+			assertThat(response.content()).hasSize(1);
+			assertThat(response.content().get(0)).isInstanceOf(McpSchema.TextContent.class);
+
+			String errorMessage = ((McpSchema.TextContent) response.content().get(0)).text();
+			assertThat(errorMessage)
+				.isEqualTo("Tool call with non-empty outputSchema must have a result with structured content");
+		}
+
+		mcpServer.close();
+	}
+
+	@Test
+	void testStructuredOutputRuntimeToolAddition() {
+		// Start server without tools
+		var mcpServer = McpServer.sync(mcpServerTransportProvider)
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().tools(true).build())
+			.build();
+
+		try (var mcpClient = clientBuilder.build()) {
+			InitializeResult initResult = mcpClient.initialize();
+			assertThat(initResult).isNotNull();
+
+			// Initially no tools
+			assertThat(mcpClient.listTools().tools()).isEmpty();
+
+			// Add tool with output schema at runtime
+			Map<String, Object> outputSchema = Map.of("type", "object", "properties",
+					Map.of("message", Map.of("type", "string"), "count", Map.of("type", "integer")), "required",
+					List.of("message", "count"));
+
+			Tool dynamicTool = new Tool("dynamic-tool", "Dynamically added tool", (McpSchema.JsonSchema) null,
+					outputSchema, (McpSchema.ToolAnnotations) null);
+
+			McpServerFeatures.SyncToolSpecification toolSpec = new McpServerFeatures.SyncToolSpecification(dynamicTool,
+					(exchange, request) -> {
+						int count = (Integer) request.getOrDefault("count", 1);
+						return CallToolResult.builder()
+							.addTextContent("Dynamic tool executed " + count + " times")
+							.structuredContent(Map.of("message", "Dynamic execution", "count", count))
+							.build();
+					});
+
+			// Add tool to server
+			mcpServer.addTool(toolSpec);
+
+			// Wait for tool list change notification
+			await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+				assertThat(mcpClient.listTools().tools()).hasSize(1);
+			});
+
+			// Verify tool was added with output schema
+			var toolsList = mcpClient.listTools();
+			assertThat(toolsList.tools()).hasSize(1);
+			assertThat(toolsList.tools().get(0).name()).isEqualTo("dynamic-tool");
+			// Note: outputSchema might be null in sync server, but validation still works
+
+			// Call dynamically added tool
+			CallToolResult response = mcpClient
+				.callTool(new McpSchema.CallToolRequest("dynamic-tool", Map.of("count", 3)));
+
+			assertThat(response).isNotNull();
+			assertThat(response.isError()).isFalse();
+			assertThat(response.structuredContent()).containsEntry("message", "Dynamic execution")
+				.containsEntry("count", 3);
+		}
+
+		mcpServer.close();
+	}
+
+	private double evaluateExpression(String expression) {
+		// Simple expression evaluator for testing
+		return switch (expression) {
+			case "2 + 3" -> 5.0;
+			case "10 * 2" -> 20.0;
+			case "7 + 8" -> 15.0;
+			case "5 + 3" -> 8.0;
+			default -> 0.0;
+		};
 	}
 
 }

--- a/mcp/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
@@ -734,9 +734,234 @@ public class McpSchemaTests {
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
 			.when(Option.IGNORING_EXTRA_ARRAY_ITEMS)
 			.isObject()
-			.isEqualTo(
-					json("""
-							{"name":"test-tool","description":"A test tool","inputSchema":{"type":"object","properties":{"name":{"type":"string"},"value":{"type":"number"}},"required":["name"]},"annotations":{"title":"A test tool","readOnlyHint":false,"destructiveHint":false,"idempotentHint":false,"openWorldHint":false,"returnDirect":false}}"""));
+			.isEqualTo(json("""
+					{
+						"name":"test-tool",
+						"description":"A test tool",
+						"inputSchema":{
+							"type":"object",
+							"properties":{
+								"name":{"type":"string"},
+								"value":{"type":"number"}
+							},
+							"required":["name"]
+						},
+						"annotations":{
+							"title":"A test tool",
+							"readOnlyHint":false,
+							"destructiveHint":false,
+							"idempotentHint":false,
+							"openWorldHint":false,
+							"returnDirect":false
+						}
+					}
+					"""));
+	}
+
+	@Test
+	void testToolWithOutputSchema() throws Exception {
+		String inputSchemaJson = """
+				{
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"value": {
+							"type": "number"
+						}
+					},
+					"required": ["name"]
+				}
+				""";
+
+		String outputSchemaJson = """
+				{
+					"type": "object",
+					"properties": {
+						"result": {
+							"type": "string"
+						},
+						"status": {
+							"type": "string",
+							"enum": ["success", "error"]
+						}
+					},
+					"required": ["result", "status"]
+				}
+				""";
+
+		McpSchema.Tool tool = new McpSchema.Tool("test-tool", "A test tool", inputSchemaJson, outputSchemaJson, null);
+
+		String value = mapper.writeValueAsString(tool);
+		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
+			.when(Option.IGNORING_EXTRA_ARRAY_ITEMS)
+			.isObject()
+			.isEqualTo(json("""
+					{
+						"name":"test-tool",
+						"description":"A test tool",
+						"inputSchema":{
+							"type":"object",
+							"properties":{
+								"name":{"type":"string"},
+								"value":{"type":"number"}
+							},
+							"required":["name"]
+						},
+						"outputSchema":{
+							"type":"object",
+							"properties":{
+								"result":{"type":"string"},
+								"status":{
+									"type":"string",
+									"enum":["success","error"]
+								}
+							},
+							"required":["result","status"]
+						}
+					}
+					"""));
+	}
+
+	@Test
+	void testToolWithOutputSchemaAndAnnotations() throws Exception {
+		String inputSchemaJson = """
+				{
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						}
+					},
+					"required": ["name"]
+				}
+				""";
+
+		String outputSchemaJson = """
+				{
+					"type": "object",
+					"properties": {
+						"result": {
+							"type": "string"
+						}
+					},
+					"required": ["result"]
+				}
+				""";
+
+		McpSchema.ToolAnnotations annotations = new McpSchema.ToolAnnotations("A test tool with output", true, false,
+				true, false, true);
+
+		McpSchema.Tool tool = new McpSchema.Tool("test-tool", "A test tool", inputSchemaJson, outputSchemaJson,
+				annotations);
+
+		String value = mapper.writeValueAsString(tool);
+		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
+			.when(Option.IGNORING_EXTRA_ARRAY_ITEMS)
+			.isObject()
+			.isEqualTo(json("""
+					{
+						"name":"test-tool",
+						"description":"A test tool",
+						"inputSchema":{
+							"type":"object",
+							"properties":{
+								"name":{"type":"string"}
+							},
+							"required":["name"]
+						},
+						"outputSchema":{
+							"type":"object",
+							"properties":{
+								"result":{"type":"string"}
+							},
+							"required":["result"]
+						},
+						"annotations":{
+							"title":"A test tool with output",
+							"readOnlyHint":true,
+							"destructiveHint":false,
+							"idempotentHint":true,
+							"openWorldHint":false,
+							"returnDirect":true
+						}
+					}"""));
+	}
+
+	@Test
+	void testToolDeserialization() throws Exception {
+		String toolJson = """
+				{
+					"name": "test-tool",
+					"description": "A test tool",
+					"inputSchema": {
+						"type": "object",
+						"properties": {
+							"name": {"type": "string"}
+						},
+						"required": ["name"]
+					},
+					"outputSchema": {
+						"type": "object",
+						"properties": {
+							"result": {"type": "string"}
+						},
+						"required": ["result"]
+					},
+					"annotations": {
+						"title": "Test Tool",
+						"readOnlyHint": true,
+						"destructiveHint": false,
+						"idempotentHint": true,
+						"openWorldHint": false,
+						"returnDirect": false
+					}
+				}
+				""";
+
+		McpSchema.Tool tool = mapper.readValue(toolJson, McpSchema.Tool.class);
+
+		assertThat(tool).isNotNull();
+		assertThat(tool.name()).isEqualTo("test-tool");
+		assertThat(tool.description()).isEqualTo("A test tool");
+		assertThat(tool.inputSchema()).isNotNull();
+		assertThat(tool.inputSchema().type()).isEqualTo("object");
+		assertThat(tool.outputSchema()).isNotNull();
+		assertThat(tool.outputSchema()).containsKey("type");
+		assertThat(tool.outputSchema().get("type")).isEqualTo("object");
+		assertThat(tool.annotations()).isNotNull();
+		assertThat(tool.annotations().title()).isEqualTo("Test Tool");
+		assertThat(tool.annotations().readOnlyHint()).isTrue();
+		assertThat(tool.annotations().idempotentHint()).isTrue();
+		assertThat(tool.annotations().destructiveHint()).isFalse();
+		assertThat(tool.annotations().returnDirect()).isFalse();
+	}
+
+	@Test
+	void testToolDeserializationWithoutOutputSchema() throws Exception {
+		String toolJson = """
+				{
+					"name": "test-tool",
+					"description": "A test tool",
+					"inputSchema": {
+						"type": "object",
+						"properties": {
+							"name": {"type": "string"}
+						},
+						"required": ["name"]
+					}
+				}
+				""";
+
+		McpSchema.Tool tool = mapper.readValue(toolJson, McpSchema.Tool.class);
+
+		assertThat(tool).isNotNull();
+		assertThat(tool.name()).isEqualTo("test-tool");
+		assertThat(tool.description()).isEqualTo("A test tool");
+		assertThat(tool.inputSchema()).isNotNull();
+		assertThat(tool.outputSchema()).isNull();
+		assertThat(tool.annotations()).isNull();
 	}
 
 	@Test

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
 		<awaitility.version>4.2.0</awaitility.version>
 		<bnd-maven-plugin.version>7.1.0</bnd-maven-plugin.version>
 		<json-unit-assertj.version>4.1.0</json-unit-assertj.version>
+		<json-schema-validator.version>1.5.7</json-schema-validator.version>
 
 	</properties>
 


### PR DESCRIPTION
- Add JsonSchemaValidator interface and DefaultJsonSchemaValidator implementation
- Extend Tool schema to support outputSchema field for defining expected output structure
- Add structuredContent field to CallToolResult for validated structured responses
- Implement automatic validation of tool outputs against their defined schemas
- Add comprehensive test coverage for structured output validation scenarios
- Add json-schema-validator and json-unit-assertj dependencies for validation and testing
- Update McpServer builders to accept custom JsonSchemaValidator instances
- Ensure backward compatibility with existing tools without output schemas


<!-- Provide a brief summary of your changes -->
This PR implements **compulsory server-side validation** for MCP tools with output schemas, adding support for JSON schema validation of tool outputs according to the MCP specification. Tools can now define output schemas that are automatically validated on the server side, ensuring structured responses conform to expected formats before being sent to clients.
Spec Reference: https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The MCP specification requires that **servers** with tools that have output schemas must provide structured results that conform to those schemas. This change implements that **mandatory server-side validation requirement** by:
- Enabling tools to define expected output structure via JSON schemas
- Automatically validating tool responses against their defined schemas **on the server side**
- Providing clear error messages when validation fails
- Ensuring backward compatibility with existing tools

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Test coverage has been added across all server transport implementations:

- `WebFluxSseIntegrationTests.java` - Added 4 new test methods for structured output validation
- `WebMvcSseIntegrationTests.java` - Added 4 new test methods for structured output validation
- `HttpServletSseServerTransportProviderIntegrationTests.java` - Added 4 new test methods for structured output validation
- `McpSchemaTests.java` - Added 5 new test methods for Tool schema serialization/deserialization with output schemas

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
**No breaking changes.** This is a backward-compatible addition:
- Existing tools without output schemas continue to work unchanged
- New `outputSchema` and `structuredContent` fields are optional
- Default `JsonSchemaValidator` is provided automatically for server-side validation
- All existing APIs maintain their current behavior

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
**Implementation Details:**
- Added `JsonSchemaValidator` interface with `DefaultJsonSchemaValidator` implementation using `json-schema-validator` library
- Extended `Tool` record with optional `outputSchema` field
- Extended `CallToolResult` record with optional `structuredContent` field
- Implemented `StructuredOutputCallToolHandler` wrapper that validates outputs automatically **on the server side**
- Added comprehensive test utilities using `json-unit-assertj` for JSON assertions

**Design Decisions:**
- **Server-side validation** is performed automatically when tools have output schemas defined
- Invalid outputs are converted to error responses with descriptive messages **before being sent to clients**
- Structured content is also serialized to text content for backward compatibility
- Custom `JsonSchemaValidator` implementations can be provided via builder methods
- Validation only occurs for tools that explicitly define output schemas
- This implements the **compulsory server-side validation** requirement from the MCP specification

**Dependencies Added:**
- `json-schema-validator` (1.5.7) for JSON schema validation on the server
- `json-unit-assertj` for enhanced JSON testing capabilities

**Scope:**
This PR focuses exclusively on **server-side validation** as required by the MCP specification. Client-side validation is not included in this implementation.

