### PR TITLE
feat: Add error logging for HttpClientSseClientTransport

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
@@ -421,10 +421,10 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 				.build();
 
 			return Mono.fromFuture(
-					httpClient.sendAsync(request, HttpResponse.BodyHandlers.discarding()).thenAccept(response -> {
+					httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenAccept(response -> {
 						if (response.statusCode() != 200 && response.statusCode() != 201 && response.statusCode() != 202
 								&& response.statusCode() != 206) {
-							logger.error("Error sending message: {}", response.statusCode());
+							logger.error("Error sending message, code: {}, body: {}", response.statusCode(), response.body());
 						}
 					}));
 		}


### PR DESCRIPTION
Modified the HTTP request error handling to now capture and log the response body content (via response.body()) for non-success status codes (non-200/201/202/206), rather than only logging the status code.

## Motivation and Context
When a failed status code is received, ​​the response lacks a body​​, forcing developers to manually reproduce the issue.

## How Has This Been Tested?
Constructed an improperly configured HTTP client request builder and verified the log message output via unit testing.​

## Breaking Changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Using ofString() to read the response body aids in troubleshooting server errors, but ​​incurs serialization overhead​​ (even for trivial bodies like "Accepted"). If maintainers reject this change, the method requires a ​​documentation comment instructing developers to manually inspect the response body​​ during debugging.