### PR TITLE
Add option for immediate execution in McpSyncServer

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpSyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpSyncServer.java
@@ -54,13 +54,27 @@ public class McpSyncServer {
 	 */
 	private final McpAsyncServer asyncServer;
 
+	private final boolean immediateExecution;
+
 	/**
 	 * Creates a new synchronous server that wraps the provided async server.
 	 * @param asyncServer The async server to wrap
 	 */
 	public McpSyncServer(McpAsyncServer asyncServer) {
+		this(asyncServer, false);
+	}
+
+	/**
+	 * Creates a new synchronous server that wraps the provided async server.
+	 * @param asyncServer The async server to wrap
+	 * @param immediateExecution Tools, prompts, and resources handlers execute work
+	 * without blocking code offloading. Do NOT set to true if the {@code asyncServer}'s
+	 * transport is non-blocking.
+	 */
+	public McpSyncServer(McpAsyncServer asyncServer, boolean immediateExecution) {
 		Assert.notNull(asyncServer, "Async server must not be null");
 		this.asyncServer = asyncServer;
+		this.immediateExecution = immediateExecution;
 	}
 
 	/**
@@ -68,7 +82,9 @@ public class McpSyncServer {
 	 * @param toolHandler The tool handler to add
 	 */
 	public void addTool(McpServerFeatures.SyncToolSpecification toolHandler) {
-		this.asyncServer.addTool(McpServerFeatures.AsyncToolSpecification.fromSync(toolHandler)).block();
+		this.asyncServer
+			.addTool(McpServerFeatures.AsyncToolSpecification.fromSync(toolHandler, this.immediateExecution))
+			.block();
 	}
 
 	/**
@@ -84,7 +100,10 @@ public class McpSyncServer {
 	 * @param resourceHandler The resource handler to add
 	 */
 	public void addResource(McpServerFeatures.SyncResourceSpecification resourceHandler) {
-		this.asyncServer.addResource(McpServerFeatures.AsyncResourceSpecification.fromSync(resourceHandler)).block();
+		this.asyncServer
+			.addResource(
+					McpServerFeatures.AsyncResourceSpecification.fromSync(resourceHandler, this.immediateExecution))
+			.block();
 	}
 
 	/**
@@ -100,7 +119,10 @@ public class McpSyncServer {
 	 * @param promptSpecification The prompt specification to add
 	 */
 	public void addPrompt(McpServerFeatures.SyncPromptSpecification promptSpecification) {
-		this.asyncServer.addPrompt(McpServerFeatures.AsyncPromptSpecification.fromSync(promptSpecification)).block();
+		this.asyncServer
+			.addPrompt(
+					McpServerFeatures.AsyncPromptSpecification.fromSync(promptSpecification, this.immediateExecution))
+			.block();
 	}
 
 	/**

--- a/mcp/src/test/java/io/modelcontextprotocol/server/transport/McpTestServletFilter.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/transport/McpTestServletFilter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 - 2025 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server.transport;
+
+import java.io.IOException;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+
+/**
+ * Simple {@link Filter} which sets a value in a thread local. Used to verify whether MCP
+ * executions happen on the thread processing the request or are offloaded.
+ *
+ * @author Daniel Garnier-Moiroux
+ */
+public class McpTestServletFilter implements Filter {
+
+	public static final String THREAD_LOCAL_VALUE = McpTestServletFilter.class.getName();
+
+	private static final ThreadLocal<String> holder = new ThreadLocal<>();
+
+	@Override
+	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+			throws IOException, ServletException {
+		holder.set(THREAD_LOCAL_VALUE);
+		try {
+			filterChain.doFilter(servletRequest, servletResponse);
+		}
+		finally {
+			holder.remove();
+		}
+	}
+
+	public static String getThreadLocalValue() {
+		return holder.get();
+	}
+
+}

--- a/mcp/src/test/java/io/modelcontextprotocol/server/transport/TomcatTestUtil.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/transport/TomcatTestUtil.java
@@ -10,9 +10,12 @@ import java.net.ServerSocket;
 import jakarta.servlet.Servlet;
 import org.apache.catalina.Context;
 import org.apache.catalina.startup.Tomcat;
+import org.apache.tomcat.util.descriptor.web.FilterDef;
+import org.apache.tomcat.util.descriptor.web.FilterMap;
 
 /**
  * @author Christian Tzolov
+ * @author Daniel Garnier-Moiroux
  */
 public class TomcatTestUtil {
 
@@ -38,6 +41,16 @@ public class TomcatTestUtil {
 		wrapper.setAsyncSupported(true);
 		context.addChild(wrapper);
 		context.addServletMappingDecoded("/*", "mcpServlet");
+
+		var filterDef = new FilterDef();
+		filterDef.setFilterClass(McpTestServletFilter.class.getName());
+		filterDef.setFilterName(McpTestServletFilter.class.getSimpleName());
+		context.addFilterDef(filterDef);
+
+		var filterMap = new FilterMap();
+		filterMap.setFilterName(McpTestServletFilter.class.getSimpleName());
+		filterMap.addURLPattern("/*");
+		context.addFilterMap(filterMap);
 
 		var connector = tomcat.getConnector();
 		connector.setAsyncTimeout(3000);


### PR DESCRIPTION
Add the ability to decide whether or not to use blocking code offloading in `McpSyncServer`. Turning it off allows for the propagation of `ThreadLocal`s.

## Motivation and Context

I use this with Spring Security. Authentication data about the JWT that was used in the request is stored in a ThreadLocal. With `.subscribeOn(Schedulers.boundedElastic()))`, thread hops are introduced in blocking scenarios, and thread locals are lost.

In select case, when the user is sure they are NOT in a reactive context, they might want to enable "immediate execution", on the thread that calls `.block()`, for example in the `McpSyncServerExchange`, and preserve thread locals.

## How Has This Been Tested?

Trying this change with a [Spring-based sample](https://github.com/Kehrlann/spring-ai-mcp-authorization-demo), using Spring Security to pass the `SecurityContext` and authentication information.

## Breaking Changes

None

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
