### PR TITLE
Fix non-OK HTTP POST responses handling

### DIFF
--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebClientStreamableHttpTransport.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebClientStreamableHttpTransport.java
@@ -354,7 +354,7 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 			if (responseException.getStatusCode().isSameCodeAs(HttpStatus.BAD_REQUEST)) {
 				return Mono.error(new McpTransportSessionNotFoundException(sessionRepresentation, toPropagate));
 			}
-			return Mono.empty();
+			return Mono.error(toPropagate);
 		}).flux();
 	}
 


### PR DESCRIPTION
Currently, JDK HttpClient SSE implementation incorrectly handles a non-2xx HTTP response code for POST. Instead of immediately failing the caller, it ignores the issue and the user awaits until the timeout kicks in.

A related problem happened with the WebClient Streamable HTTP implementation, where the error was swallowed for non-400 responses.