### PR TITLE
refactor: Replace string concatenation with {} placeholders in log statements

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/StdioClientTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/StdioClientTransport.java
@@ -269,7 +269,7 @@ public class StdioClientTransport implements McpClientTransport {
 					}
 					catch (Exception e) {
 						if (!isClosing) {
-							logger.error("Error processing inbound message for line: " + line, e);
+							logger.error("Error processing inbound message for line: {}", line, e);
 						}
 						break;
 					}
@@ -366,7 +366,7 @@ public class StdioClientTransport implements McpClientTransport {
 			}
 		})).doOnNext(process -> {
 			if (process.exitValue() != 0) {
-				logger.warn("Process terminated with code " + process.exitValue());
+				logger.warn("Process terminated with code {}", process.exitValue());
 			}
 			else {
 				logger.info("MCP server process stopped");

--- a/mcp/src/test/java/io/modelcontextprotocol/spec/McpClientSessionTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/spec/McpClientSessionTests.java
@@ -47,7 +47,7 @@ class McpClientSessionTests {
 	void setUp() {
 		transport = new MockMcpClientTransport();
 		session = new McpClientSession(TIMEOUT, transport, Map.of(),
-				Map.of(TEST_NOTIFICATION, params -> Mono.fromRunnable(() -> logger.info("Status update: " + params))));
+				Map.of(TEST_NOTIFICATION, params -> Mono.fromRunnable(() -> logger.info("Status update: {}", params))));
 	}
 
 	@AfterEach


### PR DESCRIPTION
Improve logging performance and readability by replacing '+' based string concatenation with SLF4J-style {} placeholders across relevant modules.