### PR TITLE
fix: improve error handling in HttpClientSseClientTransport and add test

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
@@ -424,8 +424,8 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 				.flatMap(body -> sendHttpPost(messageEndpointUri, body).handle((response, sink) -> {
 					if (response.statusCode() != 200 && response.statusCode() != 201 && response.statusCode() != 202
 							&& response.statusCode() != 206) {
-						sink.error(new RuntimeException(
-								"Sending message failed with a non-OK HTTP code: " + response.statusCode()));
+						sink.error(new RuntimeException("Sending message failed with a non-OK HTTP code: "
+								+ response.statusCode() + " - " + response.body()));
 					}
 					else {
 						sink.next(response);
@@ -453,7 +453,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 		});
 	}
 
-	private Mono<HttpResponse<Void>> sendHttpPost(final String endpoint, final String body) {
+	private Mono<HttpResponse<String>> sendHttpPost(final String endpoint, final String body) {
 		final URI requestUri = Utils.resolveUri(baseUri, endpoint);
 		final HttpRequest request = this.requestBuilder.copy()
 			.uri(requestUri)
@@ -461,7 +461,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 			.build();
 
 		// TODO: why discard the body?
-		return Mono.fromFuture(httpClient.sendAsync(request, HttpResponse.BodyHandlers.discarding()));
+		return Mono.fromFuture(httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()));
 	}
 
 	/**

--- a/mcp/src/test/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransportTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransportTests.java
@@ -106,6 +106,16 @@ class HttpClientSseClientTransportTests {
 	}
 
 	@Test
+	void testErrorOnBogusMessage() {
+		// bogus message
+		JSONRPCRequest bogusMessage = new JSONRPCRequest(null, null, "test-id", Map.of("key", "value"));
+
+		StepVerifier.create(transport.sendMessage(bogusMessage))
+			.verifyErrorMessage(
+					"Sending message failed with a non-OK HTTP code: 400 - Invalid message: {\"id\":\"test-id\",\"params\":{\"key\":\"value\"}}");
+	}
+
+	@Test
 	void testMessageProcessing() {
 		// Create a test message
 		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method", "test-id",


### PR DESCRIPTION
- Include response body in error messages for better debugging
- Change sendHttpPost return type from HttpResponse<Void> to HttpResponse<String>
- Use BodyHandlers.ofString() instead of discarding response body
- Add testErrorOnBogusMessage test to verify error handling for invalid JSON-RPC messages
- Test validates that malformed messages return 400 status with descriptive error message

Replace #361

