### PR TITLE
Enforce String or Integer non-null ID for MCP JSON-RPC Messages with a new McpSchema subclass

### DIFF
--- a/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransportTests.java
+++ b/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransportTests.java
@@ -12,6 +12,7 @@ import java.util.function.Function;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.JSONRPCRequest;
+import io.modelcontextprotocol.spec.McpSchema.MessageId;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -161,8 +162,8 @@ class WebFluxSseClientTransportTests {
 	@Test
 	void testMessageProcessing() {
 		// Create a test message
-		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method", "test-id",
-				Map.of("key", "value"));
+		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method",
+				MessageId.of("test-id"), Map.of("key", "value"));
 
 		// Simulate receiving the message
 		transport.simulateMessageEvent("""
@@ -192,8 +193,8 @@ class WebFluxSseClientTransportTests {
 				""");
 
 		// Create and send a request message
-		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method", "test-id",
-				Map.of("key", "value"));
+		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method",
+				MessageId.of("test-id"), Map.of("key", "value"));
 
 		// Verify message handling
 		StepVerifier.create(transport.sendMessage(testMessage)).verifyComplete();
@@ -216,8 +217,8 @@ class WebFluxSseClientTransportTests {
 				""");
 
 		// Create and send a request message
-		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method", "test-id",
-				Map.of("key", "value"));
+		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method",
+				MessageId.of("test-id"), Map.of("key", "value"));
 
 		// Verify message handling
 		StepVerifier.create(transport.sendMessage(testMessage)).verifyComplete();
@@ -246,8 +247,8 @@ class WebFluxSseClientTransportTests {
 		StepVerifier.create(transport.closeGracefully()).verifyComplete();
 
 		// Create a test message
-		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method", "test-id",
-				Map.of("key", "value"));
+		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method",
+				MessageId.of("test-id"), Map.of("key", "value"));
 
 		// Verify message is not processed after shutdown
 		StepVerifier.create(transport.sendMessage(testMessage)).verifyComplete();
@@ -292,10 +293,10 @@ class WebFluxSseClientTransportTests {
 				""");
 
 		// Create and send corresponding messages
-		JSONRPCRequest message1 = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "method1", "id1",
+		JSONRPCRequest message1 = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "method1", MessageId.of("id1"),
 				Map.of("key", "value1"));
 
-		JSONRPCRequest message2 = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "method2", "id2",
+		JSONRPCRequest message2 = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "method2", MessageId.of("id2"),
 				Map.of("key", "value2"));
 
 		// Verify both messages are processed

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
+import io.modelcontextprotocol.spec.McpSchema.MessageId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
@@ -23,7 +24,7 @@ public class McpServerSession implements McpSession {
 
 	private static final Logger logger = LoggerFactory.getLogger(McpServerSession.class);
 
-	private final ConcurrentHashMap<Object, MonoSink<McpSchema.JSONRPCResponse>> pendingResponses = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<MessageId, MonoSink<McpSchema.JSONRPCResponse>> pendingResponses = new ConcurrentHashMap<>();
 
 	private final String id;
 
@@ -104,13 +105,13 @@ public class McpServerSession implements McpSession {
 		this.clientInfo.lazySet(clientInfo);
 	}
 
-	private String generateRequestId() {
-		return this.id + "-" + this.requestCounter.getAndIncrement();
+	private MessageId generateRequestId() {
+		return MessageId.of(this.id + "-" + this.requestCounter.getAndIncrement());
 	}
 
 	@Override
 	public <T> Mono<T> sendRequest(String method, Object requestParams, TypeReference<T> typeRef) {
-		String requestId = this.generateRequestId();
+		MessageId requestId = this.generateRequestId();
 
 		return Mono.<McpSchema.JSONRPCResponse>create(sink -> {
 			this.pendingResponses.put(requestId, sink);

--- a/mcp/src/test/java/io/modelcontextprotocol/client/McpAsyncClientResponseHandlerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/McpAsyncClientResponseHandlerTests.java
@@ -17,6 +17,7 @@ import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.ClientCapabilities;
 import io.modelcontextprotocol.spec.McpSchema.InitializeResult;
+import io.modelcontextprotocol.spec.McpSchema.MessageId;
 import io.modelcontextprotocol.spec.McpSchema.PaginatedRequest;
 import io.modelcontextprotocol.spec.McpSchema.Root;
 import org.junit.jupiter.api.Test;
@@ -172,7 +173,7 @@ class McpAsyncClientResponseHandlerTests {
 
 		// Simulate incoming request
 		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION,
-				McpSchema.METHOD_ROOTS_LIST, "test-id", null);
+				McpSchema.METHOD_ROOTS_LIST, MessageId.of("test-id"), null);
 		transport.simulateIncomingMessage(request);
 
 		// Verify response
@@ -180,7 +181,7 @@ class McpAsyncClientResponseHandlerTests {
 		assertThat(sentMessage).isInstanceOf(McpSchema.JSONRPCResponse.class);
 
 		McpSchema.JSONRPCResponse response = (McpSchema.JSONRPCResponse) sentMessage;
-		assertThat(response.id()).isEqualTo("test-id");
+		assertThat(response.id()).isEqualTo(MessageId.of("test-id"));
 		assertThat(response.result())
 			.isEqualTo(new McpSchema.ListRootsResult(List.of(new Root("file:///test/path", "test-root"))));
 		assertThat(response.error()).isNull();
@@ -309,7 +310,7 @@ class McpAsyncClientResponseHandlerTests {
 
 		// Simulate incoming request
 		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION,
-				McpSchema.METHOD_SAMPLING_CREATE_MESSAGE, "test-id", messageRequest);
+				McpSchema.METHOD_SAMPLING_CREATE_MESSAGE, MessageId.of("test-id"), messageRequest);
 		transport.simulateIncomingMessage(request);
 
 		// Verify response
@@ -317,7 +318,7 @@ class McpAsyncClientResponseHandlerTests {
 		assertThat(sentMessage).isInstanceOf(McpSchema.JSONRPCResponse.class);
 
 		McpSchema.JSONRPCResponse response = (McpSchema.JSONRPCResponse) sentMessage;
-		assertThat(response.id()).isEqualTo("test-id");
+		assertThat(response.id()).isEqualTo(MessageId.of("test-id"));
 		assertThat(response.error()).isNull();
 
 		McpSchema.CreateMessageResult result = transport.unmarshalFrom(response.result(),
@@ -350,7 +351,7 @@ class McpAsyncClientResponseHandlerTests {
 
 		// Simulate incoming request
 		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION,
-				McpSchema.METHOD_SAMPLING_CREATE_MESSAGE, "test-id", messageRequest);
+				McpSchema.METHOD_SAMPLING_CREATE_MESSAGE, MessageId.of("test-id"), messageRequest);
 		transport.simulateIncomingMessage(request);
 
 		// Verify error response
@@ -358,7 +359,7 @@ class McpAsyncClientResponseHandlerTests {
 		assertThat(sentMessage).isInstanceOf(McpSchema.JSONRPCResponse.class);
 
 		McpSchema.JSONRPCResponse response = (McpSchema.JSONRPCResponse) sentMessage;
-		assertThat(response.id()).isEqualTo("test-id");
+		assertThat(response.id()).isEqualTo(MessageId.of("test-id"));
 		assertThat(response.result()).isNull();
 		assertThat(response.error()).isNotNull();
 		assertThat(response.error().message()).contains("Method not found: sampling/createMessage");
@@ -414,7 +415,7 @@ class McpAsyncClientResponseHandlerTests {
 
 		// Simulate incoming request
 		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION,
-				McpSchema.METHOD_ELICITATION_CREATE, "test-id", elicitRequest);
+				McpSchema.METHOD_ELICITATION_CREATE, MessageId.of("test-id"), elicitRequest);
 		transport.simulateIncomingMessage(request);
 
 		// Verify response
@@ -422,7 +423,7 @@ class McpAsyncClientResponseHandlerTests {
 		assertThat(sentMessage).isInstanceOf(McpSchema.JSONRPCResponse.class);
 
 		McpSchema.JSONRPCResponse response = (McpSchema.JSONRPCResponse) sentMessage;
-		assertThat(response.id()).isEqualTo("test-id");
+		assertThat(response.id()).isEqualTo(MessageId.of("test-id"));
 		assertThat(response.error()).isNull();
 
 		McpSchema.ElicitResult result = transport.unmarshalFrom(response.result(), new TypeReference<>() {
@@ -459,7 +460,7 @@ class McpAsyncClientResponseHandlerTests {
 
 		// Simulate incoming request
 		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION,
-				McpSchema.METHOD_ELICITATION_CREATE, "test-id", elicitRequest);
+				McpSchema.METHOD_ELICITATION_CREATE, MessageId.of("test-id"), elicitRequest);
 		transport.simulateIncomingMessage(request);
 
 		// Verify response
@@ -467,7 +468,7 @@ class McpAsyncClientResponseHandlerTests {
 		assertThat(sentMessage).isInstanceOf(McpSchema.JSONRPCResponse.class);
 
 		McpSchema.JSONRPCResponse response = (McpSchema.JSONRPCResponse) sentMessage;
-		assertThat(response.id()).isEqualTo("test-id");
+		assertThat(response.id()).isEqualTo(MessageId.of("test-id"));
 		assertThat(response.error()).isNull();
 
 		McpSchema.ElicitResult result = transport.unmarshalFrom(response.result(), new TypeReference<>() {
@@ -498,7 +499,7 @@ class McpAsyncClientResponseHandlerTests {
 
 		// Simulate incoming request
 		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION,
-				McpSchema.METHOD_ELICITATION_CREATE, "test-id", elicitRequest);
+				McpSchema.METHOD_ELICITATION_CREATE, MessageId.of("test-id"), elicitRequest);
 		transport.simulateIncomingMessage(request);
 
 		// Verify error response
@@ -506,7 +507,7 @@ class McpAsyncClientResponseHandlerTests {
 		assertThat(sentMessage).isInstanceOf(McpSchema.JSONRPCResponse.class);
 
 		McpSchema.JSONRPCResponse response = (McpSchema.JSONRPCResponse) sentMessage;
-		assertThat(response.id()).isEqualTo("test-id");
+		assertThat(response.id()).isEqualTo(MessageId.of("test-id"));
 		assertThat(response.result()).isNull();
 		assertThat(response.error()).isNotNull();
 		assertThat(response.error().message()).contains("Method not found: elicitation/create");
@@ -535,7 +536,7 @@ class McpAsyncClientResponseHandlerTests {
 
 		// Simulate incoming ping request from server
 		McpSchema.JSONRPCRequest pingRequest = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION,
-				McpSchema.METHOD_PING, "ping-id", null);
+				McpSchema.METHOD_PING, MessageId.of("ping-id"), null);
 		transport.simulateIncomingMessage(pingRequest);
 
 		// Verify response
@@ -543,7 +544,7 @@ class McpAsyncClientResponseHandlerTests {
 		assertThat(sentMessage).isInstanceOf(McpSchema.JSONRPCResponse.class);
 
 		McpSchema.JSONRPCResponse response = (McpSchema.JSONRPCResponse) sentMessage;
-		assertThat(response.id()).isEqualTo("ping-id");
+		assertThat(response.id()).isEqualTo(MessageId.of("ping-id"));
 		assertThat(response.error()).isNull();
 		assertThat(response.result()).isInstanceOf(Map.class);
 		assertThat(((Map<?, ?>) response.result())).isEmpty();

--- a/mcp/src/test/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransportTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransportTests.java
@@ -17,6 +17,7 @@ import java.util.function.Function;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.JSONRPCRequest;
+import io.modelcontextprotocol.spec.McpSchema.MessageId;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -108,7 +109,7 @@ class HttpClientSseClientTransportTests {
 	@Test
 	void testErrorOnBogusMessage() {
 		// bogus message
-		JSONRPCRequest bogusMessage = new JSONRPCRequest(null, null, "test-id", Map.of("key", "value"));
+		JSONRPCRequest bogusMessage = new JSONRPCRequest(null, null, MessageId.of("test-id"), Map.of("key", "value"));
 
 		StepVerifier.create(transport.sendMessage(bogusMessage))
 			.verifyErrorMessage(
@@ -118,8 +119,8 @@ class HttpClientSseClientTransportTests {
 	@Test
 	void testMessageProcessing() {
 		// Create a test message
-		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method", "test-id",
-				Map.of("key", "value"));
+		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method",
+				MessageId.of("test-id"), Map.of("key", "value"));
 
 		// Simulate receiving the message
 		transport.simulateMessageEvent("""
@@ -149,8 +150,8 @@ class HttpClientSseClientTransportTests {
 				""");
 
 		// Create and send a request message
-		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method", "test-id",
-				Map.of("key", "value"));
+		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method",
+				MessageId.of("test-id"), Map.of("key", "value"));
 
 		// Verify message handling
 		StepVerifier.create(transport.sendMessage(testMessage)).verifyComplete();
@@ -173,8 +174,8 @@ class HttpClientSseClientTransportTests {
 				""");
 
 		// Create and send a request message
-		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method", "test-id",
-				Map.of("key", "value"));
+		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method",
+				MessageId.of("test-id"), Map.of("key", "value"));
 
 		// Verify message handling
 		StepVerifier.create(transport.sendMessage(testMessage)).verifyComplete();
@@ -203,8 +204,8 @@ class HttpClientSseClientTransportTests {
 		StepVerifier.create(transport.closeGracefully()).verifyComplete();
 
 		// Create a test message
-		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method", "test-id",
-				Map.of("key", "value"));
+		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method",
+				MessageId.of("test-id"), Map.of("key", "value"));
 
 		// Verify message is not processed after shutdown
 		StepVerifier.create(transport.sendMessage(testMessage)).verifyComplete();
@@ -248,10 +249,10 @@ class HttpClientSseClientTransportTests {
 				""");
 
 		// Create and send corresponding messages
-		JSONRPCRequest message1 = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "method1", "id1",
+		JSONRPCRequest message1 = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "method1", MessageId.of("id1"),
 				Map.of("key", "value1"));
 
-		JSONRPCRequest message2 = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "method2", "id2",
+		JSONRPCRequest message2 = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "method2", MessageId.of("id2"),
 				Map.of("key", "value2"));
 
 		// Verify both messages are processed

--- a/mcp/src/test/java/io/modelcontextprotocol/server/McpServerProtocolVersionTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/McpServerProtocolVersionTests.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import io.modelcontextprotocol.MockMcpServerTransport;
 import io.modelcontextprotocol.MockMcpServerTransportProvider;
 import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.MessageId;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,7 +24,7 @@ class McpServerProtocolVersionTests {
 
 	private static final McpSchema.Implementation CLIENT_INFO = new McpSchema.Implementation("test-client", "1.0.0");
 
-	private McpSchema.JSONRPCRequest jsonRpcInitializeRequest(String requestId, String protocolVersion) {
+	private McpSchema.JSONRPCRequest jsonRpcInitializeRequest(MessageId requestId, String protocolVersion) {
 		return new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, McpSchema.METHOD_INITIALIZE, requestId,
 				new McpSchema.InitializeRequest(protocolVersion, null, CLIENT_INFO));
 	}
@@ -34,7 +35,7 @@ class McpServerProtocolVersionTests {
 		var transportProvider = new MockMcpServerTransportProvider(serverTransport);
 		McpAsyncServer server = McpServer.async(transportProvider).serverInfo(SERVER_INFO).build();
 
-		String requestId = UUID.randomUUID().toString();
+		MessageId requestId = MessageId.of(UUID.randomUUID().toString());
 
 		transportProvider
 			.simulateIncomingMessage(jsonRpcInitializeRequest(requestId, McpSchema.LATEST_PROTOCOL_VERSION));
@@ -60,7 +61,7 @@ class McpServerProtocolVersionTests {
 
 		server.setProtocolVersions(List.of(oldVersion, McpSchema.LATEST_PROTOCOL_VERSION));
 
-		String requestId = UUID.randomUUID().toString();
+		MessageId requestId = MessageId.of(UUID.randomUUID().toString());
 
 		transportProvider.simulateIncomingMessage(jsonRpcInitializeRequest(requestId, oldVersion));
 
@@ -83,7 +84,7 @@ class McpServerProtocolVersionTests {
 
 		McpAsyncServer server = McpServer.async(transportProvider).serverInfo(SERVER_INFO).build();
 
-		String requestId = UUID.randomUUID().toString();
+		MessageId requestId = MessageId.of(UUID.randomUUID().toString());
 
 		transportProvider.simulateIncomingMessage(jsonRpcInitializeRequest(requestId, unsupportedVersion));
 
@@ -111,7 +112,8 @@ class McpServerProtocolVersionTests {
 
 		server.setProtocolVersions(List.of(oldVersion, middleVersion, latestVersion));
 
-		String requestId = UUID.randomUUID().toString();
+		MessageId requestId = MessageId.of(UUID.randomUUID().toString());
+
 		transportProvider.simulateIncomingMessage(jsonRpcInitializeRequest(requestId, latestVersion));
 
 		McpSchema.JSONRPCMessage response = serverTransport.getLastSentMessage();

--- a/mcp/src/test/java/io/modelcontextprotocol/spec/McpClientSessionTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/spec/McpClientSessionTests.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.modelcontextprotocol.MockMcpClientTransport;
+import io.modelcontextprotocol.spec.McpSchema.MessageId;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -144,7 +145,7 @@ class McpClientSessionTests {
 
 		// Simulate incoming request
 		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, ECHO_METHOD,
-				"test-id", echoMessage);
+				MessageId.of("test-id"), echoMessage);
 		transport.simulateIncomingMessage(request);
 
 		// Verify response
@@ -179,7 +180,7 @@ class McpClientSessionTests {
 	void testUnknownMethodHandling() {
 		// Simulate incoming request for unknown method
 		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, "unknown.method",
-				"test-id", null);
+				MessageId.of("test-id"), null);
 		transport.simulateIncomingMessage(request);
 
 		// Verify error response

--- a/mcp/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
 
+import io.modelcontextprotocol.spec.McpSchema.MessageId;
 import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
 import net.javacrumbs.jsonunit.core.Option;
 
@@ -240,8 +241,8 @@ public class McpSchemaTests {
 		Map<String, Object> params = new HashMap<>();
 		params.put("key", "value");
 
-		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, "method_name", 1,
-				params);
+		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, "method_name",
+				MessageId.of(1), params);
 
 		String value = mapper.writeValueAsString(request);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -272,7 +273,8 @@ public class McpSchemaTests {
 		Map<String, Object> result = new HashMap<>();
 		result.put("result_key", "result_value");
 
-		McpSchema.JSONRPCResponse response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, 1, result, null);
+		McpSchema.JSONRPCResponse response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, MessageId.of(1),
+				result, null);
 
 		String value = mapper.writeValueAsString(response);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -287,7 +289,8 @@ public class McpSchemaTests {
 		McpSchema.JSONRPCResponse.JSONRPCError error = new McpSchema.JSONRPCResponse.JSONRPCError(
 				McpSchema.ErrorCodes.INVALID_REQUEST, "Invalid request", null);
 
-		McpSchema.JSONRPCResponse response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, 1, null, error);
+		McpSchema.JSONRPCResponse response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, MessageId.of(1),
+				null, error);
 
 		String value = mapper.writeValueAsString(response);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)


### PR DESCRIPTION
I considered `JSONRPCMessageID`, but didn't want the `JSONRPC` prefix as it might imply nullability or possibly a float, as is standard for a JSON-RPC `id`.
I also considered `id` but figured it was too ambiguous.
I can see an argument for `McpMessageId`, but I figured it being in the `McpSchema` namespace was good enough for someone to identify the `MessageId` type as specific to MCP.


## Motivation and Context
The specification conditions for JSON-RPC Message `id` values include the requirements of the value being a (non-null) String or Integer.

## How Has This Been Tested?
Multiple existing tests use this field, have been updated accordingly, and confirmed to work correctly after the changes.

## Breaking Changes
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

