### PR TITLE
feat: implement MCP protocol version header support

### DIFF
--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebClientStreamableHttpTransport.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebClientStreamableHttpTransport.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.modelcontextprotocol.spec.DefaultMcpTransportSession;
 import io.modelcontextprotocol.spec.DefaultMcpTransportStream;
+import io.modelcontextprotocol.spec.HttpHeaders;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -66,9 +67,7 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 
 	private static final Logger logger = LoggerFactory.getLogger(WebClientStreamableHttpTransport.class);
 
-	private static final String MCP_PROTOCOL_VERSION = "2025-06-18";
-
-	private static final String MCP_PROTOCOL_VERSION_HEADER_NAME = "MCP-Protocol-Version";
+	private static final String MCP_PROTOCOL_VERSION = "2025-03-26";
 
 	private static final String DEFAULT_ENDPOINT = "/mcp";
 
@@ -107,6 +106,11 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 		this.activeSession.set(createTransportSession());
 	}
 
+	@Override
+	public String protocolVersion() {
+		return MCP_PROTOCOL_VERSION;
+	}
+
 	/**
 	 * Create a stateful builder for creating {@link WebClientStreamableHttpTransport}
 	 * instances.
@@ -134,10 +138,10 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 		Function<String, Publisher<Void>> onClose = sessionId -> sessionId == null ? Mono.empty()
 				: webClient.delete()
 					.uri(this.endpoint)
-					.header(MCP_PROTOCOL_VERSION_HEADER_NAME, MCP_PROTOCOL_VERSION)
+					.header(HttpHeaders.PROTOCOL_VERSION, MCP_PROTOCOL_VERSION)
 					.headers(httpHeaders -> {
-						httpHeaders.add("mcp-session-id", sessionId);
-						httpHeaders.add(MCP_PROTOCOL_VERSION_HEADER_NAME, MCP_PROTOCOL_VERSION);
+						httpHeaders.add(HttpHeaders.MCP_SESSION_ID, sessionId);
+						httpHeaders.add(HttpHeaders.PROTOCOL_VERSION, MCP_PROTOCOL_VERSION);
 					})
 					.retrieve()
 					.toBodilessEntity()
@@ -198,11 +202,11 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 			Disposable connection = webClient.get()
 				.uri(this.endpoint)
 				.accept(MediaType.TEXT_EVENT_STREAM)
-				.header(MCP_PROTOCOL_VERSION_HEADER_NAME, MCP_PROTOCOL_VERSION)
+				.header(HttpHeaders.PROTOCOL_VERSION, MCP_PROTOCOL_VERSION)
 				.headers(httpHeaders -> {
-					transportSession.sessionId().ifPresent(id -> httpHeaders.add("mcp-session-id", id));
+					transportSession.sessionId().ifPresent(id -> httpHeaders.add(HttpHeaders.MCP_SESSION_ID, id));
 					if (stream != null) {
-						stream.lastId().ifPresent(id -> httpHeaders.add("last-event-id", id));
+						stream.lastId().ifPresent(id -> httpHeaders.add(HttpHeaders.LAST_EVENT_ID, id));
 					}
 				})
 				.exchangeToFlux(response -> {
@@ -259,14 +263,14 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 			Disposable connection = webClient.post()
 				.uri(this.endpoint)
 				.accept(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
-				.header(MCP_PROTOCOL_VERSION_HEADER_NAME, MCP_PROTOCOL_VERSION)
+				.header(HttpHeaders.PROTOCOL_VERSION, MCP_PROTOCOL_VERSION)
 				.headers(httpHeaders -> {
-					transportSession.sessionId().ifPresent(id -> httpHeaders.add("mcp-session-id", id));
+					transportSession.sessionId().ifPresent(id -> httpHeaders.add(HttpHeaders.MCP_SESSION_ID, id));
 				})
 				.bodyValue(message)
 				.exchangeToFlux(response -> {
 					if (transportSession
-						.markInitialized(response.headers().asHttpHeaders().getFirst("mcp-session-id"))) {
+						.markInitialized(response.headers().asHttpHeaders().getFirst(HttpHeaders.MCP_SESSION_ID))) {
 						// Once we have a session, we try to open an async stream for
 						// the server to send notifications and requests out-of-band.
 						reconnect(null).contextWrite(sink.contextView()).subscribe();

--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransport.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransport.java
@@ -9,6 +9,8 @@ import java.util.function.Function;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.modelcontextprotocol.spec.HttpHeaders;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -63,8 +65,6 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 	private static final Logger logger = LoggerFactory.getLogger(WebFluxSseClientTransport.class);
 
 	private static final String MCP_PROTOCOL_VERSION = "2024-11-05";
-
-	private static final String MCP_PROTOCOL_VERSION_HEADER_NAME = "MCP-Protocol-Version";
 
 	/**
 	 * Event type for JSON-RPC messages received through the SSE connection. The server
@@ -170,6 +170,11 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 		this.sseEndpoint = sseEndpoint;
 	}
 
+	@Override
+	public String protocolVersion() {
+		return MCP_PROTOCOL_VERSION;
+	}
+
 	/**
 	 * Establishes a connection to the MCP server using Server-Sent Events (SSE). This
 	 * method initiates the SSE connection and sets up the message processing pipeline.
@@ -254,7 +259,7 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 				return webClient.post()
 					.uri(messageEndpointUri)
 					.contentType(MediaType.APPLICATION_JSON)
-					.header(MCP_PROTOCOL_VERSION_HEADER_NAME, MCP_PROTOCOL_VERSION)
+					.header(HttpHeaders.PROTOCOL_VERSION, MCP_PROTOCOL_VERSION)
 					.bodyValue(jsonText)
 					.retrieve()
 					.toBodilessEntity()
@@ -287,7 +292,7 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 			.get()
 			.uri(this.sseEndpoint)
 			.accept(MediaType.TEXT_EVENT_STREAM)
-			.header(MCP_PROTOCOL_VERSION_HEADER_NAME, MCP_PROTOCOL_VERSION)
+			.header(HttpHeaders.PROTOCOL_VERSION, MCP_PROTOCOL_VERSION)
 			.retrieve()
 			.bodyToFlux(SSE_TYPE)
 			.retryWhen(Retry.from(retrySignal -> retrySignal.handle(inboundRetryHandler)));

--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransport.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransport.java
@@ -62,6 +62,10 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 
 	private static final Logger logger = LoggerFactory.getLogger(WebFluxSseClientTransport.class);
 
+	private static final String MCP_PROTOCOL_VERSION = "2024-11-05";
+
+	private static final String MCP_PROTOCOL_VERSION_HEADER_NAME = "MCP-Protocol-Version";
+
 	/**
 	 * Event type for JSON-RPC messages received through the SSE connection. The server
 	 * sends messages with this event type to transmit JSON-RPC protocol data.
@@ -250,6 +254,7 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 				return webClient.post()
 					.uri(messageEndpointUri)
 					.contentType(MediaType.APPLICATION_JSON)
+					.header(MCP_PROTOCOL_VERSION_HEADER_NAME, MCP_PROTOCOL_VERSION)
 					.bodyValue(jsonText)
 					.retrieve()
 					.toBodilessEntity()
@@ -282,6 +287,7 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 			.get()
 			.uri(this.sseEndpoint)
 			.accept(MediaType.TEXT_EVENT_STREAM)
+			.header(MCP_PROTOCOL_VERSION_HEADER_NAME, MCP_PROTOCOL_VERSION)
 			.retrieve()
 			.bodyToFlux(SSE_TYPE)
 			.retryWhen(Retry.from(retrySignal -> retrySignal.handle(inboundRetryHandler)));

--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxSseServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxSseServerTransportProvider.java
@@ -79,6 +79,8 @@ public class WebFluxSseServerTransportProvider implements McpServerTransportProv
 	 */
 	public static final String ENDPOINT_EVENT_TYPE = "endpoint";
 
+	private static final String MCP_PROTOCOL_VERSION = "2025-06-18";
+
 	/**
 	 * Default SSE endpoint path as specified by the MCP transport specification.
 	 */
@@ -210,6 +212,11 @@ public class WebFluxSseServerTransportProvider implements McpServerTransportProv
 
 			this.keepAliveScheduler.start();
 		}
+	}
+
+	@Override
+	public String protocolVersion() {
+		return "2024-11-05";
 	}
 
 	@Override

--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxStatelessServerTransport.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxStatelessServerTransport.java
@@ -21,7 +21,6 @@ import reactor.core.publisher.Mono;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.function.Function;
 
 /**
  * Implementation of a WebFlux based {@link McpStatelessServerTransport}.

--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxStreamableServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxStreamableServerTransportProvider.java
@@ -96,6 +96,11 @@ public class WebFluxStreamableServerTransportProvider implements McpStreamableSe
 	}
 
 	@Override
+	public String protocolVersion() {
+		return "2025-03-26";
+	}
+
+	@Override
 	public void setSessionFactory(McpStreamableServerSession.Factory sessionFactory) {
 		this.sessionFactory = sessionFactory;
 	}

--- a/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransportProvider.java
@@ -210,6 +210,11 @@ public class WebMvcSseServerTransportProvider implements McpServerTransportProvi
 	}
 
 	@Override
+	public String protocolVersion() {
+		return "2024-11-05";
+	}
+
+	@Override
 	public void setSessionFactory(McpServerSession.Factory sessionFactory) {
 		this.sessionFactory = sessionFactory;
 	}

--- a/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcStreamableServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcStreamableServerTransportProvider.java
@@ -148,6 +148,11 @@ public class WebMvcStreamableServerTransportProvider implements McpStreamableSer
 	}
 
 	@Override
+	public String protocolVersion() {
+		return "2025-03-26";
+	}
+
+	@Override
 	public void setSessionFactory(McpStreamableServerSession.Factory sessionFactory) {
 		this.sessionFactory = sessionFactory;
 	}

--- a/mcp-spring/mcp-spring-webmvc/src/test/java/io/modelcontextprotocol/server/WebMvcSseCustomContextPathTests.java
+++ b/mcp-spring/mcp-spring-webmvc/src/test/java/io/modelcontextprotocol/server/WebMvcSseCustomContextPathTests.java
@@ -91,8 +91,15 @@ class WebMvcSseCustomContextPathTests {
 		@Bean
 		public WebMvcSseServerTransportProvider webMvcSseServerTransportProvider() {
 
-			return new WebMvcSseServerTransportProvider(new ObjectMapper(), CUSTOM_CONTEXT_PATH, MESSAGE_ENDPOINT,
-					WebMvcSseServerTransportProvider.DEFAULT_SSE_ENDPOINT);
+			return WebMvcSseServerTransportProvider.builder()
+				.objectMapper(new ObjectMapper())
+				.baseUrl(CUSTOM_CONTEXT_PATH)
+				.messageEndpoint(MESSAGE_ENDPOINT)
+				.sseEndpoint(WebMvcSseServerTransportProvider.DEFAULT_SSE_ENDPOINT)
+				.build();
+			// return new WebMvcSseServerTransportProvider(new ObjectMapper(),
+			// CUSTOM_CONTEXT_PATH, MESSAGE_ENDPOINT,
+			// WebMvcSseServerTransportProvider.DEFAULT_SSE_ENDPOINT);
 		}
 
 		@Bean

--- a/mcp/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
@@ -272,9 +272,8 @@ public class McpAsyncClient {
 				asyncProgressNotificationHandler(progressConsumersFinal));
 
 		this.initializer = new LifecycleInitializer(clientCapabilities, clientInfo,
-				List.of(McpSchema.LATEST_PROTOCOL_VERSION), initializationTimeout,
-				ctx -> new McpClientSession(requestTimeout, transport, requestHandlers, notificationHandlers,
-						con -> con.contextWrite(ctx)));
+				List.of(transport.protocolVersion()), initializationTimeout, ctx -> new McpClientSession(requestTimeout,
+						transport, requestHandlers, notificationHandlers, con -> con.contextWrite(ctx)));
 		this.transport.setExceptionHandler(this.initializer::handleException);
 	}
 

--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
@@ -61,6 +61,10 @@ import reactor.core.publisher.Sinks;
  */
 public class HttpClientSseClientTransport implements McpClientTransport {
 
+	private static final String MCP_PROTOCOL_VERSION = "2024-11-05";
+
+	private static final String MCP_PROTOCOL_VERSION_HEADER_NAME = "MCP-Protocol-Version";
+
 	private static final Logger logger = LoggerFactory.getLogger(HttpClientSseClientTransport.class);
 
 	/** SSE event type for JSON-RPC messages */
@@ -391,6 +395,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 				.uri(uri)
 				.header("Accept", "text/event-stream")
 				.header("Cache-Control", "no-cache")
+				.header(MCP_PROTOCOL_VERSION_HEADER_NAME, MCP_PROTOCOL_VERSION)
 				.GET();
 			return Mono.from(this.httpRequestCustomizer.customize(builder, "GET", uri, null));
 		}).flatMap(requestBuilder -> Mono.create(sink -> {
@@ -516,7 +521,10 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 	private Mono<HttpResponse<String>> sendHttpPost(final String endpoint, final String body) {
 		final URI requestUri = Utils.resolveUri(baseUri, endpoint);
 		return Mono.defer(() -> {
-			var builder = this.requestBuilder.copy().uri(requestUri).POST(HttpRequest.BodyPublishers.ofString(body));
+			var builder = this.requestBuilder.copy()
+				.uri(requestUri)
+				.header(MCP_PROTOCOL_VERSION_HEADER_NAME, MCP_PROTOCOL_VERSION)
+				.POST(HttpRequest.BodyPublishers.ofString(body));
 			return Mono.from(this.httpRequestCustomizer.customize(builder, "POST", requestUri, body));
 		}).flatMap(customizedBuilder -> {
 			var request = customizedBuilder.build();

--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
@@ -215,6 +215,11 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 		this.httpRequestCustomizer = httpRequestCustomizer;
 	}
 
+	@Override
+	public String protocolVersion() {
+		return MCP_PROTOCOL_VERSION;
+	}
+
 	/**
 	 * Creates a new builder for {@link HttpClientSseClientTransport}.
 	 * @param baseUri the base URI of the MCP server

--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
@@ -72,6 +72,10 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 
 	private static final Logger logger = LoggerFactory.getLogger(HttpClientStreamableHttpTransport.class);
 
+	private static final String MCP_PROTOCOL_VERSION = "2025-06-18";
+
+	private static final String MCP_PROTOCOL_VERSION_HEADER_NAME = "MCP-Protocol-Version";
+
 	private static final String DEFAULT_ENDPOINT = "/mcp";
 
 	/**
@@ -157,12 +161,14 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 	}
 
 	private Publisher<Void> createDelete(String sessionId) {
+
 		var uri = Utils.resolveUri(this.baseUri, this.endpoint);
 		return Mono.defer(() -> {
 			var builder = this.requestBuilder.copy()
 				.uri(uri)
 				.header("Cache-Control", "no-cache")
 				.header("mcp-session-id", sessionId)
+				.header(MCP_PROTOCOL_VERSION_HEADER_NAME, MCP_PROTOCOL_VERSION)
 				.DELETE();
 			return Mono.from(this.httpRequestCustomizer.customize(builder, "DELETE", uri, null));
 		}).flatMap(requestBuilder -> {
@@ -231,6 +237,7 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 				var builder = requestBuilder.uri(uri)
 					.header("Accept", TEXT_EVENT_STREAM)
 					.header("Cache-Control", "no-cache")
+					.header(MCP_PROTOCOL_VERSION_HEADER_NAME, MCP_PROTOCOL_VERSION)
 					.GET();
 				return Mono.from(this.httpRequestCustomizer.customize(builder, "GET", uri, null));
 			})
@@ -384,6 +391,7 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 					.header("Accept", APPLICATION_JSON + ", " + TEXT_EVENT_STREAM)
 					.header("Content-Type", APPLICATION_JSON)
 					.header("Cache-Control", "no-cache")
+					.header(MCP_PROTOCOL_VERSION_HEADER_NAME, MCP_PROTOCOL_VERSION)
 					.POST(HttpRequest.BodyPublishers.ofString(jsonBody));
 				return Mono.from(this.httpRequestCustomizer.customize(builder, "GET", uri, jsonBody));
 			}).flatMapMany(requestBuilder -> Flux.<ResponseEvent>create(responseEventSink -> {

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -115,7 +115,7 @@ public class McpAsyncServer {
 
 	private final ConcurrentHashMap<McpSchema.CompleteReference, McpServerFeatures.AsyncCompletionSpecification> completions = new ConcurrentHashMap<>();
 
-	private List<String> protocolVersions = List.of(McpSchema.LATEST_PROTOCOL_VERSION);
+	private List<String> protocolVersions;
 
 	private McpUriTemplateManagerFactory uriTemplateManagerFactory = new DeafaultMcpUriTemplateManagerFactory();
 
@@ -145,6 +145,8 @@ public class McpAsyncServer {
 		Map<String, McpRequestHandler<?>> requestHandlers = prepareRequestHandlers();
 		Map<String, McpNotificationHandler> notificationHandlers = prepareNotificationHandlers(features);
 
+		this.protocolVersions = List.of(mcpTransportProvider.protocolVersion());
+
 		mcpTransportProvider.setSessionFactory(transport -> new McpServerSession(UUID.randomUUID().toString(),
 				requestTimeout, transport, this::asyncInitializeRequestHandler, requestHandlers, notificationHandlers));
 	}
@@ -167,6 +169,8 @@ public class McpAsyncServer {
 
 		Map<String, McpRequestHandler<?>> requestHandlers = prepareRequestHandlers();
 		Map<String, McpNotificationHandler> notificationHandlers = prepareNotificationHandlers(features);
+
+		this.protocolVersions = List.of(mcpTransportProvider.protocolVersion());
 
 		mcpTransportProvider.setSessionFactory(new DefaultMcpStreamableServerSessionFactory(requestTimeout,
 				this::asyncInitializeRequestHandler, requestHandlers, notificationHandlers));

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
@@ -63,7 +63,7 @@ public class McpStatelessAsyncServer {
 
 	private final ConcurrentHashMap<McpSchema.CompleteReference, McpStatelessServerFeatures.AsyncCompletionSpecification> completions = new ConcurrentHashMap<>();
 
-	private List<String> protocolVersions = List.of(McpSchema.LATEST_PROTOCOL_VERSION);
+	private List<String> protocolVersions;
 
 	private McpUriTemplateManagerFactory uriTemplateManagerFactory = new DeafaultMcpUriTemplateManagerFactory();
 
@@ -117,6 +117,8 @@ public class McpStatelessAsyncServer {
 		if (this.serverCapabilities.completions() != null) {
 			requestHandlers.put(McpSchema.METHOD_COMPLETION_COMPLETE, completionCompleteRequestHandler());
 		}
+
+		this.protocolVersions = List.of(mcpTransport.protocolVersion());
 
 		McpStatelessServerHandler handler = new DefaultMcpStatelessServerHandler(requestHandlers, Map.of());
 		mcpTransport.setMcpHandler(handler);

--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
@@ -178,6 +178,11 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 		}
 	}
 
+	@Override
+	public String protocolVersion() {
+		return "2024-11-05";
+	}
+
 	/**
 	 * Creates a new HttpServletSseServerTransportProvider instance with the default SSE
 	 * endpoint.

--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
@@ -155,6 +155,11 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 	}
 
 	@Override
+	public String protocolVersion() {
+		return "2025-03-26";
+	}
+
+	@Override
 	public void setSessionFactory(McpStreamableServerSession.Factory sessionFactory) {
 		this.sessionFactory = sessionFactory;
 	}

--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
@@ -89,6 +89,11 @@ public class StdioServerTransportProvider implements McpServerTransportProvider 
 	}
 
 	@Override
+	public String protocolVersion() {
+		return "2024-11-05";
+	}
+
+	@Override
 	public void setSessionFactory(McpServerSession.Factory sessionFactory) {
 		// Create a single session for the stdio connection
 		var transport = new StdioMcpSessionTransport();

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/HttpHeaders.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/HttpHeaders.java
@@ -17,4 +17,9 @@ public interface HttpHeaders {
 	 */
 	String LAST_EVENT_ID = "last-event-id";
 
+	/**
+	 * Identifies the MCP protocol version.
+	 */
+	String PROTOCOL_VERSION = "MCP-Protocol-Version";
+
 }

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -44,6 +44,7 @@ public final class McpSchema {
 	private McpSchema() {
 	}
 
+	@Deprecated
 	public static final String LATEST_PROTOCOL_VERSION = "2025-03-26";
 
 	public static final String JSONRPC_VERSION = "2.0";

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerTransportProviderBase.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerTransportProviderBase.java
@@ -55,4 +55,12 @@ public interface McpServerTransportProviderBase {
 	 */
 	Mono<Void> closeGracefully();
 
+	/**
+	 * Returns the protocol version supported by this transport provider.
+	 * @return the protocol version as a string
+	 */
+	default String protocolVersion() {
+		return "2024-11-05";
+	}
+
 }

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpStatelessServerTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpStatelessServerTransport.java
@@ -22,4 +22,8 @@ public interface McpStatelessServerTransport {
 	 */
 	Mono<Void> closeGracefully();
 
+	default String protocolVersion() {
+		return "2025-03-26";
+	}
+
 }

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpStreamableServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpStreamableServerTransportProvider.java
@@ -2,8 +2,6 @@ package io.modelcontextprotocol.spec;
 
 import reactor.core.publisher.Mono;
 
-import java.util.Map;
-
 /**
  * The core building block providing the server-side MCP transport for Streamable HTTP
  * servers. Implement this interface to bridge between a particular server-side technology

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpTransport.java
@@ -77,4 +77,8 @@ public interface McpTransport {
 	 */
 	<T> T unmarshalFrom(Object data, TypeReference<T> typeRef);
 
+	default String protocolVersion() {
+		return "2024-11-05";
+	}
+
 }

--- a/mcp/src/test/java/io/modelcontextprotocol/MockMcpClientTransport.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/MockMcpClientTransport.java
@@ -29,6 +29,8 @@ public class MockMcpClientTransport implements McpClientTransport {
 
 	private final BiConsumer<MockMcpClientTransport, McpSchema.JSONRPCMessage> interceptor;
 
+	private String protocolVersion = McpSchema.LATEST_PROTOCOL_VERSION;
+
 	public MockMcpClientTransport() {
 		this((t, msg) -> {
 		});
@@ -36,6 +38,15 @@ public class MockMcpClientTransport implements McpClientTransport {
 
 	public MockMcpClientTransport(BiConsumer<MockMcpClientTransport, McpSchema.JSONRPCMessage> interceptor) {
 		this.interceptor = interceptor;
+	}
+
+	public MockMcpClientTransport withProtocolVersion(String protocolVersion) {
+		return this;
+	}
+
+	@Override
+	public String protocolVersion() {
+		return protocolVersion;
 	}
 
 	public void simulateIncomingMessage(McpSchema.JSONRPCMessage message) {

--- a/mcp/src/test/java/io/modelcontextprotocol/client/McpAsyncClientResponseHandlerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/McpAsyncClientResponseHandlerTests.java
@@ -52,7 +52,7 @@ class McpAsyncClientResponseHandlerTests {
 						r.id(), mockInitResult, null);
 				t.simulateIncomingMessage(initResponse);
 			}
-		});
+		}).withProtocolVersion(McpSchema.LATEST_PROTOCOL_VERSION);
 	}
 
 	@Test
@@ -79,7 +79,7 @@ class McpAsyncClientResponseHandlerTests {
 
 		// Verify initialization result
 		assertThat(result).isNotNull();
-		assertThat(result.protocolVersion()).isEqualTo(McpSchema.LATEST_PROTOCOL_VERSION);
+		assertThat(result.protocolVersion()).isEqualTo(transport.protocolVersion());
 		assertThat(result.capabilities()).isEqualTo(serverCapabilities);
 		assertThat(result.serverInfo()).isEqualTo(serverInfo);
 		assertThat(result.instructions()).isEqualTo("Test instructions");

--- a/mcp/src/test/java/io/modelcontextprotocol/client/McpAsyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/McpAsyncClientTests.java
@@ -20,8 +20,8 @@ class McpAsyncClientTests {
 	public static final McpSchema.ServerCapabilities MOCK_SERVER_CAPABILITIES = McpSchema.ServerCapabilities.builder()
 		.build();
 
-	public static final McpSchema.InitializeResult MOCK_INIT_RESULT = new McpSchema.InitializeResult(
-			McpSchema.LATEST_PROTOCOL_VERSION, MOCK_SERVER_CAPABILITIES, MOCK_SERVER_INFO, "Test instructions");
+	public static final McpSchema.InitializeResult MOCK_INIT_RESULT = new McpSchema.InitializeResult("2024-11-05",
+			MOCK_SERVER_CAPABILITIES, MOCK_SERVER_INFO, "Test instructions");
 
 	private static final String CONTEXT_KEY = "context.key";
 

--- a/mcp/src/test/java/io/modelcontextprotocol/client/McpClientProtocolVersionTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/McpClientProtocolVersionTests.java
@@ -41,14 +41,14 @@ class McpClientProtocolVersionTests {
 				McpSchema.JSONRPCRequest request = transport.getLastSentMessageAsRequest();
 				assertThat(request.params()).isInstanceOf(McpSchema.InitializeRequest.class);
 				McpSchema.InitializeRequest initRequest = (McpSchema.InitializeRequest) request.params();
-				assertThat(initRequest.protocolVersion()).isEqualTo(McpSchema.LATEST_PROTOCOL_VERSION);
+				assertThat(initRequest.protocolVersion()).isEqualTo(transport.protocolVersion());
 
 				transport.simulateIncomingMessage(new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(),
-						new McpSchema.InitializeResult(McpSchema.LATEST_PROTOCOL_VERSION, null,
+						new McpSchema.InitializeResult(transport.protocolVersion(), null,
 								new McpSchema.Implementation("test-server", "1.0.0"), null),
 						null));
 			}).assertNext(result -> {
-				assertThat(result.protocolVersion()).isEqualTo(McpSchema.LATEST_PROTOCOL_VERSION);
+				assertThat(result.protocolVersion()).isEqualTo(transport.protocolVersion());
 			}).verifyComplete();
 
 		}

--- a/mcp/src/test/java/io/modelcontextprotocol/server/McpServerProtocolVersionTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/McpServerProtocolVersionTests.java
@@ -45,7 +45,7 @@ class McpServerProtocolVersionTests {
 		assertThat(jsonResponse.id()).isEqualTo(requestId);
 		assertThat(jsonResponse.result()).isInstanceOf(McpSchema.InitializeResult.class);
 		McpSchema.InitializeResult result = (McpSchema.InitializeResult) jsonResponse.result();
-		assertThat(result.protocolVersion()).isEqualTo(McpSchema.LATEST_PROTOCOL_VERSION);
+		assertThat(result.protocolVersion()).isEqualTo(transportProvider.protocolVersion());
 
 		server.closeGracefully().subscribe();
 	}
@@ -93,7 +93,7 @@ class McpServerProtocolVersionTests {
 		assertThat(jsonResponse.id()).isEqualTo(requestId);
 		assertThat(jsonResponse.result()).isInstanceOf(McpSchema.InitializeResult.class);
 		McpSchema.InitializeResult result = (McpSchema.InitializeResult) jsonResponse.result();
-		assertThat(result.protocolVersion()).isEqualTo(McpSchema.LATEST_PROTOCOL_VERSION);
+		assertThat(result.protocolVersion()).isEqualTo(transportProvider.protocolVersion());
 
 		server.closeGracefully().subscribe();
 	}


### PR DESCRIPTION
Add MCP-Protocol-Version header to all HTTP requests as required by MCP specification 2025-06-18. This enables proper server-side version negotiation and backwards compatibility handling.

- Add protocol version constants (2025-06-18 for streamable HTTP, 2024-11-05 for SSE)
- Include MCP-Protocol-Version header in all GET/POST/DELETE requests
- Update WebClientStreamableHttpTransport, WebFluxSseClientTransport, HttpClientSseClientTransport, and HttpClientStreamableHttpTransport

Complies with MCP specification requirement that HTTP clients MUST include protocol version header on all requests to MCP servers.

Related to #398 , #363 , #250

**Implementation Details:**
- Added `MCP_PROTOCOL_VERSION` and `MCP_PROTOCOL_VERSION_HEADER_NAME` constants to all HTTP transport classes
- Uses protocol version `2025-06-18` for streamable HTTP transports (WebClientStreamableHttpTransport, HttpClientStreamableHttpTransport)
- Uses protocol version `2024-11-05` for SSE transports (WebFluxSseClientTransport, HttpClientSseClientTransport) for backwards compatibility
- Header is included in all HTTP requests (GET, POST, DELETE) across all transport implementations

**Specification Reference:**
- [MCP Specification - Protocol Version Header](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#protocol-version-header)

This change ensures full compliance with the MCP specification requirement that "the client MUST include the MCP-Protocol-Version HTTP header on all subsequent requests to the MCP server."

<!-- Provide a brief summary of your changes -->
Add MCP protocol version header support to all HTTP transport implementations as required by MCP specification 2025-06-18.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The MCP specification 2025-06-18 requires that HTTP clients **MUST** include the `MCP-Protocol-Version` header on all requests to MCP servers. This enables:
Without this header, servers cannot properly handle version-specific behavior and may not function correctly with clients using different protocol versions.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
- All existing unit tests pass with the changes
- HTTP requests now include the MCP-Protocol-Version header in all transport implementations
- Tested with both streamable HTTP transport (2025-06-18) and SSE transport (2024-11-05) scenarios
- Verified header is included in GET, POST, and DELETE requests across all affected transport classes

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
**No breaking changes.** This is a backwards-compatible addition:
- Existing client code continues to work without modification
- Only adds required headers to HTTP requests
- Servers that don't check for the header will continue to function normally
- Maintains backwards compatibility with older MCP protocol versions

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed


