### PR TITLE
feat: Expose initial ServerRequest for server-side auth

### DIFF
--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxSseServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxSseServerTransportProvider.java
@@ -206,6 +206,7 @@ public class WebFluxSseServerTransportProvider implements McpServerTransportProv
 	// FIXME: This javadoc makes claims about using isClosing flag but it's not
 	// actually
 	// doing that.
+
 	/**
 	 * Initiates a graceful shutdown of all the sessions. This method ensures all active
 	 * sessions are properly closed and cleaned up.
@@ -258,7 +259,7 @@ public class WebFluxSseServerTransportProvider implements McpServerTransportProv
 		return ServerResponse.ok()
 			.contentType(MediaType.TEXT_EVENT_STREAM)
 			.body(Flux.<ServerSentEvent<?>>create(sink -> {
-				WebFluxMcpSessionTransport sessionTransport = new WebFluxMcpSessionTransport(sink);
+				WebFluxMcpSessionTransport sessionTransport = new WebFluxMcpSessionTransport(request, sink);
 
 				McpServerSession session = sessionFactory.create(sessionTransport);
 				String sessionId = session.getId();
@@ -331,10 +332,17 @@ public class WebFluxSseServerTransportProvider implements McpServerTransportProv
 
 	private class WebFluxMcpSessionTransport implements McpServerTransport {
 
+		private final ServerRequest request;
+
 		private final FluxSink<ServerSentEvent<?>> sink;
 
-		public WebFluxMcpSessionTransport(FluxSink<ServerSentEvent<?>> sink) {
+		public WebFluxMcpSessionTransport(ServerRequest request, FluxSink<ServerSentEvent<?>> sink) {
+			this.request = request;
 			this.sink = sink;
+		}
+
+		public ServerRequest getRequest() {
+			return request;
 		}
 
 		@Override


### PR DESCRIPTION


<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Exposing the initial `ServerRequest` within the `McpServerTransport` is valuable as it enables the server to handle authentication and authorization mechanisms based on this request object.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

- Add ServerRequest parameter to WebFluxMcpSessionTransport constructor
- Implement getRequest() method to retrieve ServerRequest
- Update createSession() to pass ServerRequest to WebFluxMcpSessionTransport
