### PR TITLE
java-sdk/issues/399

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,10 +116,11 @@
 				<version>${spring-javaformat-maven-plugin.version}</version>
 				<executions>
 					<execution>
+						<id>checkstyle-validation</id>
 						<phase>validate</phase>
 						<inherited>true</inherited>
 						<goals>
-							<goal>validate</goal>
+							<goal>apply</goal>
 						</goals>
 					</execution>
 				</executions>


### PR DESCRIPTION
Ref: https://github.com/modelcontextprotocol/java-sdk/issues/399
spring-javaformat is present in pom https://github.com/modelcontextprotocol/java-sdk/blob/main/pom.xml#L113-L126. we can set to goal apply `spring-javaformat:apply`. It will execute when we ran mvn install command to reformat the code

