### PR TITLE
fix: improve SSE event handling to gracefully ignore unrecognized events

### DIFF
--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebClientStreamableHttpTransport.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebClientStreamableHttpTransport.java
@@ -432,7 +432,8 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 			}
 		}
 		else {
-			throw new McpError("Received unrecognized SSE event type: " + event.event());
+			logger.debug("Received SSE event with type: {}", event);
+			return Tuples.of(Optional.empty(), List.of());
 		}
 	}
 

--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransport.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransport.java
@@ -216,7 +216,8 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 				}
 			}
 			else {
-				s.error(new McpError("Received unrecognized SSE event type: " + event.event()));
+				logger.warn("Received unrecognized SSE event type: {}", event);
+				s.complete(); // Ignore unrecognized events
 			}
 		}).transform(handler)).subscribe();
 

--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransport.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransport.java
@@ -216,8 +216,8 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 				}
 			}
 			else {
-				logger.warn("Received unrecognized SSE event type: {}", event);
-				s.complete(); // Ignore unrecognized events
+				logger.debug("Received unrecognized SSE event type: {}", event);
+				s.complete();
 			}
 		}).transform(handler)).subscribe();
 

--- a/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransportTests.java
+++ b/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransportTests.java
@@ -197,7 +197,8 @@ class WebFluxSseClientTransportTests {
 				    "jsonrpc": "2.0",
 				    "method": "test-method",
 				    "id": "test-id",
-				    "params": {"key": "value"}				}
+				    "params": {"key": "value"}				
+				}
 				""");
 
 		// Subscribe to messages and verify

--- a/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransportTests.java
+++ b/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransportTests.java
@@ -197,7 +197,7 @@ class WebFluxSseClientTransportTests {
 				    "jsonrpc": "2.0",
 				    "method": "test-method",
 				    "id": "test-id",
-				    "params": {"key": "value"}				
+				    "params": {"key": "value"}
 				}
 				""");
 

--- a/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransportTests.java
+++ b/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransportTests.java
@@ -6,6 +6,7 @@ package io.modelcontextprotocol.client.transport;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
@@ -75,6 +76,11 @@ class WebFluxSseClientTransportTests {
 
 		public int getInboundMessageCount() {
 			return inboundMessageCount.get();
+		}
+
+		public void simulateSseComment(String comment) {
+			events.tryEmitNext(ServerSentEvent.<String>builder().comment(comment).build());
+			inboundMessageCount.incrementAndGet();
 		}
 
 		public void simulateEndpointEvent(String jsonMessage) {
@@ -159,6 +165,27 @@ class WebFluxSseClientTransportTests {
 	}
 
 	@Test
+	void testCommentSseMessage() {
+		// If the line starts with a character (:) are comment lins and should be ingored
+		// https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
+
+		CopyOnWriteArrayList<Throwable> droppedErrors = new CopyOnWriteArrayList<>();
+		reactor.core.publisher.Hooks.onErrorDropped(droppedErrors::add);
+
+		try {
+			// Simulate receiving the SSE comment line
+			transport.simulateSseComment("sse comment");
+
+			StepVerifier.create(transport.closeGracefully()).verifyComplete();
+
+			assertThat(droppedErrors).hasSize(0);
+		}
+		finally {
+			reactor.core.publisher.Hooks.resetOnErrorDropped();
+		}
+	}
+
+	@Test
 	void testMessageProcessing() {
 		// Create a test message
 		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method", "test-id",
@@ -167,10 +194,10 @@ class WebFluxSseClientTransportTests {
 		// Simulate receiving the message
 		transport.simulateMessageEvent("""
 				{
-				    "jsonrpc": "2.0",
-				    "method": "test-method",
-				    "id": "test-id",
-				    "params": {"key": "value"}
+				"jsonrpc": "2.0",
+				"method": "test-method",
+				"id": "test-id",
+				"params": {"key": "value"}
 				}
 				""");
 

--- a/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransportTests.java
+++ b/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransportTests.java
@@ -194,11 +194,10 @@ class WebFluxSseClientTransportTests {
 		// Simulate receiving the message
 		transport.simulateMessageEvent("""
 				{
-				"jsonrpc": "2.0",
-				"method": "test-method",
-				"id": "test-id",
-				"params": {"key": "value"}
-				}
+				    "jsonrpc": "2.0",
+				    "method": "test-method",
+				    "id": "test-id",
+				    "params": {"key": "value"}				}
 				""");
 
 		// Subscribe to messages and verify

--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
@@ -366,10 +366,8 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 								return Flux.just(message);
 							}
 							else {
-								logger.error("Received unrecognized SSE event type: {}",
-										responseEvent.sseEvent().event());
-								sink.error(new McpError(
-										"Received unrecognized SSE event type: " + responseEvent.sseEvent().event()));
+								logger.debug("Received unrecognized SSE event type: {}", responseEvent.sseEvent());
+								sink.success();
 							}
 						}
 						catch (IOException e) {

--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
@@ -264,6 +264,10 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 										"Error parsing JSON-RPC message: " + responseEvent.sseEvent().data()));
 							}
 						}
+						else {
+							logger.debug("Received SSE event with type: {}", responseEvent.sseEvent());
+							return Flux.empty();
+						}
 					}
 					else if (statusCode == METHOD_NOT_ALLOWED) { // NotAllowed
 						logger.debug("The server does not support SSE streams, using request-response mode.");


### PR DESCRIPTION
This change improves client resilience by gracefully handling unknown events instead of failing, allowing clients to continue processing valid events even when encountering unexpected ones.

- Replace McpError exceptions with debug/warning logs for unrecognized SSE event types
- Continue processing instead of failing when encountering unknown SSE events
- Update transport implementations:
  - WebClientStreamableHttpTransport: return empty tuple instead of throwing
  - WebFluxSseClientTransport: complete stream instead of erroring
  - HttpClientSseClientTransport: call sink.success() instead of sink.error()
  - HttpClientStreamableHttpTransport: return empty Flux for unknown events

This improves client resilience when servers send non-standard or future SSE event types.

Resolves #272 , #223 , #93, #421

<!-- Provide a brief summary of your changes -->
Improve SSE event handling to gracefully ignore unrecognized events instead of throwing errors

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Previously, when MCP clients received unrecognized Server-Sent Events (SSE) from servers, they would throw `McpError` exceptions and terminate the connection. This created fragility when:
- Servers send non-standard SSE event types
- Future MCP versions introduce new SSE event types that older clients don't recognize
- SSE comment lines (starting with `:`) are sent, which should be ignored per the SSE specification


## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
- Added unit test `testCommentSseMessage()` to verify SSE comment lines are properly ignored
- Existing transport tests continue to pass, ensuring backward compatibility
- Tested scenarios include:
  - SSE comment lines (`:` prefixed lines)
  - Unknown SSE event types
  - Mixed streams with both recognized and unrecognized events

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes. This is a backward-compatible improvement that makes clients more resilient. Existing functionality remains unchanged.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
**Implementation Details:**
- **WebClientStreamableHttpTransport**: Returns empty tuple instead of throwing
- **WebFluxSseClientTransport**: Completes stream with warning log instead of erroring
- **HttpClientSseClientTransport**: Calls `sink.success()` with debug log instead of `sink.error()`
- **HttpClientStreamableHttpTransport**: Returns empty Flux for unknown events
