### PR TITLE
fix: Change McpAsyncServerExchange default minLoggingLevel level from INFO to DEBUG

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
@@ -31,7 +31,7 @@ public class McpAsyncServerExchange {
 
 	private final McpSchema.Implementation clientInfo;
 
-	private volatile LoggingLevel minLoggingLevel = LoggingLevel.INFO;
+	private volatile LoggingLevel minLoggingLevel = LoggingLevel.DEBUG;
 
 	private static final TypeReference<McpSchema.CreateMessageResult> CREATE_MESSAGE_RESULT_TYPE_REF = new TypeReference<>() {
 	};


### PR DESCRIPTION


<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

The default minimum logging level is set to INFO, which prevents DEBUG level messages from being sent to clients even when they explicitly request debug information.

Also, I noticed that the deprecated method's `minLoggingLevel` variable previously had a default value of DEBUG
```java
// McpAsyncServer.java
// FIXME: this field is deprecated and should be remvoed together with the
// broadcasting loggingNotification.
private LoggingLevel minLoggingLevel = LoggingLevel.DEBUG;
```

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Manual Testing



## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
