### PR TITLE
Update ResponseSubscribers.java

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/ResponseSubscribers.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/ResponseSubscribers.java
@@ -237,10 +237,10 @@ class ResponseSubscribers {
 
 		@Override
 		protected void hookOnComplete() {
-			if (this.eventBuilder.length() > 0) {
-				String data = this.eventBuilder.toString();
-				this.sink.next(new AggregateResponseEvent(responseInfo, data));
-			}
+			// sink.next() is must 
+			String data = this.eventBuilder.toString();
+			this.sink.next(new AggregateResponseEvent(responseInfo, data));
+		
 			this.sink.complete();
 		}
 


### PR DESCRIPTION
sink.must() must be executed, otherwise in the case of empty return (such as notify), the deliveredSink of sendMessage will not be able to process the stream correctly, resulting in Client failed to initialize by explicit API call

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
