### PR TITLE
Use `Last-Event-ID` instead of `last-event-id`

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/spec/HttpHeaders.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/HttpHeaders.java
@@ -19,7 +19,7 @@ public interface HttpHeaders {
 	/**
 	 * Identifies events within an SSE Stream.
 	 */
-	String LAST_EVENT_ID = "last-event-id";
+	String LAST_EVENT_ID = "Last-Event-ID";
 
 	/**
 	 * Identifies the MCP protocol version.


### PR DESCRIPTION
see https://html.spec.whatwg.org/multipage/server-sent-events.html#the-last-event-id-header
