### PR TITLE
Add MCP handler getter to McpStatelessServerTransport

### DIFF
--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxStatelessServerTransport.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxStatelessServerTransport.java
@@ -68,6 +68,11 @@ public class WebFluxStatelessServerTransport implements McpStatelessServerTransp
 	}
 
 	@Override
+	public McpStatelessServerHandler getMcpHandler() {
+		return mcpHandler;
+	}
+
+	@Override
 	public Mono<Void> closeGracefully() {
 		return Mono.fromRunnable(() -> this.isClosing = true);
 	}

--- a/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcStatelessServerTransport.java
+++ b/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcStatelessServerTransport.java
@@ -72,6 +72,11 @@ public class WebMvcStatelessServerTransport implements McpStatelessServerTranspo
 	}
 
 	@Override
+	public McpStatelessServerHandler getMcpHandler() {
+		return mcpHandler;
+	}
+
+	@Override
 	public Mono<Void> closeGracefully() {
 		return Mono.fromRunnable(() -> this.isClosing = true);
 	}

--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStatelessServerTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStatelessServerTransport.java
@@ -76,6 +76,11 @@ public class HttpServletStatelessServerTransport extends HttpServlet implements 
 	}
 
 	@Override
+	public McpStatelessServerHandler getMcpHandler() {
+		return mcpHandler;
+	}
+
+	@Override
 	public Mono<Void> closeGracefully() {
 		return Mono.fromRunnable(() -> this.isClosing = true);
 	}

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpStatelessServerTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpStatelessServerTransport.java
@@ -13,6 +13,8 @@ public interface McpStatelessServerTransport {
 
 	void setMcpHandler(McpStatelessServerHandler mcpHandler);
 
+	McpStatelessServerHandler getMcpHandler();
+
 	/**
 	 * Immediately closes all the transports with connected clients and releases any
 	 * associated resources.


### PR DESCRIPTION
## Motivation and Context

There are many use cases where users will want to wrap/override the McpHandler. That's not currently possible. This change enables that by returning the current McpHandler, which would allow a wrapper McpHandler to be set. One use-case is catching app-specific exceptions and converting them into standard JSON-RPC error responses.

## How Has This Been Tested?

`testWrappingMcpHandler()` added to `HttpServletStatelessIntegrationTests`

## Breaking Changes

`McpStatelessServerTransport` has a new method.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
