### PR TITLE
ServerCapabilities builder should not assign logging an initial value

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -533,7 +533,7 @@ public final class McpSchema {
 
 			private Map<String, Object> experimental;
 
-			private LoggingCapabilities logging = new LoggingCapabilities();
+			private LoggingCapabilities logging;
 
 			private PromptCapabilities prompts;
 

--- a/mcp/src/test/java/io/modelcontextprotocol/client/McpAsyncClientResponseHandlerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/McpAsyncClientResponseHandlerTests.java
@@ -81,6 +81,7 @@ class McpAsyncClientResponseHandlerTests {
 		assertThat(result).isNotNull();
 		assertThat(result.protocolVersion()).isEqualTo(transport.protocolVersions().get(0));
 		assertThat(result.capabilities()).isEqualTo(serverCapabilities);
+		assertThat(result.capabilities().logging()).isNull();
 		assertThat(result.serverInfo()).isEqualTo(serverInfo);
 		assertThat(result.instructions()).isEqualTo("Test instructions");
 


### PR DESCRIPTION
## Motivation and Context

ServerCapabilities builder should not assign logging an initial value

## How Has This Been Tested?

added `assertThat(result.capabilities().logging()).isNull();` to `testSuccessfulInitialization`

## Breaking Changes

`ServerCapabilities` builder no longer has logging enabled by default.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
