### PR TITLE
Support server to client notifications from the stateless transport

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpTransportContext.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpTransportContext.java
@@ -47,4 +47,13 @@ public interface McpTransportContext {
 	 */
 	McpTransportContext copy();
 
+	/**
+	 * Sends a notification from the server to the client.
+	 * @param method notification method name
+	 * @param params any parameters or {@code null}
+	 */
+	default void sendNotification(String method, Object params) {
+		throw new UnsupportedOperationException("Not supported in this implementation of MCP transport context");
+	}
+
 }

--- a/mcp/src/main/java/io/modelcontextprotocol/server/StatelessMcpTransportContext.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/StatelessMcpTransportContext.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import java.util.function.BiConsumer;
+
+public class StatelessMcpTransportContext implements McpTransportContext {
+
+	private final McpTransportContext delegate;
+
+	private final BiConsumer<String, Object> notificationHandler;
+
+	/**
+	 * Create an empty instance.
+	 */
+	public StatelessMcpTransportContext(BiConsumer<String, Object> notificationHandler) {
+		this(new DefaultMcpTransportContext(), notificationHandler);
+	}
+
+	private StatelessMcpTransportContext(McpTransportContext delegate, BiConsumer<String, Object> notificationHandler) {
+		this.delegate = delegate;
+		this.notificationHandler = notificationHandler;
+	}
+
+	@Override
+	public Object get(String key) {
+		return this.delegate.get(key);
+	}
+
+	@Override
+	public void put(String key, Object value) {
+		this.delegate.put(key, value);
+	}
+
+	public McpTransportContext copy() {
+		return new StatelessMcpTransportContext(delegate.copy(), notificationHandler);
+	}
+
+	@Override
+	public void sendNotification(String method, Object params) {
+		notificationHandler.accept(method, params);
+	}
+
+}


### PR DESCRIPTION
The MCP spec allows stateless servers to send notifications to the client during a request. The response needs to be upgraded to SSE and the notifications are send in a stream until the final result is sent.

This commit adds a `sendNotification` method to the transport context allowing each transport implementation to implement it or not. In this commit, HttpServletStatelessServerTransport implements the method and when the caller first sends a notification, the response is changed to `TEXT_EVENT_STREAM` and events are then streamed until the final result.

This change will allow future features such as logging, list changes, etc. should we ever decide to support sessions in some manner. Even if we don't support sessions, sending progress notifications is a useful feature by itself.

## Motivation and Context

We would like to have support for progress notifications in the stateless implementation.

## How Has This Been Tested?

- `testNotifications()` added to `HttpServletStatelessIntegrationTests`
- manual testing with the MCP inspector

## Breaking Changes

none

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

