### PR TITLE
Feature: McpTransportContext for HttpServletSseServerTransportProvider

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/server/DefaultMcpTransportContext.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/DefaultMcpTransportContext.java
@@ -5,6 +5,7 @@
 package io.modelcontextprotocol.server;
 
 import java.util.Map;
+import java.util.StringJoiner;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -44,6 +45,15 @@ public class DefaultMcpTransportContext implements McpTransportContext {
 	 */
 	public McpTransportContext copy() {
 		return new DefaultMcpTransportContext(new ConcurrentHashMap<>(this.storage));
+	}
+
+	// TODO for debugging
+
+	@Override
+	public String toString() {
+		return new StringJoiner(", ", DefaultMcpTransportContext.class.getSimpleName() + "[", "]")
+			.add("storage=" + storage)
+			.toString();
 	}
 
 }

--- a/mcp/src/main/java/io/modelcontextprotocol/server/DefaultMcpTransportContext.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/DefaultMcpTransportContext.java
@@ -5,7 +5,6 @@
 package io.modelcontextprotocol.server;
 
 import java.util.Map;
-import java.util.StringJoiner;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**

--- a/mcp/src/main/java/io/modelcontextprotocol/server/DefaultMcpTransportContext.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/DefaultMcpTransportContext.java
@@ -47,13 +47,4 @@ public class DefaultMcpTransportContext implements McpTransportContext {
 		return new DefaultMcpTransportContext(new ConcurrentHashMap<>(this.storage));
 	}
 
-	// TODO for debugging
-
-	@Override
-	public String toString() {
-		return new StringJoiner(", ", DefaultMcpTransportContext.class.getSimpleName() + "[", "]")
-			.add("storage=" + storage)
-			.toString();
-	}
-
 }

--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
@@ -149,7 +149,7 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 	@Deprecated
 	public HttpServletSseServerTransportProvider(ObjectMapper objectMapper, String baseUrl, String messageEndpoint,
 			String sseEndpoint) {
-		this(objectMapper, baseUrl, messageEndpoint, sseEndpoint, null, null);
+		this(objectMapper, baseUrl, messageEndpoint, sseEndpoint, null, (serverRequest, context) -> context);
 	}
 
 	/**
@@ -168,7 +168,8 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 	@Deprecated
 	public HttpServletSseServerTransportProvider(ObjectMapper objectMapper, String baseUrl, String messageEndpoint,
 			String sseEndpoint, Duration keepAliveInterval) {
-		this(objectMapper, baseUrl, messageEndpoint, sseEndpoint, keepAliveInterval, null);
+		this(objectMapper, baseUrl, messageEndpoint, sseEndpoint, keepAliveInterval,
+				(serverRequest, context) -> context);
 	}
 
 	/**
@@ -180,7 +181,7 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 	 * @param messageEndpoint The endpoint path where clients will send their messages
 	 * @param sseEndpoint The endpoint path where clients will establish SSE connections
 	 * @param keepAliveInterval The interval for keep-alive pings, or null to disable
-     * keep-alive functionality
+	 * keep-alive functionality
 	 * @param contextExtractor The extractor for transport context from the request.
 	 * @deprecated Use the builder {@link #builder()} instead for better configuration
 	 * options.
@@ -188,6 +189,11 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 	private HttpServletSseServerTransportProvider(ObjectMapper objectMapper, String baseUrl, String messageEndpoint,
 			String sseEndpoint, Duration keepAliveInterval,
 			McpTransportContextExtractor<HttpServletRequest> contextExtractor) {
+
+		Assert.notNull(objectMapper, "ObjectMapper must not be null");
+		Assert.notNull(messageEndpoint, "messageEndpoint must not be null");
+		Assert.notNull(sseEndpoint, "sseEndpoint must not be null");
+		Assert.notNull(contextExtractor, "Context extractor must not be null");
 
 		this.objectMapper = objectMapper;
 		this.baseUrl = baseUrl;

--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
@@ -185,8 +185,7 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 	 * @deprecated Use the builder {@link #builder()} instead for better configuration
 	 * options.
 	 */
-	@Deprecated
-	public HttpServletSseServerTransportProvider(ObjectMapper objectMapper, String baseUrl, String messageEndpoint,
+	private HttpServletSseServerTransportProvider(ObjectMapper objectMapper, String baseUrl, String messageEndpoint,
 			String sseEndpoint, Duration keepAliveInterval,
 			McpTransportContextExtractor<HttpServletRequest> contextExtractor) {
 

--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
@@ -371,7 +371,7 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 				body.append(line);
 			}
 
-			final McpTransportContext transportContext = contextExtractor.extract(request,
+			final McpTransportContext transportContext = this.contextExtractor.extract(request,
 					new DefaultMcpTransportContext());
 			McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(objectMapper, body.toString());
 

--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
@@ -16,6 +16,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.server.DefaultMcpTransportContext;
+import io.modelcontextprotocol.server.McpTransportContext;
+import io.modelcontextprotocol.server.McpTransportContextExtractor;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpServerSession;
@@ -102,6 +105,8 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 	/** Map of active client sessions, keyed by session ID */
 	private final Map<String, McpServerSession> sessions = new ConcurrentHashMap<>();
 
+	private McpTransportContextExtractor<HttpServletRequest> contextExtractor;
+
 	/** Flag indicating if the transport is in the process of shutting down */
 	private final AtomicBoolean isClosing = new AtomicBoolean(false);
 
@@ -144,7 +149,7 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 	@Deprecated
 	public HttpServletSseServerTransportProvider(ObjectMapper objectMapper, String baseUrl, String messageEndpoint,
 			String sseEndpoint) {
-		this(objectMapper, baseUrl, messageEndpoint, sseEndpoint, null);
+		this(objectMapper, baseUrl, messageEndpoint, sseEndpoint, null, null);
 	}
 
 	/**
@@ -163,11 +168,33 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 	@Deprecated
 	public HttpServletSseServerTransportProvider(ObjectMapper objectMapper, String baseUrl, String messageEndpoint,
 			String sseEndpoint, Duration keepAliveInterval) {
+		this(objectMapper, baseUrl, messageEndpoint, sseEndpoint, keepAliveInterval, null);
+	}
+
+	/**
+	 * Creates a new HttpServletSseServerTransportProvider instance with a custom SSE
+	 * endpoint.
+	 * @param objectMapper The JSON object mapper to use for message
+	 * serialization/deserialization
+	 * @param baseUrl The base URL for the server transport
+	 * @param messageEndpoint The endpoint path where clients will send their messages
+	 * @param sseEndpoint The endpoint path where clients will establish SSE connections
+	 * @param keepAliveInterval The interval for keep-alive pings, or null to disable
+	 * @param contextExtractor The extractor for transport context from the request.
+	 * keep-alive functionality
+	 * @deprecated Use the builder {@link #builder()} instead for better configuration
+	 * options.
+	 */
+	@Deprecated
+	public HttpServletSseServerTransportProvider(ObjectMapper objectMapper, String baseUrl, String messageEndpoint,
+			String sseEndpoint, Duration keepAliveInterval,
+			McpTransportContextExtractor<HttpServletRequest> contextExtractor) {
 
 		this.objectMapper = objectMapper;
 		this.baseUrl = baseUrl;
 		this.messageEndpoint = messageEndpoint;
 		this.sseEndpoint = sseEndpoint;
+		this.contextExtractor = contextExtractor;
 
 		if (keepAliveInterval != null) {
 
@@ -339,10 +366,13 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 				body.append(line);
 			}
 
+			final McpTransportContext transportContext = contextExtractor.extract(request,
+					new DefaultMcpTransportContext());
 			McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(objectMapper, body.toString());
 
 			// Process the message through the session's handle method
-			session.handle(message).block(); // Block for Servlet compatibility
+			// Block for Servlet compatibility
+			session.handle(message).contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext)).block();
 
 			response.setStatus(HttpServletResponse.SC_OK);
 		}
@@ -534,6 +564,8 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 
 		private String sseEndpoint = DEFAULT_SSE_ENDPOINT;
 
+		private McpTransportContextExtractor<HttpServletRequest> contextExtractor = (serverRequest, context) -> context;
+
 		private Duration keepAliveInterval;
 
 		/**
@@ -584,6 +616,19 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 		}
 
 		/**
+		 * Sets the context extractor for extracting transport context from the request.
+		 * @param contextExtractor The context extractor to use. Must not be null.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if contextExtractor is null
+		 */
+		public HttpServletSseServerTransportProvider.Builder contextExtractor(
+				McpTransportContextExtractor<HttpServletRequest> contextExtractor) {
+			Assert.notNull(contextExtractor, "Context extractor must not be null");
+			this.contextExtractor = contextExtractor;
+			return this;
+		}
+
+		/**
 		 * Sets the interval for keep-alive pings.
 		 * <p>
 		 * If not specified, keep-alive pings will be disabled.
@@ -609,7 +654,7 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 				throw new IllegalStateException("MessageEndpoint must be set");
 			}
 			return new HttpServletSseServerTransportProvider(objectMapper, baseUrl, messageEndpoint, sseEndpoint,
-					keepAliveInterval);
+					keepAliveInterval, contextExtractor);
 		}
 
 	}

--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
@@ -180,8 +180,8 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 	 * @param messageEndpoint The endpoint path where clients will send their messages
 	 * @param sseEndpoint The endpoint path where clients will establish SSE connections
 	 * @param keepAliveInterval The interval for keep-alive pings, or null to disable
+     * keep-alive functionality
 	 * @param contextExtractor The extractor for transport context from the request.
-	 * keep-alive functionality
 	 * @deprecated Use the builder {@link #builder()} instead for better configuration
 	 * options.
 	 */

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
@@ -271,6 +271,12 @@ public class McpServerSession implements McpLoggableSession {
 				}
 
 				resultMono = this.exchangeSink.asMono().flatMap(exchange -> {
+					// This legacy implementation assumes an exchange is established upon
+					// the initialization phase see: exchangeSink.tryEmitValue(...),
+					// which creates a cached immutable exchange.
+					// Here, we create a new exchange and copy over everything from that
+					// cached exchange, and use it for a single HTTP request, with the
+					// transport context passed in.
 					McpAsyncServerExchange newExchange = new McpAsyncServerExchange(exchange.sessionId(), this,
 							exchange.getClientCapabilities(), exchange.getClientInfo(), transportContext);
 					return handler.handle(newExchange, request.params());
@@ -308,6 +314,12 @@ public class McpServerSession implements McpLoggableSession {
 				return Mono.empty();
 			}
 			return this.exchangeSink.asMono().flatMap(exchange -> {
+				// This legacy implementation assumes an exchange is established upon
+				// the initialization phase see: exchangeSink.tryEmitValue(...),
+				// which creates a cached immutable exchange.
+				// Here, we create a new exchange and copy over everything from that
+				// cached exchange, and use it for a single HTTP request, with the
+				// transport context passed in.
 				McpAsyncServerExchange newExchange = new McpAsyncServerExchange(exchange.sessionId(), this,
 						exchange.getClientCapabilities(), exchange.getClientInfo(), transportContext);
 				return handler.handle(newExchange, notification.params());

--- a/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpClientServerIntegrationTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpClientServerIntegrationTests.java
@@ -1599,7 +1599,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 		};
 	}
 
-	protected static McpTransportContextExtractor<HttpServletRequest> extractor = (r, tc) -> {
+	protected static McpTransportContextExtractor<HttpServletRequest> TEST_CONTEXT_EXTRACTOR = (r, tc) -> {
 		tc.put("important", "value");
 		return tc;
 	};

--- a/mcp/src/test/java/io/modelcontextprotocol/server/HttpServletSseIntegrationTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/HttpServletSseIntegrationTests.java
@@ -40,7 +40,7 @@ class HttpServletSseIntegrationTests extends AbstractMcpClientServerIntegrationT
 		// Create and configure the transport provider
 		mcpServerTransportProvider = HttpServletSseServerTransportProvider.builder()
 			.objectMapper(new ObjectMapper())
-			.contextExtractor(extractor)
+			.contextExtractor(TEST_CONTEXT_EXTRACTOR)
 			.messageEndpoint(CUSTOM_MESSAGE_ENDPOINT)
 			.sseEndpoint(CUSTOM_SSE_ENDPOINT)
 			.build();

--- a/mcp/src/test/java/io/modelcontextprotocol/server/HttpServletSseIntegrationTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/HttpServletSseIntegrationTests.java
@@ -40,6 +40,7 @@ class HttpServletSseIntegrationTests extends AbstractMcpClientServerIntegrationT
 		// Create and configure the transport provider
 		mcpServerTransportProvider = HttpServletSseServerTransportProvider.builder()
 			.objectMapper(new ObjectMapper())
+			.contextExtractor(extractor)
 			.messageEndpoint(CUSTOM_MESSAGE_ENDPOINT)
 			.sseEndpoint(CUSTOM_SSE_ENDPOINT)
 			.build();

--- a/mcp/src/test/java/io/modelcontextprotocol/server/HttpServletStreamableIntegrationTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/HttpServletStreamableIntegrationTests.java
@@ -38,7 +38,7 @@ class HttpServletStreamableIntegrationTests extends AbstractMcpClientServerInteg
 		// Create and configure the transport provider
 		mcpServerTransportProvider = HttpServletStreamableServerTransportProvider.builder()
 			.objectMapper(new ObjectMapper())
-			.contextExtractor(extractor)
+			.contextExtractor(TEST_CONTEXT_EXTRACTOR)
 			.mcpEndpoint(MESSAGE_ENDPOINT)
 			.keepAliveInterval(Duration.ofSeconds(1))
 			.build();

--- a/mcp/src/test/java/io/modelcontextprotocol/server/HttpServletStreamableIntegrationTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/HttpServletStreamableIntegrationTests.java
@@ -38,6 +38,7 @@ class HttpServletStreamableIntegrationTests extends AbstractMcpClientServerInteg
 		// Create and configure the transport provider
 		mcpServerTransportProvider = HttpServletStreamableServerTransportProvider.builder()
 			.objectMapper(new ObjectMapper())
+			.contextExtractor(extractor)
 			.mcpEndpoint(MESSAGE_ENDPOINT)
 			.keepAliveInterval(Duration.ofSeconds(1))
 			.build();


### PR DESCRIPTION
Implements https://github.com/modelcontextprotocol/java-sdk/issues/476.

## Motivation and Context

https://github.com/modelcontextprotocol/java-sdk/pull/420 introduced McpTransportContext.

`McpTransportContext` should be supported in `HttpServletSseServerTransportProvider` to enable those who are still on that transport to leverage `McpTransportContext` to set attributes that Tools, etc. have access to. This is crucial for implementing Authentication & Authorization at the Tool level.

Current Behavior

`McpTransportContext` is absent from `HttpServletSseServerTransportProvider`

Context

How has this issue affected you?

We're not able to switch to `HttpServletStreamableServerTransportProvider` yet, but wish to use `McpTransportContext` instead of our custom built similar capability.

What are you trying to accomplish?

Authn/z at Tool level.

## How Has This Been Tested?

* In a langchain4j agent application calling into a Dropwizard application serving MCP using `HttpServletSseServerTransportProvider`
* directly by testing a Dropwizard application serving MCP using `HttpServletSseServerTransportProvider`
* Integration tests included with PR

## Breaking Changes
No, use of the `McpTransportContext` is optional. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
None