### PR TITLE
fix: build ServerCapabilities without logging

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -548,7 +548,7 @@ public final class McpSchema {
 
 			private Map<String, Object> experimental;
 
-			private LoggingCapabilities logging = new LoggingCapabilities();
+			private LoggingCapabilities logging;
 
 			private PromptCapabilities prompts;
 

--- a/mcp/src/test/java/io/modelcontextprotocol/spec/ServerCapabilitiesTest.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/spec/ServerCapabilitiesTest.java
@@ -1,0 +1,15 @@
+package io.modelcontextprotocol.spec;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ServerCapabilitiesTest {
+    @Test
+    void serverCapabilitiesExcludeLoggingByDefault() {
+        McpSchema.ServerCapabilities serverCapabilities = McpSchema.ServerCapabilities.builder().build();
+        assertNull(serverCapabilities.logging());
+        serverCapabilities = McpSchema.ServerCapabilities.builder().logging().build();
+        assertNotNull(serverCapabilities.logging());
+    }
+}


### PR DESCRIPTION
## Motivation and Context

Currently, logging is always set when building a `ServerCapabilities` instance with the builder.

I want to be able to build instances of `ServerCapabilities` with and without logging capabilities that it is currently impossible which I see as a bug. 

I expect this test to pass:

```java
McpSchema.ServerCapabilities serverCapabilities = McpSchema.ServerCapabilities.builder().build();
assertNull(serverCapabilities.logging());
serverCapabilities = McpSchema.ServerCapabilities.builder().logging().build();
assertNotNull(serverCapabilities.logging());
```

## How Has This Been Tested?

I include a unit test in the pull request.

## Breaking Changes

Before this change, if you were creating  `ServerCapabilities` with the builder without explicitly setting `ServerCapabilities::logging()`, it was set nonetheless. After this change, until you explicitly set the logging capability, it will be null. 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed