### PR TITLE
feat: Introduce Slf4jLoggingConsumer

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/client/Slf4jLoggingConsumer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/Slf4jLoggingConsumer.java
@@ -31,16 +31,17 @@ public class Slf4jLoggingConsumer implements Consumer<McpSchema.LoggingMessageNo
 	// https://github.com/google/adk-java/pull/370. It's now been moved here to be useful
 	// to others.
 
+	private static final Logger LOG = LoggerFactory.getLogger(Slf4jLoggingConsumer.class);
+
 	@Override
 	public void accept(LoggingMessageNotification notif) {
-		Logger log = LoggerFactory.getLogger(notif.logger());
 		if (notif.meta().isEmpty()) {
 			// If no meta, then just log the data as a message
-			log.atLevel(convert(notif.level())).log(notif.data());
+			LOG.atLevel(convert(notif.level())).log(notif.data());
 		}
 		else {
 			// If there is meta, then log it as a structured log message
-			var builder = log.atLevel(convert(notif.level())).setMessage(notif.data());
+			var builder = LOG.atLevel(convert(notif.level())).setMessage(notif.data());
 			notif.meta().forEach((key, value) -> builder.addKeyValue(key, value));
 			builder.log();
 		}


### PR DESCRIPTION
## Motivation and Context

MCP Client-side consumer which logs received messages from MCP Servers using SLF4J.

## How Has This Been Tested?

Yeah, it seems to work.

## Breaking Changes

_Will users need to update their code or configurations?_ No, this is non-breaking. It's just a new class which can be used with `SyncSpec#loggingConsumer(Consumer)` to log received MCP messages. But if a user upgrades without using it, then there will no change.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context

This class originated in (my) [here](https://github.com/enola-dev/enola/blob/ffc004666ea7f71357562ef12464d2b9fdbf9dbd/java/dev/enola/ai/mcp/McpServer.java#L29), where it is used for https://docs.enola.dev/concepts/mcp/.

It then found its way into Google's Agent Development Kit (ADK) in https://github.com/google/adk-java/pull/370.

I'm now proposing to "upstream" it here to be useful to others.