### PR TITLE
fix SseLineSubscriber will not request after default 256 request

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/ResponseSubscribers.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/ResponseSubscribers.java
@@ -141,7 +141,7 @@ class ResponseSubscribers {
 
 		@Override
 		protected void hookOnNext(String line) {
-
+			request(1);
 			if (line.isEmpty()) {
 				// Empty line means end of event
 				if (this.eventBuilder.length() > 0) {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

https://github.com/modelcontextprotocol/java-sdk/issues/502

## How Has This Been Tested?
Tested 24 hours, Client received all messages.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
