### PR TITLE
fix: disable logging capabilities for stateless servers

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpStatelessServerFeatures.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpStatelessServerFeatures.java
@@ -67,10 +67,7 @@ public class McpStatelessServerFeatures {
 			this.serverCapabilities = (serverCapabilities != null) ? serverCapabilities
 					: new McpSchema.ServerCapabilities(null, // completions
 							null, // experimental
-							new McpSchema.ServerCapabilities.LoggingCapabilities(), // Enable
-																					// logging
-																					// by
-																					// default
+							null, // currently statless server doesn't support set logging
 							!Utils.isEmpty(prompts) ? new McpSchema.ServerCapabilities.PromptCapabilities(false) : null,
 							!Utils.isEmpty(resources)
 									? new McpSchema.ServerCapabilities.ResourceCapabilities(false, false) : null,


### PR DESCRIPTION
Remove LoggingCapabilities from McpStatelessServerFeatures.Async constructor as stateless servers do not support setLogging operations. This aligns the async implementation with the sync implementation which already has logging disabled.

Follows up on #463

<!-- Provide a brief summary of your changes -->
Remove logging capabilities from stateless servers as they don't support setLogging operations.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
This change fixes an inconsistency in the MCP Java SDK where stateless servers were incorrectly advertising logging capabilities. Stateless servers do not support setLogging operations, so they should not expose LoggingCapabilities in their server capabilities.

This follows up on #463 and aligns the async stateless server implementation with the sync implementation, which already correctly sets logging capabilities to null.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
- Verified that stateless servers no longer advertise logging capabilities
- Confirmed that existing functionality remains unchanged
- Tested that the server capabilities are properly constructed with null logging

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
This is not a breaking change for users. Clients that were attempting to use logging with stateless servers would have encountered errors anyway, so removing the capability advertisement prevents confusion and aligns with actual server behavior.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
