### PR TITLE
fix: HttpClientStreamableHttpTransport redirect

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
@@ -588,7 +588,9 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 
 		private ObjectMapper objectMapper;
 
-		private HttpClient.Builder clientBuilder = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1);
+		private HttpClient.Builder clientBuilder = HttpClient.newBuilder()
+			.version(HttpClient.Version.HTTP_1_1)
+			.followRedirects(HttpClient.Redirect.NORMAL);
 
 		private String endpoint = DEFAULT_ENDPOINT;
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
This PR updates the HttpClientStreamableHttpTransport to automatically handle HTTP redirects, such as 307 Temporary Redirect.

Resolve: #433 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Currently, the HttpClientStreamableHttpTransport does not handle HTTP redirects. The underlying java.net.http.HttpClient defaults to a redirect policy of NEVER. Consequently, when an MCP server returns a 307 status code, the client fails to follow the redirect and throws an error. This change configures the HTTP client to automatically follow redirects, making the transport more robust and compliant with standard HTTP behavior.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
This was tested by pointing the client to a server endpoint that issues a 307 Temporary Redirect. Before this change, the client would fail. With this change, the client successfully follows the redirect and establishes a connection with the new endpoint.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
The fix is applied by setting the followRedirects policy to HttpClient.Redirect.NORMAL in the HttpClient.Builder. This enables the client to handle common redirect status codes (301, 302, 307, 308) automatically.

