### PR TITLE
Stateless server transport shouldn't require TEXT_EVENT_STREAM

### DIFF
--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxStatelessServerTransport.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxStatelessServerTransport.java
@@ -30,6 +30,7 @@ import java.util.List;
  * Implementation of a WebFlux based {@link McpStatelessServerTransport}.
  *
  * @author Dariusz Jędrzejczyk
+ * @author Yanming Zhou
  */
 public class WebFluxStatelessServerTransport implements McpStatelessServerTransport {
 
@@ -100,8 +101,7 @@ public class WebFluxStatelessServerTransport implements McpStatelessServerTransp
 		McpTransportContext transportContext = this.contextExtractor.extract(request, new DefaultMcpTransportContext());
 
 		List<MediaType> acceptHeaders = request.headers().asHttpHeaders().getAccept();
-		if (!(acceptHeaders.contains(MediaType.APPLICATION_JSON)
-				&& acceptHeaders.contains(MediaType.TEXT_EVENT_STREAM))) {
+		if (!acceptHeaders.contains(MediaType.APPLICATION_JSON)) {
 			return ServerResponse.badRequest().build();
 		}
 

--- a/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcStatelessServerTransport.java
+++ b/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcStatelessServerTransport.java
@@ -34,6 +34,7 @@ import java.util.List;
  * {@link io.modelcontextprotocol.server.transport.WebFluxStatelessServerTransport}
  *
  * @author Christian Tzolov
+ * @author Yanming Zhou
  */
 public class WebMvcStatelessServerTransport implements McpStatelessServerTransport {
 
@@ -104,8 +105,7 @@ public class WebMvcStatelessServerTransport implements McpStatelessServerTranspo
 		McpTransportContext transportContext = this.contextExtractor.extract(request, new DefaultMcpTransportContext());
 
 		List<MediaType> acceptHeaders = request.headers().asHttpHeaders().getAccept();
-		if (!(acceptHeaders.contains(MediaType.APPLICATION_JSON)
-				&& acceptHeaders.contains(MediaType.TEXT_EVENT_STREAM))) {
+		if (!acceptHeaders.contains(MediaType.APPLICATION_JSON)) {
 			return ServerResponse.badRequest().build();
 		}
 

--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStatelessServerTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStatelessServerTransport.java
@@ -33,6 +33,7 @@ import reactor.core.publisher.Mono;
  *
  * @author Christian Tzolov
  * @author Dariusz Jędrzejczyk
+ * @author Yanming Zhou
  */
 @WebServlet(asyncSupported = true)
 public class HttpServletStatelessServerTransport extends HttpServlet implements McpStatelessServerTransport {
@@ -126,9 +127,9 @@ public class HttpServletStatelessServerTransport extends HttpServlet implements 
 		McpTransportContext transportContext = this.contextExtractor.extract(request, new DefaultMcpTransportContext());
 
 		String accept = request.getHeader(ACCEPT);
-		if (accept == null || !(accept.contains(APPLICATION_JSON) && accept.contains(TEXT_EVENT_STREAM))) {
+		if (accept == null || !accept.contains(APPLICATION_JSON)) {
 			this.responseError(response, HttpServletResponse.SC_BAD_REQUEST,
-					new McpError("Both application/json and text/event-stream required in Accept header"));
+					new McpError("application/json required in Accept header"));
 			return;
 		}
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
It's a trivial improvement.

## How Has This Been Tested?
Tested with curl.

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
