### PR TITLE
fix: align tool error handling with MCP specification

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -29,10 +29,12 @@ import io.modelcontextprotocol.spec.McpClientSession;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.JSONRPCResponse;
 import io.modelcontextprotocol.spec.McpSchema.LoggingLevel;
 import io.modelcontextprotocol.spec.McpSchema.LoggingMessageNotification;
 import io.modelcontextprotocol.spec.McpSchema.ResourceTemplate;
 import io.modelcontextprotocol.spec.McpSchema.SetLevelRequest;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import io.modelcontextprotocol.spec.McpServerSession;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
@@ -376,6 +378,11 @@ public class McpAsyncServer {
 
 			return this.delegateCallToolResult.apply(exchange, request).map(result -> {
 
+				if (result.isError() != null && result.isError()) {
+					// If the tool call resulted in an error, skip further validation
+					return result;
+				}
+
 				if (outputSchema == null) {
 					if (result.structuredContent() != null) {
 						logger.warn(
@@ -507,11 +514,23 @@ public class McpAsyncServer {
 				.findAny();
 
 			if (toolSpecification.isEmpty()) {
-				return Mono.error(new McpError("Tool not found: " + callToolRequest.name()));
+				return Mono.error(new McpError(new JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INVALID_PARAMS,
+						"Unknown tool: invalid_tool_name", "Tool not found: " + callToolRequest.name())));
 			}
+			else {
+				return toolSpecification.get().callHandler().apply(exchange, callToolRequest).onErrorResume(error -> {
+					logger.error("Error calling tool: {}", callToolRequest.name(), error);
 
-			return toolSpecification.map(tool -> Mono.defer(() -> tool.callHandler().apply(exchange, callToolRequest)))
-				.orElse(Mono.error(new McpError("Tool not found: " + callToolRequest.name())));
+					// Tool errors should be reported within the result object, not as MCP
+					// protocol-level errors. This allows the LLM to see and potentially
+					// handle the error.
+					return Mono.just(CallToolResult.builder()
+						.isError(true)
+						.content(List
+							.of(new TextContent("Error calling tool: " + Utils.findRootCause(error).getMessage())))
+						.build());
+				});
+			}
 		};
 	}
 

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
@@ -249,6 +249,11 @@ public class McpStatelessAsyncServer {
 
 			return this.delegateHandler.apply(transportContext, request).map(result -> {
 
+				if (result.isError() != null && result.isError()) {
+					// If the tool call resulted in an error, skip further validation
+					return result;
+				}
+
 				if (outputSchema == null) {
 					if (result.structuredContent() != null) {
 						logger.warn(

--- a/mcp/src/main/java/io/modelcontextprotocol/util/Utils.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/util/Utils.java
@@ -9,6 +9,7 @@ import reactor.util.annotation.Nullable;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Miscellaneous utility methods.
@@ -105,6 +106,15 @@ public final class Utils {
 			basePath = basePath.substring(0, basePath.length() - 1);
 		}
 		return endpointPath.startsWith(basePath);
+	}
+
+	public static Throwable findRootCause(Throwable throwable) {
+		Objects.requireNonNull(throwable);
+		Throwable rootCause = throwable;
+		while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
+			rootCause = rootCause.getCause();
+		}
+		return rootCause;
 	}
 
 }

--- a/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpClientServerIntegrationTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpClientServerIntegrationTests.java
@@ -4,15 +4,6 @@
 
 package io.modelcontextprotocol.server;
 
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.assertWith;
-import static org.awaitility.Awaitility.await;
-import static org.mockito.Mockito.mock;
-
-import io.modelcontextprotocol.common.McpTransportContext;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -30,10 +21,8 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-
 import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -55,8 +44,17 @@ import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import io.modelcontextprotocol.util.Utils;
 import net.javacrumbs.jsonunit.core.Option;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertWith;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.mock;
 
 public abstract class AbstractMcpClientServerIntegrationTests {
 
@@ -104,8 +102,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 		McpServerFeatures.AsyncToolSpecification tool = McpServerFeatures.AsyncToolSpecification.builder()
 			.tool(Tool.builder().name("tool1").description("tool1 description").inputSchema(emptyJsonSchema).build())
 			.callHandler((exchange, request) -> {
-				exchange.createMessage(mock(McpSchema.CreateMessageRequest.class)).block();
-				return Mono.just(mock(CallToolResult.class));
+				return exchange.createMessage(mock(McpSchema.CreateMessageRequest.class))
+					.then(Mono.just(mock(CallToolResult.class)));
 			})
 			.build();
 
@@ -118,13 +116,15 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 
 			assertThat(client.initialize()).isNotNull();
 
-			try {
-				client.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
-			}
-			catch (McpError e) {
-				assertThat(e).isInstanceOf(McpError.class)
-					.hasMessage("Client must be configured with sampling capabilities");
-			}
+			McpSchema.CallToolResult callToolResult = client.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
+
+			// Tool errors should be reported within the result object, not as MCP
+			// protocol-level errors. This allows the LLM to see and potentially
+			// handle the error.
+			assertThat(callToolResult).isNotNull();
+			assertThat(callToolResult.isError()).isTrue();
+			assertThat(callToolResult.content()).containsExactly(new McpSchema.TextContent(
+					"Error calling tool: Client must be configured with sampling capabilities"));
 		}
 		finally {
 			server.closeGracefully().block();
@@ -334,9 +334,16 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			InitializeResult initResult = mcpClient.initialize();
 			assertThat(initResult).isNotNull();
 
-			assertThatExceptionOfType(McpError.class).isThrownBy(() -> {
-				mcpClient.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
-			}).withMessageContaining("1000ms");
+			McpSchema.CallToolResult callToolResult = mcpClient
+				.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
+
+			// Tool errors should be reported within the result object, not as MCP
+			// protocol-level errors. This allows the LLM to see and potentially
+			// handle the error.
+			assertThat(callToolResult).isNotNull();
+			assertThat(callToolResult.isError()).isTrue();
+			assertThat(callToolResult.content()).containsExactly(new McpSchema.TextContent(
+					"Error calling tool: Did not observe any item or terminal signal within 1000ms in 'source(MonoCreate)' (and no fallback has been configured)"));
 		}
 		finally {
 			mcpServer.closeGracefully().block();
@@ -552,9 +559,16 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			InitializeResult initResult = mcpClient.initialize();
 			assertThat(initResult).isNotNull();
 
-			assertThatExceptionOfType(McpError.class).isThrownBy(() -> {
-				mcpClient.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
-			}).withMessageContaining("within 1000ms");
+			McpSchema.CallToolResult callToolResult = mcpClient
+				.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
+
+			// Tool errors should be reported within the result object, not as MCP
+			// protocol-level errors. This allows the LLM to see and potentially
+			// handle the error.
+			assertThat(callToolResult).isNotNull();
+			assertThat(callToolResult.isError()).isTrue();
+			assertThat(callToolResult.content()).containsExactly(new McpSchema.TextContent(
+					"Error calling tool: Did not observe any item or terminal signal within 1000ms in 'source(MonoCreate)' (and no fallback has been configured)"));
 
 			ElicitResult elicitResult = resultRef.get();
 			assertThat(elicitResult).isNull();
@@ -838,12 +852,16 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			InitializeResult initResult = mcpClient.initialize();
 			assertThat(initResult).isNotNull();
 
-			// We expect the tool call to fail immediately with the exception raised by
-			// the offending tool
-			// instead of getting back a timeout.
-			assertThatExceptionOfType(McpError.class)
-				.isThrownBy(() -> mcpClient.callTool(new McpSchema.CallToolRequest("tool1", Map.of())))
-				.withMessageContaining("Timeout on blocking read");
+			McpSchema.CallToolResult callToolResult = mcpClient
+				.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
+
+			// Tool errors should be reported within the result object, not as MCP
+			// protocol-level errors. This allows the LLM to see and potentially
+			// handle the error.
+			assertThat(callToolResult).isNotNull();
+			assertThat(callToolResult.isError()).isTrue();
+			assertThat(callToolResult.content()).containsExactly(new McpSchema.TextContent(
+					"Error calling tool: Timeout on blocking read for 1000000000 NANOSECONDS"));
 		}
 		finally {
 			mcpServer.closeGracefully();

--- a/mcp/src/test/java/io/modelcontextprotocol/server/HttpServletSseIntegrationTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/HttpServletSseIntegrationTests.java
@@ -4,12 +4,18 @@
 
 package io.modelcontextprotocol.server;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import io.modelcontextprotocol.common.McpTransportContext;
 import java.time.Duration;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.server.McpServer.AsyncSpecification;
+import io.modelcontextprotocol.server.McpServer.SyncSpecification;
+import io.modelcontextprotocol.server.transport.HttpServletSseServerTransportProvider;
+import io.modelcontextprotocol.server.transport.TomcatTestUtil;
+import jakarta.servlet.http.HttpServletRequest;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.LifecycleState;
 import org.apache.catalina.startup.Tomcat;
@@ -17,15 +23,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Timeout;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.modelcontextprotocol.client.McpClient;
-import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
-import io.modelcontextprotocol.server.McpServer.AsyncSpecification;
-import io.modelcontextprotocol.server.McpServer.SyncSpecification;
-import io.modelcontextprotocol.server.transport.HttpServletSseServerTransportProvider;
-import io.modelcontextprotocol.server.transport.TomcatTestUtil;
-import jakarta.servlet.http.HttpServletRequest;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Timeout(15)
 class HttpServletSseIntegrationTests extends AbstractMcpClientServerIntegrationTests {

--- a/mcp/src/test/java/io/modelcontextprotocol/server/HttpServletStreamableIntegrationTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/HttpServletStreamableIntegrationTests.java
@@ -4,12 +4,18 @@
 
 package io.modelcontextprotocol.server;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import io.modelcontextprotocol.common.McpTransportContext;
 import java.time.Duration;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.server.McpServer.AsyncSpecification;
+import io.modelcontextprotocol.server.McpServer.SyncSpecification;
+import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
+import io.modelcontextprotocol.server.transport.TomcatTestUtil;
+import jakarta.servlet.http.HttpServletRequest;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.LifecycleState;
 import org.apache.catalina.startup.Tomcat;
@@ -17,15 +23,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Timeout;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.modelcontextprotocol.client.McpClient;
-import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
-import io.modelcontextprotocol.server.McpServer.AsyncSpecification;
-import io.modelcontextprotocol.server.McpServer.SyncSpecification;
-import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
-import io.modelcontextprotocol.server.transport.TomcatTestUtil;
-import jakarta.servlet.http.HttpServletRequest;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Timeout(15)
 class HttpServletStreamableIntegrationTests extends AbstractMcpClientServerIntegrationTests {


### PR DESCRIPTION
Implement proper error handling for tool calls according to MCP Tools' Error Handling specification (https://modelcontextprotocol.io/specification/2025-06-18/server/tools#error-handling)

- Tool errors are now returned within CallToolResult with isError=true instead of throwing MCP protocol-level errors
- This allows LLMs to see and handle tool errors as part of normal flow
- Return proper JSON-RPC error with code -32602 in case of "Unknown tools"
- Added Utils.findRootCause() helper to extract root cause from exception chains
- Skip output schema validation when tool result already indicates an error
- Updated all integration tests to verify new error handling behavior

BREAKING CHANGE: Tool call errors are no longer thrown as McpError exceptions. They are now returned as CallToolResult objects with isError=true and error details in the content field, following MCP specification guidelines.

Resolves #538
Related to #422

<!-- Provide a brief summary of your changes -->
Changes tool error handling to return errors within CallToolResult objects instead of throwing MCP protocol-level exceptions. This allows LLMs to see and handle tool errors gracefully.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Previously, when a tool call failed (e.g., due to timeout, missing capabilities, or runtime errors), the SDK would throw an McpError exception at the protocol level. This prevented LLMs from seeing and potentially handling these errors, as they would appear as protocol failures rather than tool execution failures.

This change aligns with MCP best practices where tool errors should be reported within the result object, allowing the LLM to:
- See the error and potentially retry or use alternative approaches
- Provide better error messages to users
- Distinguish between protocol-level failures and tool execution failures

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
- Updated all existing integration tests to verify the new error handling behavior
- Tested scenarios include:
  - Tool calls without required sampling capabilities
  - Tool calls with timeouts
  - Tool calls with runtime exceptions
  - Unknown tool requests
- All tests pass with the new error handling approach

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
**Yes, this is a breaking change.** 

Users who have code that catches `McpError` exceptions from `callTool()` methods will need to update their code to check the `isError()` field of the returned `CallToolResult` instead:

**Before:**
```java
try {
    CallToolResult result = client.callTool(request);
} catch (McpError e) {
    // Handle error
}
```

**After:**
```java
CallToolResult result = client.callTool(request);
if (result.isError()) {
    // Handle error - error message is in result.content()
}
```

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
### Implementation Details:
- Added `findRootCause()` utility method to extract the root cause from exception chains
- Modified `McpAsyncServer` and `McpStatelessAsyncServer` to catch tool handler exceptions and wrap them in error results
- Error results include `isError=true` and a `TextContent` message with the error details
- Validation is skipped for error results (no schema validation when `isError=true`)
- Unknown tool errors now return INVALID_PARAMS error code for better protocol compliance

### Migration Guide:
Applications using the SDK should update their error handling logic to check `CallToolResult.isError()` instead of catching exceptions. The error message can be extracted from `result.content()` which will contain a `TextContent` object with the error details.

