### PR TITLE
Introduce McpJsonMapper interface to decouple from Jackson

### DIFF
--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebClientStreamableHttpTransport.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebClientStreamableHttpTransport.java
@@ -22,8 +22,9 @@ import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.spec.json.TypeRef;
+import io.modelcontextprotocol.spec.json.McpJsonMapper;
+import io.modelcontextprotocol.spec.json.jackson.JacksonMcpJsonMapper;
 
 import io.modelcontextprotocol.spec.DefaultMcpTransportSession;
 import io.modelcontextprotocol.spec.DefaultMcpTransportStream;
@@ -88,7 +89,7 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 	private static final ParameterizedTypeReference<ServerSentEvent<String>> PARAMETERIZED_TYPE_REF = new ParameterizedTypeReference<>() {
 	};
 
-	private final ObjectMapper objectMapper;
+	private final McpJsonMapper jsonMapper;
 
 	private final WebClient webClient;
 
@@ -104,9 +105,9 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 
 	private final AtomicReference<Consumer<Throwable>> exceptionHandler = new AtomicReference<>();
 
-	private WebClientStreamableHttpTransport(ObjectMapper objectMapper, WebClient.Builder webClientBuilder,
+	private WebClientStreamableHttpTransport(McpJsonMapper jsonMapper, WebClient.Builder webClientBuilder,
 			String endpoint, boolean resumableStreams, boolean openConnectionOnStartup) {
-		this.objectMapper = objectMapper;
+		this.jsonMapper = jsonMapper;
 		this.webClient = webClientBuilder.build();
 		this.endpoint = endpoint;
 		this.resumableStreams = resumableStreams;
@@ -366,8 +367,7 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 			McpSchema.JSONRPCResponse.JSONRPCError jsonRpcError = null;
 			Exception toPropagate;
 			try {
-				McpSchema.JSONRPCResponse jsonRpcResponse = objectMapper.readValue(body,
-						McpSchema.JSONRPCResponse.class);
+				McpSchema.JSONRPCResponse jsonRpcResponse = jsonMapper.readValue(body, McpSchema.JSONRPCResponse.class);
 				jsonRpcError = jsonRpcResponse.error();
 				toPropagate = jsonRpcError != null ? new McpError(jsonRpcError)
 						: new McpTransportException("Can't parse the jsonResponse " + jsonRpcResponse);
@@ -427,7 +427,7 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 					s.complete();
 				}
 				else {
-					McpSchema.JSONRPCMessage jsonRpcResponse = McpSchema.deserializeJsonRpcMessage(objectMapper,
+					McpSchema.JSONRPCMessage jsonRpcResponse = McpSchema.deserializeJsonRpcMessage(jsonMapper,
 							responseMessage);
 					s.next(List.of(jsonRpcResponse));
 				}
@@ -447,8 +447,8 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 	}
 
 	@Override
-	public <T> T unmarshalFrom(Object data, TypeReference<T> typeRef) {
-		return this.objectMapper.convertValue(data, typeRef);
+	public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+		return this.jsonMapper.convertValue(data, typeRef);
 	}
 
 	private Tuple2<Optional<String>, Iterable<McpSchema.JSONRPCMessage>> parse(ServerSentEvent<String> event) {
@@ -456,7 +456,7 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 			try {
 				// We don't support batching ATM and probably won't since the next version
 				// considers removing it.
-				McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(this.objectMapper, event.data());
+				McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(this.jsonMapper, event.data());
 				return Tuples.of(Optional.ofNullable(event.id()), List.of(message));
 			}
 			catch (IOException ioException) {
@@ -474,7 +474,7 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 	 */
 	public static class Builder {
 
-		private ObjectMapper objectMapper;
+		private McpJsonMapper jsonMapper;
 
 		private WebClient.Builder webClientBuilder;
 
@@ -494,9 +494,20 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 		 * @param objectMapper instance to use
 		 * @return the builder instance
 		 */
-		public Builder objectMapper(ObjectMapper objectMapper) {
+		public Builder objectMapper(com.fasterxml.jackson.databind.ObjectMapper objectMapper) {
 			Assert.notNull(objectMapper, "ObjectMapper must not be null");
-			this.objectMapper = objectMapper;
+			this.jsonMapper = new JacksonMcpJsonMapper(objectMapper);
+			return this;
+		}
+
+		/**
+		 * Configure the {@link McpJsonMapper} to use.
+		 * @param jsonMapper instance to use
+		 * @return the builder instance
+		 */
+		public Builder jsonMapper(McpJsonMapper jsonMapper) {
+			Assert.notNull(jsonMapper, "JsonMapper must not be null");
+			this.jsonMapper = jsonMapper;
 			return this;
 		}
 
@@ -555,9 +566,10 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 		 * @return a new instance of {@link WebClientStreamableHttpTransport}
 		 */
 		public WebClientStreamableHttpTransport build() {
-			ObjectMapper objectMapper = this.objectMapper != null ? this.objectMapper : new ObjectMapper();
+			McpJsonMapper jsonMapper = this.jsonMapper != null ? this.jsonMapper
+					: new JacksonMcpJsonMapper(new com.fasterxml.jackson.databind.ObjectMapper());
 
-			return new WebClientStreamableHttpTransport(objectMapper, this.webClientBuilder, endpoint, resumableStreams,
+			return new WebClientStreamableHttpTransport(jsonMapper, this.webClientBuilder, endpoint, resumableStreams,
 					openConnectionOnStartup);
 		}
 

--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransport.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransport.java
@@ -9,8 +9,9 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.spec.json.McpJsonMapper;
+import io.modelcontextprotocol.spec.json.TypeRef;
+import io.modelcontextprotocol.spec.json.jackson.JacksonMcpJsonMapper;
 
 import io.modelcontextprotocol.spec.HttpHeaders;
 import io.modelcontextprotocol.spec.McpClientTransport;
@@ -100,10 +101,10 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 	private final WebClient webClient;
 
 	/**
-	 * ObjectMapper for serializing outbound messages and deserializing inbound messages.
+	 * JSON mapper for serializing outbound messages and deserializing inbound messages.
 	 * Handles conversion between JSON-RPC messages and their string representation.
 	 */
-	protected ObjectMapper objectMapper;
+	protected McpJsonMapper jsonMapper;
 
 	/**
 	 * Subscription for the SSE connection handling inbound messages. Used for cleanup
@@ -137,7 +138,7 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 	 * @throws IllegalArgumentException if webClientBuilder is null
 	 */
 	public WebFluxSseClientTransport(WebClient.Builder webClientBuilder) {
-		this(webClientBuilder, new ObjectMapper());
+		this(webClientBuilder, new JacksonMcpJsonMapper(new com.fasterxml.jackson.databind.ObjectMapper()));
 	}
 
 	/**
@@ -145,11 +146,11 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 	 * ObjectMapper. Initializes both inbound and outbound message processing pipelines.
 	 * @param webClientBuilder the WebClient.Builder to use for creating the WebClient
 	 * instance
-	 * @param objectMapper the ObjectMapper to use for JSON processing
+	 * @param jsonMapper the ObjectMapper to use for JSON processing
 	 * @throws IllegalArgumentException if either parameter is null
 	 */
-	public WebFluxSseClientTransport(WebClient.Builder webClientBuilder, ObjectMapper objectMapper) {
-		this(webClientBuilder, objectMapper, DEFAULT_SSE_ENDPOINT);
+	public WebFluxSseClientTransport(WebClient.Builder webClientBuilder, McpJsonMapper jsonMapper) {
+		this(webClientBuilder, jsonMapper, DEFAULT_SSE_ENDPOINT);
 	}
 
 	/**
@@ -157,17 +158,16 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 	 * ObjectMapper. Initializes both inbound and outbound message processing pipelines.
 	 * @param webClientBuilder the WebClient.Builder to use for creating the WebClient
 	 * instance
-	 * @param objectMapper the ObjectMapper to use for JSON processing
+	 * @param jsonMapper the ObjectMapper to use for JSON processing
 	 * @param sseEndpoint the SSE endpoint URI to use for establishing the connection
 	 * @throws IllegalArgumentException if either parameter is null
 	 */
-	public WebFluxSseClientTransport(WebClient.Builder webClientBuilder, ObjectMapper objectMapper,
-			String sseEndpoint) {
-		Assert.notNull(objectMapper, "ObjectMapper must not be null");
+	public WebFluxSseClientTransport(WebClient.Builder webClientBuilder, McpJsonMapper jsonMapper, String sseEndpoint) {
+		Assert.notNull(jsonMapper, "jsonMapper must not be null");
 		Assert.notNull(webClientBuilder, "WebClient.Builder must not be null");
 		Assert.hasText(sseEndpoint, "SSE endpoint must not be null or empty");
 
-		this.objectMapper = objectMapper;
+		this.jsonMapper = jsonMapper;
 		this.webClient = webClientBuilder.build();
 		this.sseEndpoint = sseEndpoint;
 	}
@@ -217,7 +217,7 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 			}
 			else if (MESSAGE_EVENT_TYPE.equals(event.event())) {
 				try {
-					JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(this.objectMapper, event.data());
+					JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(this.jsonMapper, event.data());
 					s.next(message);
 				}
 				catch (IOException ioException) {
@@ -255,7 +255,7 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 				return Mono.empty();
 			}
 			try {
-				String jsonText = this.objectMapper.writeValueAsString(message);
+				String jsonText = this.jsonMapper.writeValueAsString(message);
 				return webClient.post()
 					.uri(messageEndpointUri)
 					.contentType(MediaType.APPLICATION_JSON)
@@ -349,13 +349,13 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 	 * type conversion capabilities to handle complex object structures.
 	 * @param <T> the target type to convert the data into
 	 * @param data the source object to convert
-	 * @param typeRef the TypeReference describing the target type
+	 * @param typeRef the TypeRef describing the target type
 	 * @return the unmarshalled object of type T
 	 * @throws IllegalArgumentException if the conversion cannot be performed
 	 */
 	@Override
-	public <T> T unmarshalFrom(Object data, TypeReference<T> typeRef) {
-		return this.objectMapper.convertValue(data, typeRef);
+	public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+		return this.jsonMapper.convertValue(data, typeRef);
 	}
 
 	/**
@@ -377,7 +377,7 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 
 		private String sseEndpoint = DEFAULT_SSE_ENDPOINT;
 
-		private ObjectMapper objectMapper = new ObjectMapper();
+		private McpJsonMapper jsonMapper = new JacksonMcpJsonMapper(new com.fasterxml.jackson.databind.ObjectMapper());
 
 		/**
 		 * Creates a new builder with the specified WebClient.Builder.
@@ -401,12 +401,25 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 
 		/**
 		 * Sets the object mapper for JSON serialization/deserialization.
-		 * @param objectMapper the object mapper
+		 * @param objectMapper the Jackson ObjectMapper
+		 * @return this builder
+		 * @deprecated Use {@link #jsonMapper(McpJsonMapper)} instead
+		 */
+		@Deprecated(forRemoval = true)
+		public Builder objectMapper(com.fasterxml.jackson.databind.ObjectMapper objectMapper) {
+			Assert.notNull(objectMapper, "objectMapper must not be null");
+			this.jsonMapper = new JacksonMcpJsonMapper(objectMapper);
+			return this;
+		}
+
+		/**
+		 * Sets the JSON mapper for serialization/deserialization.
+		 * @param jsonMapper the JsonMapper to use
 		 * @return this builder
 		 */
-		public Builder objectMapper(ObjectMapper objectMapper) {
-			Assert.notNull(objectMapper, "objectMapper must not be null");
-			this.objectMapper = objectMapper;
+		public Builder jsonMapper(McpJsonMapper jsonMapper) {
+			Assert.notNull(jsonMapper, "jsonMapper must not be null");
+			this.jsonMapper = jsonMapper;
 			return this;
 		}
 
@@ -415,7 +428,7 @@ public class WebFluxSseClientTransport implements McpClientTransport {
 		 * @return a new transport instance
 		 */
 		public WebFluxSseClientTransport build() {
-			return new WebFluxSseClientTransport(webClientBuilder, objectMapper, sseEndpoint);
+			return new WebFluxSseClientTransport(webClientBuilder, jsonMapper, sseEndpoint);
 		}
 
 	}

--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxSseServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxSseServerTransportProvider.java
@@ -11,6 +11,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.spec.json.TypeRef;
+import io.modelcontextprotocol.spec.json.jackson.JacksonMcpJsonMapper;
 
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpTransportContextExtractor;
@@ -452,8 +454,8 @@ public class WebFluxSseServerTransportProvider implements McpServerTransportProv
 		}
 
 		@Override
-		public <T> T unmarshalFrom(Object data, TypeReference<T> typeRef) {
-			return objectMapper.convertValue(data, typeRef);
+		public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+			return new JacksonMcpJsonMapper(objectMapper).convertValue(data, typeRef);
 		}
 
 		@Override

--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxStatelessServerTransport.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxStatelessServerTransport.java
@@ -5,6 +5,8 @@
 package io.modelcontextprotocol.server.transport;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.spec.json.McpJsonMapper;
+import io.modelcontextprotocol.spec.json.jackson.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpStatelessServerHandler;
 import io.modelcontextprotocol.server.McpTransportContextExtractor;
@@ -34,7 +36,7 @@ public class WebFluxStatelessServerTransport implements McpStatelessServerTransp
 
 	private static final Logger logger = LoggerFactory.getLogger(WebFluxStatelessServerTransport.class);
 
-	private final ObjectMapper objectMapper;
+	private final McpJsonMapper jsonMapper;
 
 	private final String mcpEndpoint;
 
@@ -46,13 +48,13 @@ public class WebFluxStatelessServerTransport implements McpStatelessServerTransp
 
 	private volatile boolean isClosing = false;
 
-	private WebFluxStatelessServerTransport(ObjectMapper objectMapper, String mcpEndpoint,
+	private WebFluxStatelessServerTransport(McpJsonMapper jsonMapper, String mcpEndpoint,
 			McpTransportContextExtractor<ServerRequest> contextExtractor) {
-		Assert.notNull(objectMapper, "objectMapper must not be null");
+		Assert.notNull(jsonMapper, "jsonMapper must not be null");
 		Assert.notNull(mcpEndpoint, "mcpEndpoint must not be null");
 		Assert.notNull(contextExtractor, "contextExtractor must not be null");
 
-		this.objectMapper = objectMapper;
+		this.jsonMapper = jsonMapper;
 		this.mcpEndpoint = mcpEndpoint;
 		this.contextExtractor = contextExtractor;
 		this.routerFunction = RouterFunctions.route()
@@ -106,13 +108,20 @@ public class WebFluxStatelessServerTransport implements McpStatelessServerTransp
 
 		return request.bodyToMono(String.class).<ServerResponse>flatMap(body -> {
 			try {
-				McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(objectMapper, body);
+				McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(jsonMapper, body);
 
 				if (message instanceof McpSchema.JSONRPCRequest jsonrpcRequest) {
-					return this.mcpHandler.handleRequest(transportContext, jsonrpcRequest)
-						.flatMap(jsonrpcResponse -> ServerResponse.ok()
-							.contentType(MediaType.APPLICATION_JSON)
-							.bodyValue(jsonrpcResponse));
+					return this.mcpHandler.handleRequest(transportContext, jsonrpcRequest).flatMap(jsonrpcResponse -> {
+						try {
+							String json = jsonMapper.writeValueAsString(jsonrpcResponse);
+							return ServerResponse.ok().contentType(MediaType.APPLICATION_JSON).bodyValue(json);
+						}
+						catch (IOException e) {
+							logger.error("Failed to serialize response: {}", e.getMessage());
+							return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
+								.bodyValue(new McpError("Failed to serialize response"));
+						}
+					});
 				}
 				else if (message instanceof McpSchema.JSONRPCNotification jsonrpcNotification) {
 					return this.mcpHandler.handleNotification(transportContext, jsonrpcNotification)
@@ -146,7 +155,7 @@ public class WebFluxStatelessServerTransport implements McpStatelessServerTransp
 	 */
 	public static class Builder {
 
-		private ObjectMapper objectMapper;
+		private McpJsonMapper jsonMapper;
 
 		private String mcpEndpoint = "/mcp";
 
@@ -166,7 +175,20 @@ public class WebFluxStatelessServerTransport implements McpStatelessServerTransp
 		 */
 		public Builder objectMapper(ObjectMapper objectMapper) {
 			Assert.notNull(objectMapper, "ObjectMapper must not be null");
-			this.objectMapper = objectMapper;
+			this.jsonMapper = new JacksonMcpJsonMapper(objectMapper);
+			return this;
+		}
+
+		/**
+		 * Sets the JsonMapper to use for JSON serialization/deserialization of MCP
+		 * messages.
+		 * @param jsonMapper The JsonMapper instance. Must not be null.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if jsonMapper is null
+		 */
+		public Builder jsonMapper(McpJsonMapper jsonMapper) {
+			Assert.notNull(jsonMapper, "JsonMapper must not be null");
+			this.jsonMapper = jsonMapper;
 			return this;
 		}
 
@@ -205,10 +227,12 @@ public class WebFluxStatelessServerTransport implements McpStatelessServerTransp
 		 * @throws IllegalStateException if required parameters are not set
 		 */
 		public WebFluxStatelessServerTransport build() {
-			Assert.notNull(objectMapper, "ObjectMapper must be set");
+			if (this.jsonMapper == null) {
+				throw new IllegalStateException("JsonMapper must be set");
+			}
 			Assert.notNull(mcpEndpoint, "Message endpoint must be set");
 
-			return new WebFluxStatelessServerTransport(objectMapper, mcpEndpoint, contextExtractor);
+			return new WebFluxStatelessServerTransport(jsonMapper, mcpEndpoint, contextExtractor);
 		}
 
 	}

--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxStreamableServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxStreamableServerTransportProvider.java
@@ -6,6 +6,8 @@ package io.modelcontextprotocol.server.transport;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.spec.json.TypeRef;
+import io.modelcontextprotocol.spec.json.jackson.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpTransportContextExtractor;
 import io.modelcontextprotocol.spec.HttpHeaders;
@@ -369,8 +371,8 @@ public class WebFluxStreamableServerTransportProvider implements McpStreamableSe
 		}
 
 		@Override
-		public <T> T unmarshalFrom(Object data, TypeReference<T> typeRef) {
-			return objectMapper.convertValue(data, typeRef);
+		public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+			return new JacksonMcpJsonMapper(objectMapper).convertValue(data, typeRef);
 		}
 
 		@Override

--- a/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransportTests.java
+++ b/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransportTests.java
@@ -11,6 +11,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.spec.json.jackson.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.JSONRPCRequest;
 import org.junit.jupiter.api.AfterAll;
@@ -64,7 +65,7 @@ class WebFluxSseClientTransportTests {
 		private Sinks.Many<ServerSentEvent<String>> events = Sinks.many().unicast().onBackpressureBuffer();
 
 		public TestSseClientTransport(WebClient.Builder webClientBuilder, ObjectMapper objectMapper) {
-			super(webClientBuilder, objectMapper);
+			super(webClientBuilder, new JacksonMcpJsonMapper(objectMapper));
 		}
 
 		@Override

--- a/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransportProvider.java
@@ -13,6 +13,8 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.spec.json.TypeRef;
+import io.modelcontextprotocol.spec.json.jackson.JacksonMcpJsonMapper;
 
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpTransportContextExtractor;
@@ -478,8 +480,8 @@ public class WebMvcSseServerTransportProvider implements McpServerTransportProvi
 		 * @param <T> The target type
 		 */
 		@Override
-		public <T> T unmarshalFrom(Object data, TypeReference<T> typeRef) {
-			return objectMapper.convertValue(data, typeRef);
+		public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+			return new JacksonMcpJsonMapper(objectMapper).convertValue(data, typeRef);
 		}
 
 		/**

--- a/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcStreamableServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcStreamableServerTransportProvider.java
@@ -22,6 +22,8 @@ import org.springframework.web.servlet.function.ServerResponse.SseBuilder;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.spec.json.TypeRef;
+import io.modelcontextprotocol.spec.json.jackson.JacksonMcpJsonMapper;
 
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpTransportContextExtractor;
@@ -546,8 +548,8 @@ public class WebMvcStreamableServerTransportProvider implements McpStreamableSer
 		 * @param <T> The target type
 		 */
 		@Override
-		public <T> T unmarshalFrom(Object data, TypeReference<T> typeRef) {
-			return objectMapper.convertValue(data, typeRef);
+		public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+			return new JacksonMcpJsonMapper(objectMapper).convertValue(data, typeRef);
 		}
 
 		/**

--- a/mcp-test/src/main/java/io/modelcontextprotocol/MockMcpTransport.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/MockMcpTransport.java
@@ -9,8 +9,8 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.spec.json.TypeRef;
+import io.modelcontextprotocol.spec.json.jackson.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.JSONRPCNotification;
@@ -93,8 +93,8 @@ public class MockMcpTransport implements McpClientTransport, McpServerTransport 
 	}
 
 	@Override
-	public <T> T unmarshalFrom(Object data, TypeReference<T> typeRef) {
-		return new ObjectMapper().convertValue(data, typeRef);
+	public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+		return new JacksonMcpJsonMapper(new com.fasterxml.jackson.databind.ObjectMapper()).convertValue(data, typeRef);
 	}
 
 }

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -216,6 +216,13 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- Test-only JSON library for the Gson-based McpJsonMapper example -->
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.10.1</version>
+			<scope>test</scope>
+		</dependency>
 
 	</dependencies>
 

--- a/mcp/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
@@ -18,11 +18,10 @@ import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import io.modelcontextprotocol.spec.json.TypeRef;
 
 import io.modelcontextprotocol.spec.McpClientSession;
 import io.modelcontextprotocol.spec.McpClientTransport;
-import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.ClientCapabilities;
 import io.modelcontextprotocol.spec.McpSchema.CreateMessageRequest;
@@ -85,25 +84,25 @@ public class McpAsyncClient {
 
 	private static final Logger logger = LoggerFactory.getLogger(McpAsyncClient.class);
 
-	private static final TypeReference<Void> VOID_TYPE_REFERENCE = new TypeReference<>() {
+	private static final TypeRef<Void> VOID_TYPE_REFERENCE = new TypeRef<>() {
 	};
 
-	public static final TypeReference<Object> OBJECT_TYPE_REF = new TypeReference<>() {
+	public static final TypeRef<Object> OBJECT_TYPE_REF = new TypeRef<>() {
 	};
 
-	public static final TypeReference<PaginatedRequest> PAGINATED_REQUEST_TYPE_REF = new TypeReference<>() {
+	public static final TypeRef<PaginatedRequest> PAGINATED_REQUEST_TYPE_REF = new TypeRef<>() {
 	};
 
-	public static final TypeReference<McpSchema.InitializeResult> INITIALIZE_RESULT_TYPE_REF = new TypeReference<>() {
+	public static final TypeRef<McpSchema.InitializeResult> INITIALIZE_RESULT_TYPE_REF = new TypeRef<>() {
 	};
 
-	public static final TypeReference<CreateMessageRequest> CREATE_MESSAGE_REQUEST_TYPE_REF = new TypeReference<>() {
+	public static final TypeRef<CreateMessageRequest> CREATE_MESSAGE_REQUEST_TYPE_REF = new TypeRef<>() {
 	};
 
-	public static final TypeReference<LoggingMessageNotification> LOGGING_MESSAGE_NOTIFICATION_TYPE_REF = new TypeReference<>() {
+	public static final TypeRef<LoggingMessageNotification> LOGGING_MESSAGE_NOTIFICATION_TYPE_REF = new TypeRef<>() {
 	};
 
-	public static final TypeReference<McpSchema.ProgressNotification> PROGRESS_NOTIFICATION_TYPE_REF = new TypeReference<>() {
+	public static final TypeRef<McpSchema.ProgressNotification> PROGRESS_NOTIFICATION_TYPE_REF = new TypeRef<>() {
 	};
 
 	/**
@@ -512,7 +511,7 @@ public class McpAsyncClient {
 	// --------------------------
 	private RequestHandler<ElicitResult> elicitationCreateHandler() {
 		return params -> {
-			ElicitRequest request = transport.unmarshalFrom(params, new TypeReference<>() {
+			ElicitRequest request = transport.unmarshalFrom(params, new TypeRef<>() {
 			});
 
 			return this.elicitationHandler.apply(request);
@@ -522,10 +521,10 @@ public class McpAsyncClient {
 	// --------------------------
 	// Tools
 	// --------------------------
-	private static final TypeReference<McpSchema.CallToolResult> CALL_TOOL_RESULT_TYPE_REF = new TypeReference<>() {
+	private static final TypeRef<McpSchema.CallToolResult> CALL_TOOL_RESULT_TYPE_REF = new TypeRef<>() {
 	};
 
-	private static final TypeReference<McpSchema.ListToolsResult> LIST_TOOLS_RESULT_TYPE_REF = new TypeReference<>() {
+	private static final TypeRef<McpSchema.ListToolsResult> LIST_TOOLS_RESULT_TYPE_REF = new TypeRef<>() {
 	};
 
 	/**
@@ -596,13 +595,13 @@ public class McpAsyncClient {
 	// Resources
 	// --------------------------
 
-	private static final TypeReference<McpSchema.ListResourcesResult> LIST_RESOURCES_RESULT_TYPE_REF = new TypeReference<>() {
+	private static final TypeRef<McpSchema.ListResourcesResult> LIST_RESOURCES_RESULT_TYPE_REF = new TypeRef<>() {
 	};
 
-	private static final TypeReference<McpSchema.ReadResourceResult> READ_RESOURCE_RESULT_TYPE_REF = new TypeReference<>() {
+	private static final TypeRef<McpSchema.ReadResourceResult> READ_RESOURCE_RESULT_TYPE_REF = new TypeRef<>() {
 	};
 
-	private static final TypeReference<McpSchema.ListResourceTemplatesResult> LIST_RESOURCE_TEMPLATES_RESULT_TYPE_REF = new TypeReference<>() {
+	private static final TypeRef<McpSchema.ListResourceTemplatesResult> LIST_RESOURCE_TEMPLATES_RESULT_TYPE_REF = new TypeRef<>() {
 	};
 
 	/**
@@ -756,7 +755,7 @@ public class McpAsyncClient {
 			List<Function<List<McpSchema.ResourceContents>, Mono<Void>>> resourcesUpdateConsumers) {
 		return params -> {
 			McpSchema.ResourcesUpdatedNotification resourcesUpdatedNotification = transport.unmarshalFrom(params,
-					new TypeReference<>() {
+					new TypeRef<>() {
 					});
 
 			return readResource(new McpSchema.ReadResourceRequest(resourcesUpdatedNotification.uri()))
@@ -773,10 +772,10 @@ public class McpAsyncClient {
 	// --------------------------
 	// Prompts
 	// --------------------------
-	private static final TypeReference<McpSchema.ListPromptsResult> LIST_PROMPTS_RESULT_TYPE_REF = new TypeReference<>() {
+	private static final TypeRef<McpSchema.ListPromptsResult> LIST_PROMPTS_RESULT_TYPE_REF = new TypeRef<>() {
 	};
 
-	private static final TypeReference<McpSchema.GetPromptResult> GET_PROMPT_RESULT_TYPE_REF = new TypeReference<>() {
+	private static final TypeRef<McpSchema.GetPromptResult> GET_PROMPT_RESULT_TYPE_REF = new TypeRef<>() {
 	};
 
 	/**
@@ -911,7 +910,7 @@ public class McpAsyncClient {
 	// --------------------------
 	// Completions
 	// --------------------------
-	private static final TypeReference<McpSchema.CompleteResult> COMPLETION_COMPLETE_RESULT_TYPE_REF = new TypeReference<>() {
+	private static final TypeRef<McpSchema.CompleteResult> COMPLETION_COMPLETE_RESULT_TYPE_REF = new TypeRef<>() {
 	};
 
 	/**

--- a/mcp/src/main/java/io/modelcontextprotocol/client/transport/StdioClientTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/transport/StdioClientTransport.java
@@ -15,8 +15,9 @@ import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.spec.json.TypeRef;
+import io.modelcontextprotocol.spec.json.McpJsonMapper;
+import io.modelcontextprotocol.spec.json.jackson.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.JSONRPCMessage;
@@ -48,7 +49,7 @@ public class StdioClientTransport implements McpClientTransport {
 	/** The server process being communicated with */
 	private Process process;
 
-	private ObjectMapper objectMapper;
+	private McpJsonMapper jsonMapper;
 
 	/** Scheduler for handling inbound messages from the server process */
 	private Scheduler inboundScheduler;
@@ -75,24 +76,24 @@ public class StdioClientTransport implements McpClientTransport {
 	 * @param params The parameters for configuring the server process
 	 */
 	public StdioClientTransport(ServerParameters params) {
-		this(params, new ObjectMapper());
+		this(params, new JacksonMcpJsonMapper(new com.fasterxml.jackson.databind.ObjectMapper()));
 	}
 
 	/**
-	 * Creates a new StdioClientTransport with the specified parameters and ObjectMapper.
+	 * Creates a new StdioClientTransport with the specified parameters and JsonMapper.
 	 * @param params The parameters for configuring the server process
-	 * @param objectMapper The ObjectMapper to use for JSON serialization/deserialization
+	 * @param jsonMapper The JsonMapper to use for JSON serialization/deserialization
 	 */
-	public StdioClientTransport(ServerParameters params, ObjectMapper objectMapper) {
+	public StdioClientTransport(ServerParameters params, McpJsonMapper jsonMapper) {
 		Assert.notNull(params, "The params can not be null");
-		Assert.notNull(objectMapper, "The ObjectMapper can not be null");
+		Assert.notNull(jsonMapper, "The JsonMapper can not be null");
 
 		this.inboundSink = Sinks.many().unicast().onBackpressureBuffer();
 		this.outboundSink = Sinks.many().unicast().onBackpressureBuffer();
 
 		this.params = params;
 
-		this.objectMapper = objectMapper;
+		this.jsonMapper = jsonMapper;
 
 		this.errorSink = Sinks.many().unicast().onBackpressureBuffer();
 
@@ -100,6 +101,16 @@ public class StdioClientTransport implements McpClientTransport {
 		this.inboundScheduler = Schedulers.fromExecutorService(Executors.newSingleThreadExecutor(), "inbound");
 		this.outboundScheduler = Schedulers.fromExecutorService(Executors.newSingleThreadExecutor(), "outbound");
 		this.errorScheduler = Schedulers.fromExecutorService(Executors.newSingleThreadExecutor(), "error");
+	}
+
+	/**
+	 * Creates a new StdioClientTransport with the specified parameters and ObjectMapper.
+	 * @deprecated Use {@link #StdioClientTransport(ServerParameters, McpJsonMapper)}
+	 * instead.
+	 */
+	@Deprecated(forRemoval = true)
+	public StdioClientTransport(ServerParameters params, com.fasterxml.jackson.databind.ObjectMapper objectMapper) {
+		this(params, new JacksonMcpJsonMapper(objectMapper));
 	}
 
 	/**
@@ -259,7 +270,7 @@ public class StdioClientTransport implements McpClientTransport {
 				String line;
 				while (!isClosing && (line = processReader.readLine()) != null) {
 					try {
-						JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(this.objectMapper, line);
+						JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(this.jsonMapper, line);
 						if (!this.inboundSink.tryEmitNext(message).isSuccess()) {
 							if (!isClosing) {
 								logger.error("Failed to enqueue inbound message: {}", message);
@@ -300,7 +311,7 @@ public class StdioClientTransport implements McpClientTransport {
 			.handle((message, s) -> {
 				if (message != null && !isClosing) {
 					try {
-						String jsonMessage = objectMapper.writeValueAsString(message);
+						String jsonMessage = jsonMapper.writeValueAsString(message);
 						// Escape any embedded newlines in the JSON message as per spec:
 						// https://spec.modelcontextprotocol.io/specification/basic/transports/#stdio
 						// - Messages are delimited by newlines, and MUST NOT contain
@@ -392,8 +403,8 @@ public class StdioClientTransport implements McpClientTransport {
 	}
 
 	@Override
-	public <T> T unmarshalFrom(Object data, TypeReference<T> typeRef) {
-		return this.objectMapper.convertValue(data, typeRef);
+	public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+		return this.jsonMapper.convertValue(data, typeRef);
 	}
 
 }

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -21,8 +21,8 @@ import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.spec.json.McpJsonMapper;
+import io.modelcontextprotocol.spec.json.TypeRef;
 
 import io.modelcontextprotocol.spec.JsonSchemaValidator;
 import io.modelcontextprotocol.spec.McpClientSession;
@@ -34,7 +34,6 @@ import io.modelcontextprotocol.spec.McpSchema.LoggingLevel;
 import io.modelcontextprotocol.spec.McpSchema.LoggingMessageNotification;
 import io.modelcontextprotocol.spec.McpSchema.ResourceTemplate;
 import io.modelcontextprotocol.spec.McpSchema.SetLevelRequest;
-import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import io.modelcontextprotocol.spec.McpServerSession;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
@@ -93,7 +92,7 @@ public class McpAsyncServer {
 
 	private final McpServerTransportProviderBase mcpTransportProvider;
 
-	private final ObjectMapper objectMapper;
+	private final McpJsonMapper jsonMapper;
 
 	private final JsonSchemaValidator jsonSchemaValidator;
 
@@ -126,13 +125,13 @@ public class McpAsyncServer {
 	 * @param mcpTransportProvider The transport layer implementation for MCP
 	 * communication.
 	 * @param features The MCP server supported features.
-	 * @param objectMapper The ObjectMapper to use for JSON serialization/deserialization
+	 * @param jsonMapper The JsonMapper to use for JSON serialization/deserialization
 	 */
-	McpAsyncServer(McpServerTransportProvider mcpTransportProvider, ObjectMapper objectMapper,
+	McpAsyncServer(McpServerTransportProvider mcpTransportProvider, McpJsonMapper jsonMapper,
 			McpServerFeatures.Async features, Duration requestTimeout,
 			McpUriTemplateManagerFactory uriTemplateManagerFactory, JsonSchemaValidator jsonSchemaValidator) {
 		this.mcpTransportProvider = mcpTransportProvider;
-		this.objectMapper = objectMapper;
+		this.jsonMapper = jsonMapper;
 		this.serverInfo = features.serverInfo();
 		this.serverCapabilities = features.serverCapabilities().mutate().logging().build();
 		this.instructions = features.instructions();
@@ -153,11 +152,11 @@ public class McpAsyncServer {
 				requestTimeout, transport, this::asyncInitializeRequestHandler, requestHandlers, notificationHandlers));
 	}
 
-	McpAsyncServer(McpStreamableServerTransportProvider mcpTransportProvider, ObjectMapper objectMapper,
+	McpAsyncServer(McpStreamableServerTransportProvider mcpTransportProvider, McpJsonMapper jsonMapper,
 			McpServerFeatures.Async features, Duration requestTimeout,
 			McpUriTemplateManagerFactory uriTemplateManagerFactory, JsonSchemaValidator jsonSchemaValidator) {
 		this.mcpTransportProvider = mcpTransportProvider;
-		this.objectMapper = objectMapper;
+		this.jsonMapper = jsonMapper;
 		this.serverInfo = features.serverInfo();
 		this.serverCapabilities = features.serverCapabilities().mutate().logging().build();
 		this.instructions = features.instructions();
@@ -505,8 +504,8 @@ public class McpAsyncServer {
 
 	private McpRequestHandler<CallToolResult> toolsCallRequestHandler() {
 		return (exchange, params) -> {
-			McpSchema.CallToolRequest callToolRequest = objectMapper.convertValue(params,
-					new TypeReference<McpSchema.CallToolRequest>() {
+			McpSchema.CallToolRequest callToolRequest = jsonMapper.convertValue(params,
+					new TypeRef<McpSchema.CallToolRequest>() {
 					});
 
 			Optional<McpServerFeatures.AsyncToolSpecification> toolSpecification = this.tools.stream()
@@ -633,8 +632,8 @@ public class McpAsyncServer {
 
 	private McpRequestHandler<McpSchema.ReadResourceResult> resourcesReadRequestHandler() {
 		return (exchange, params) -> {
-			McpSchema.ReadResourceRequest resourceRequest = objectMapper.convertValue(params,
-					new TypeReference<McpSchema.ReadResourceRequest>() {
+			McpSchema.ReadResourceRequest resourceRequest = jsonMapper.convertValue(params,
+					new TypeRef<McpSchema.ReadResourceRequest>() {
 					});
 			var resourceUri = resourceRequest.uri();
 
@@ -742,8 +741,8 @@ public class McpAsyncServer {
 
 	private McpRequestHandler<McpSchema.GetPromptResult> promptsGetRequestHandler() {
 		return (exchange, params) -> {
-			McpSchema.GetPromptRequest promptRequest = objectMapper.convertValue(params,
-					new TypeReference<McpSchema.GetPromptRequest>() {
+			McpSchema.GetPromptRequest promptRequest = jsonMapper.convertValue(params,
+					new TypeRef<McpSchema.GetPromptRequest>() {
 					});
 
 			// Implement prompt retrieval logic here
@@ -790,9 +789,8 @@ public class McpAsyncServer {
 		return (exchange, params) -> {
 			return Mono.defer(() -> {
 
-				SetLevelRequest newMinLoggingLevel = objectMapper.convertValue(params,
-						new TypeReference<SetLevelRequest>() {
-						});
+				SetLevelRequest newMinLoggingLevel = jsonMapper.convertValue(params, new TypeRef<SetLevelRequest>() {
+				});
 
 				exchange.setMinLoggingLevel(newMinLoggingLevel.level());
 

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
@@ -8,7 +8,7 @@ import io.modelcontextprotocol.common.McpTransportContext;
 import java.util.ArrayList;
 import java.util.Collections;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import io.modelcontextprotocol.spec.json.TypeRef;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpLoggableSession;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -37,16 +37,16 @@ public class McpAsyncServerExchange {
 
 	private final McpTransportContext transportContext;
 
-	private static final TypeReference<McpSchema.CreateMessageResult> CREATE_MESSAGE_RESULT_TYPE_REF = new TypeReference<>() {
+	private static final TypeRef<McpSchema.CreateMessageResult> CREATE_MESSAGE_RESULT_TYPE_REF = new TypeRef<>() {
 	};
 
-	private static final TypeReference<McpSchema.ListRootsResult> LIST_ROOTS_RESULT_TYPE_REF = new TypeReference<>() {
+	private static final TypeRef<McpSchema.ListRootsResult> LIST_ROOTS_RESULT_TYPE_REF = new TypeRef<>() {
 	};
 
-	private static final TypeReference<McpSchema.ElicitResult> ELICITATION_RESULT_TYPE_REF = new TypeReference<>() {
+	private static final TypeRef<McpSchema.ElicitResult> ELICITATION_RESULT_TYPE_REF = new TypeRef<>() {
 	};
 
-	public static final TypeReference<Object> OBJECT_TYPE_REF = new TypeReference<>() {
+	public static final TypeRef<Object> OBJECT_TYPE_REF = new TypeRef<>() {
 	};
 
 	/**

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
@@ -4,8 +4,8 @@
 
 package io.modelcontextprotocol.server;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.spec.json.TypeRef;
+import io.modelcontextprotocol.spec.json.McpJsonMapper;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.spec.JsonSchemaValidator;
 import io.modelcontextprotocol.spec.McpError;
@@ -13,7 +13,6 @@ import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.JSONRPCResponse;
 import io.modelcontextprotocol.spec.McpSchema.ResourceTemplate;
-import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import io.modelcontextprotocol.spec.McpStatelessServerTransport;
 import io.modelcontextprotocol.util.Assert;
@@ -48,7 +47,7 @@ public class McpStatelessAsyncServer {
 
 	private final McpStatelessServerTransport mcpTransportProvider;
 
-	private final ObjectMapper objectMapper;
+	private final McpJsonMapper jsonMapper;
 
 	private final McpSchema.ServerCapabilities serverCapabilities;
 
@@ -72,11 +71,11 @@ public class McpStatelessAsyncServer {
 
 	private final JsonSchemaValidator jsonSchemaValidator;
 
-	McpStatelessAsyncServer(McpStatelessServerTransport mcpTransport, ObjectMapper objectMapper,
+	McpStatelessAsyncServer(McpStatelessServerTransport mcpTransport, McpJsonMapper jsonMapper,
 			McpStatelessServerFeatures.Async features, Duration requestTimeout,
 			McpUriTemplateManagerFactory uriTemplateManagerFactory, JsonSchemaValidator jsonSchemaValidator) {
 		this.mcpTransportProvider = mcpTransport;
-		this.objectMapper = objectMapper;
+		this.jsonMapper = jsonMapper;
 		this.serverInfo = features.serverInfo();
 		this.serverCapabilities = features.serverCapabilities();
 		this.instructions = features.instructions();
@@ -132,7 +131,7 @@ public class McpStatelessAsyncServer {
 	// ---------------------------------------
 	private McpStatelessRequestHandler<McpSchema.InitializeResult> asyncInitializeRequestHandler() {
 		return (ctx, req) -> Mono.defer(() -> {
-			McpSchema.InitializeRequest initializeRequest = this.objectMapper.convertValue(req,
+			McpSchema.InitializeRequest initializeRequest = this.jsonMapper.convertValue(req,
 					McpSchema.InitializeRequest.class);
 
 			logger.info("Client initialize request - Protocol: {}, Capabilities: {}, Info: {}",
@@ -373,8 +372,8 @@ public class McpStatelessAsyncServer {
 
 	private McpStatelessRequestHandler<CallToolResult> toolsCallRequestHandler() {
 		return (ctx, params) -> {
-			McpSchema.CallToolRequest callToolRequest = objectMapper.convertValue(params,
-					new TypeReference<McpSchema.CallToolRequest>() {
+			McpSchema.CallToolRequest callToolRequest = jsonMapper.convertValue(params,
+					new TypeRef<McpSchema.CallToolRequest>() {
 					});
 
 			Optional<McpStatelessServerFeatures.AsyncToolSpecification> toolSpecification = this.tools.stream()
@@ -476,8 +475,8 @@ public class McpStatelessAsyncServer {
 
 	private McpStatelessRequestHandler<McpSchema.ReadResourceResult> resourcesReadRequestHandler() {
 		return (ctx, params) -> {
-			McpSchema.ReadResourceRequest resourceRequest = objectMapper.convertValue(params,
-					new TypeReference<McpSchema.ReadResourceRequest>() {
+			McpSchema.ReadResourceRequest resourceRequest = jsonMapper.convertValue(params,
+					new TypeRef<McpSchema.ReadResourceRequest>() {
 					});
 			var resourceUri = resourceRequest.uri();
 
@@ -566,8 +565,8 @@ public class McpStatelessAsyncServer {
 
 	private McpStatelessRequestHandler<McpSchema.GetPromptResult> promptsGetRequestHandler() {
 		return (ctx, params) -> {
-			McpSchema.GetPromptRequest promptRequest = objectMapper.convertValue(params,
-					new TypeReference<McpSchema.GetPromptRequest>() {
+			McpSchema.GetPromptRequest promptRequest = jsonMapper.convertValue(params,
+					new TypeRef<McpSchema.GetPromptRequest>() {
 					});
 
 			// Implement prompt retrieval logic here

--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStatelessServerTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStatelessServerTransport.java
@@ -8,10 +8,12 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.spec.json.McpJsonMapper;
+import io.modelcontextprotocol.spec.json.jackson.JacksonMcpJsonMapper;
 
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpStatelessServerHandler;
@@ -48,7 +50,7 @@ public class HttpServletStatelessServerTransport extends HttpServlet implements 
 
 	public static final String FAILED_TO_SEND_ERROR_RESPONSE = "Failed to send error response: {}";
 
-	private final ObjectMapper objectMapper;
+	private final McpJsonMapper jsonMapper;
 
 	private final String mcpEndpoint;
 
@@ -58,13 +60,13 @@ public class HttpServletStatelessServerTransport extends HttpServlet implements 
 
 	private volatile boolean isClosing = false;
 
-	private HttpServletStatelessServerTransport(ObjectMapper objectMapper, String mcpEndpoint,
+	private HttpServletStatelessServerTransport(McpJsonMapper jsonMapper, String mcpEndpoint,
 			McpTransportContextExtractor<HttpServletRequest> contextExtractor) {
-		Assert.notNull(objectMapper, "objectMapper must not be null");
+		Assert.notNull(jsonMapper, "jsonMapper must not be null");
 		Assert.notNull(mcpEndpoint, "mcpEndpoint must not be null");
 		Assert.notNull(contextExtractor, "contextExtractor must not be null");
 
-		this.objectMapper = objectMapper;
+		this.jsonMapper = jsonMapper;
 		this.mcpEndpoint = mcpEndpoint;
 		this.contextExtractor = contextExtractor;
 	}
@@ -139,7 +141,7 @@ public class HttpServletStatelessServerTransport extends HttpServlet implements 
 				body.append(line);
 			}
 
-			McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(objectMapper, body.toString());
+			McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(jsonMapper, body.toString());
 
 			if (message instanceof McpSchema.JSONRPCRequest jsonrpcRequest) {
 				try {
@@ -152,7 +154,7 @@ public class HttpServletStatelessServerTransport extends HttpServlet implements 
 					response.setCharacterEncoding(UTF_8);
 					response.setStatus(HttpServletResponse.SC_OK);
 
-					String jsonResponseText = objectMapper.writeValueAsString(jsonrpcResponse);
+					String jsonResponseText = jsonMapper.writeValueAsString(jsonrpcResponse);
 					PrintWriter writer = response.getWriter();
 					writer.write(jsonResponseText);
 					writer.flush();
@@ -203,7 +205,7 @@ public class HttpServletStatelessServerTransport extends HttpServlet implements 
 		response.setContentType(APPLICATION_JSON);
 		response.setCharacterEncoding(UTF_8);
 		response.setStatus(httpCode);
-		String jsonError = objectMapper.writeValueAsString(mcpError);
+		String jsonError = jsonMapper.writeValueAsString(mcpError);
 		PrintWriter writer = response.getWriter();
 		writer.write(jsonError);
 		writer.flush();
@@ -236,7 +238,7 @@ public class HttpServletStatelessServerTransport extends HttpServlet implements 
 	 */
 	public static class Builder {
 
-		private ObjectMapper objectMapper;
+		private McpJsonMapper jsonMapper;
 
 		private String mcpEndpoint = "/mcp";
 
@@ -254,9 +256,23 @@ public class HttpServletStatelessServerTransport extends HttpServlet implements 
 		 * @return this builder instance
 		 * @throws IllegalArgumentException if objectMapper is null
 		 */
+		@Deprecated(forRemoval = true)
 		public Builder objectMapper(ObjectMapper objectMapper) {
 			Assert.notNull(objectMapper, "ObjectMapper must not be null");
-			this.objectMapper = objectMapper;
+			this.jsonMapper = new JacksonMcpJsonMapper(objectMapper);
+			return this;
+		}
+
+		/**
+		 * Sets the JsonMapper to use for JSON serialization/deserialization of MCP
+		 * messages.
+		 * @param jsonMapper The JsonMapper instance. Must not be null.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if jsonMapper is null
+		 */
+		public Builder jsonMapper(McpJsonMapper jsonMapper) {
+			Assert.notNull(jsonMapper, "JsonMapper must not be null");
+			this.jsonMapper = jsonMapper;
 			return this;
 		}
 
@@ -295,10 +311,12 @@ public class HttpServletStatelessServerTransport extends HttpServlet implements 
 		 * @throws IllegalStateException if required parameters are not set
 		 */
 		public HttpServletStatelessServerTransport build() {
-			Assert.notNull(objectMapper, "ObjectMapper must be set");
+			if (this.jsonMapper == null) {
+				throw new IllegalStateException("JsonMapper must be set");
+			}
 			Assert.notNull(mcpEndpoint, "Message endpoint must be set");
 
-			return new HttpServletStatelessServerTransport(objectMapper, mcpEndpoint, contextExtractor);
+			return new HttpServletStatelessServerTransport(jsonMapper, mcpEndpoint, contextExtractor);
 		}
 
 	}

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/DefaultJsonSchemaValidator.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/DefaultJsonSchemaValidator.java
@@ -21,6 +21,8 @@ import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
 
 import io.modelcontextprotocol.util.Assert;
+import io.modelcontextprotocol.spec.json.McpJsonMapper;
+import io.modelcontextprotocol.spec.json.jackson.JacksonMcpJsonMapper;
 
 /**
  * Default implementation of the {@link JsonSchemaValidator} interface. This class
@@ -46,6 +48,24 @@ public class DefaultJsonSchemaValidator implements JsonSchemaValidator {
 
 	public DefaultJsonSchemaValidator(ObjectMapper objectMapper) {
 		this.objectMapper = objectMapper;
+		this.schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
+		this.schemaCache = new ConcurrentHashMap<>();
+	}
+
+	/**
+	 * Alternate constructor that accepts a JsonMapper. If the mapper is backed by
+	 * Jackson, the underlying ObjectMapper will be reused; otherwise a new ObjectMapper
+	 * will be created for schema validation only.
+	 */
+	public DefaultJsonSchemaValidator(McpJsonMapper jsonMapper) {
+		ObjectMapper mapper;
+		if (jsonMapper instanceof JacksonMcpJsonMapper jacksonJsonMapper) {
+			mapper = jacksonJsonMapper.getObjectMapper();
+		}
+		else {
+			mapper = new ObjectMapper();
+		}
+		this.objectMapper = mapper;
 		this.schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
 		this.schemaCache = new ConcurrentHashMap<>();
 	}

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpClientSession.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpClientSession.java
@@ -4,7 +4,7 @@
 
 package io.modelcontextprotocol.spec;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import io.modelcontextprotocol.spec.json.TypeRef;
 import io.modelcontextprotocol.util.Assert;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
@@ -254,7 +254,7 @@ public class McpClientSession implements McpSession {
 	 * @return A Mono containing the response
 	 */
 	@Override
-	public <T> Mono<T> sendRequest(String method, Object requestParams, TypeReference<T> typeRef) {
+	public <T> Mono<T> sendRequest(String method, Object requestParams, TypeRef<T> typeRef) {
 		String requestId = this.generateRequestId();
 
 		return Mono.deferContextual(ctx -> Mono.<McpSchema.JSONRPCResponse>create(pendingResponseSink -> {

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
@@ -11,12 +11,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpInitRequestHandler;
 import io.modelcontextprotocol.server.McpNotificationHandler;
 import io.modelcontextprotocol.server.McpRequestHandler;
+import io.modelcontextprotocol.spec.json.TypeRef;
 import io.modelcontextprotocol.util.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -153,7 +153,7 @@ public class McpServerSession implements McpLoggableSession {
 	}
 
 	@Override
-	public <T> Mono<T> sendRequest(String method, Object requestParams, TypeReference<T> typeRef) {
+	public <T> Mono<T> sendRequest(String method, Object requestParams, TypeRef<T> typeRef) {
 		String requestId = this.generateRequestId();
 
 		return Mono.<McpSchema.JSONRPCResponse>create(sink -> {
@@ -259,7 +259,7 @@ public class McpServerSession implements McpLoggableSession {
 			if (McpSchema.METHOD_INITIALIZE.equals(request.method())) {
 				// TODO handle situation where already initialized!
 				McpSchema.InitializeRequest initializeRequest = transport.unmarshalFrom(request.params(),
-						new TypeReference<McpSchema.InitializeRequest>() {
+						new TypeRef<McpSchema.InitializeRequest>() {
 						});
 
 				this.state.lazySet(STATE_INITIALIZING);

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpSession.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpSession.java
@@ -4,7 +4,7 @@
 
 package io.modelcontextprotocol.spec;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import io.modelcontextprotocol.spec.json.TypeRef;
 import reactor.core.publisher.Mono;
 
 /**
@@ -37,7 +37,7 @@ public interface McpSession {
 	 * @param typeRef the TypeReference describing the expected response type
 	 * @return a Mono that will emit the response when received
 	 */
-	<T> Mono<T> sendRequest(String method, Object requestParams, TypeReference<T> typeRef);
+	<T> Mono<T> sendRequest(String method, Object requestParams, TypeRef<T> typeRef);
 
 	/**
 	 * Sends a notification to the model client or server without parameters.

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpStreamableServerSession.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpStreamableServerSession.java
@@ -15,7 +15,7 @@ import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import io.modelcontextprotocol.spec.json.TypeRef;
 
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
@@ -110,7 +110,7 @@ public class McpStreamableServerSession implements McpLoggableSession {
 	}
 
 	@Override
-	public <T> Mono<T> sendRequest(String method, Object requestParams, TypeReference<T> typeRef) {
+	public <T> Mono<T> sendRequest(String method, Object requestParams, TypeRef<T> typeRef) {
 		return Mono.defer(() -> {
 			McpLoggableSession listeningStream = this.listeningStreamRef.get();
 			return listeningStream.sendRequest(method, requestParams, typeRef);
@@ -347,7 +347,7 @@ public class McpStreamableServerSession implements McpLoggableSession {
 		}
 
 		@Override
-		public <T> Mono<T> sendRequest(String method, Object requestParams, TypeReference<T> typeRef) {
+		public <T> Mono<T> sendRequest(String method, Object requestParams, TypeRef<T> typeRef) {
 			String requestId = McpStreamableServerSession.this.generateRequestId();
 
 			McpStreamableServerSession.this.requestIdToStream.put(requestId, this);

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpTransport.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpTransport.java
@@ -6,8 +6,8 @@ package io.modelcontextprotocol.spec;
 
 import java.util.List;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.modelcontextprotocol.spec.McpSchema.JSONRPCMessage;
+import io.modelcontextprotocol.spec.json.TypeRef;
 import reactor.core.publisher.Mono;
 
 /**
@@ -77,7 +77,7 @@ public interface McpTransport {
 	 * @param typeRef the type reference for the object to unmarshal
 	 * @return the unmarshalled object
 	 */
-	<T> T unmarshalFrom(Object data, TypeReference<T> typeRef);
+	<T> T unmarshalFrom(Object data, TypeRef<T> typeRef);
 
 	default List<String> protocolVersions() {
 		return List.of(ProtocolVersions.MCP_2024_11_05);

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/MissingMcpTransportSession.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/MissingMcpTransportSession.java
@@ -4,7 +4,7 @@
 
 package io.modelcontextprotocol.spec;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import io.modelcontextprotocol.spec.json.TypeRef;
 import io.modelcontextprotocol.util.Assert;
 import reactor.core.publisher.Mono;
 
@@ -31,7 +31,7 @@ public class MissingMcpTransportSession implements McpLoggableSession {
 	}
 
 	@Override
-	public <T> Mono<T> sendRequest(String method, Object requestParams, TypeReference<T> typeRef) {
+	public <T> Mono<T> sendRequest(String method, Object requestParams, TypeRef<T> typeRef) {
 		return Mono.error(new IllegalStateException("Stream unavailable for session " + this.sessionId));
 	}
 

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/json/McpJsonMapper.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/json/McpJsonMapper.java
@@ -1,0 +1,86 @@
+package io.modelcontextprotocol.spec.json;
+
+import java.io.IOException;
+
+/**
+ * Abstraction for JSON serialization/deserialization to decouple the SDK from any
+ * specific JSON library. A default implementation backed by Jackson is provided in
+ * io.modelcontextprotocol.spec.json.jackson.JacksonJsonMapper.
+ */
+public interface McpJsonMapper {
+
+	/**
+	 * Deserialize JSON string into a target type.
+	 * @param content JSON as String
+	 * @param type target class
+	 * @return deserialized instance
+	 * @param <T> generic type
+	 * @throws IOException on parse errors
+	 */
+	<T> T readValue(String content, Class<T> type) throws IOException;
+
+	/**
+	 * Deserialize JSON bytes into a target type.
+	 * @param content JSON as bytes
+	 * @param type target class
+	 * @return deserialized instance
+	 * @param <T> generic type
+	 * @throws IOException on parse errors
+	 */
+	<T> T readValue(byte[] content, Class<T> type) throws IOException;
+
+	/**
+	 * Deserialize JSON string into a parameterized target type.
+	 * @param content JSON as String
+	 * @param type parameterized type reference
+	 * @return deserialized instance
+	 * @param <T> generic type
+	 * @throws IOException on parse errors
+	 */
+	<T> T readValue(String content, TypeRef<T> type) throws IOException;
+
+	/**
+	 * Deserialize JSON bytes into a parameterized target type.
+	 * @param content JSON as bytes
+	 * @param type parameterized type reference
+	 * @return deserialized instance
+	 * @param <T> generic type
+	 * @throws IOException on parse errors
+	 */
+	<T> T readValue(byte[] content, TypeRef<T> type) throws IOException;
+
+	/**
+	 * Convert a value to a given type, useful for mapping nested JSON structures.
+	 * @param fromValue source value
+	 * @param type target class
+	 * @return converted value
+	 * @param <T> generic type
+	 */
+	<T> T convertValue(Object fromValue, Class<T> type);
+
+	/**
+	 * Convert a value to a given parameterized type.
+	 * @param fromValue source value
+	 * @param type target type reference
+	 * @return converted value
+	 * @param <T> generic type
+	 */
+	<T> T convertValue(Object fromValue, TypeRef<T> type);
+
+	/**
+	 * Serialize an object to JSON string.
+	 * @param value object to serialize
+	 * @return JSON as String
+	 * @throws IOException on serialization errors
+	 */
+	String writeValueAsString(Object value) throws IOException;
+
+	/**
+	 * Serialize an object to JSON bytes.
+	 * @param value object to serialize
+	 * @return JSON as bytes
+	 * @throws IOException on serialization errors
+	 */
+	byte[] writeValueAsBytes(Object value) throws IOException;
+
+}

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/json/TypeRef.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/json/TypeRef.java
@@ -1,0 +1,26 @@
+package io.modelcontextprotocol.spec.json;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+/**
+ * Captures generic type information at runtime for parameterized JSON (de)serialization.
+ * Usage: TypeRef<List<Foo>> ref = new TypeRef<>(){};
+ */
+public abstract class TypeRef<T> {
+
+	private final Type type;
+
+	protected TypeRef() {
+		Type superClass = getClass().getGenericSuperclass();
+		if (superClass instanceof Class) {
+			throw new IllegalStateException("TypeRef constructed without actual type information");
+		}
+		this.type = ((ParameterizedType) superClass).getActualTypeArguments()[0];
+	}
+
+	public Type getType() {
+		return type;
+	}
+
+}

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/json/jackson/JacksonMcpJsonMapper.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/json/jackson/JacksonMcpJsonMapper.java
@@ -1,0 +1,72 @@
+package io.modelcontextprotocol.spec.json.jackson;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.spec.json.McpJsonMapper;
+import io.modelcontextprotocol.spec.json.TypeRef;
+
+import java.io.IOException;
+
+/**
+ * Jackson-based implementation of JsonMapper. Wraps a Jackson ObjectMapper but keeps the
+ * SDK decoupled from Jackson at the API level.
+ */
+public final class JacksonMcpJsonMapper implements McpJsonMapper {
+
+	private final ObjectMapper objectMapper;
+
+	public JacksonMcpJsonMapper(ObjectMapper objectMapper) {
+		if (objectMapper == null) {
+			throw new IllegalArgumentException("ObjectMapper must not be null");
+		}
+		this.objectMapper = objectMapper;
+	}
+
+	public ObjectMapper getObjectMapper() {
+		return objectMapper;
+	}
+
+	@Override
+	public <T> T readValue(String content, Class<T> type) throws IOException {
+		return objectMapper.readValue(content, type);
+	}
+
+	@Override
+	public <T> T readValue(byte[] content, Class<T> type) throws IOException {
+		return objectMapper.readValue(content, type);
+	}
+
+	@Override
+	public <T> T readValue(String content, TypeRef<T> type) throws IOException {
+		JavaType javaType = objectMapper.getTypeFactory().constructType(type.getType());
+		return objectMapper.readValue(content, javaType);
+	}
+
+	@Override
+	public <T> T readValue(byte[] content, TypeRef<T> type) throws IOException {
+		JavaType javaType = objectMapper.getTypeFactory().constructType(type.getType());
+		return objectMapper.readValue(content, javaType);
+	}
+
+	@Override
+	public <T> T convertValue(Object fromValue, Class<T> type) {
+		return objectMapper.convertValue(fromValue, type);
+	}
+
+	@Override
+	public <T> T convertValue(Object fromValue, TypeRef<T> type) {
+		JavaType javaType = objectMapper.getTypeFactory().constructType(type.getType());
+		return objectMapper.convertValue(fromValue, javaType);
+	}
+
+	@Override
+	public String writeValueAsString(Object value) throws IOException {
+		return objectMapper.writeValueAsString(value);
+	}
+
+	@Override
+	public byte[] writeValueAsBytes(Object value) throws IOException {
+		return objectMapper.writeValueAsBytes(value);
+	}
+
+}

--- a/mcp/src/main/java/io/modelcontextprotocol/util/KeepAliveScheduler.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/util/KeepAliveScheduler.java
@@ -11,7 +11,7 @@ import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import io.modelcontextprotocol.spec.json.TypeRef;
 
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSession;
@@ -33,7 +33,7 @@ public class KeepAliveScheduler {
 
 	private static final Logger logger = LoggerFactory.getLogger(KeepAliveScheduler.class);
 
-	private static final TypeReference<Object> OBJECT_TYPE_REF = new TypeReference<>() {
+	private static final TypeRef<Object> OBJECT_TYPE_REF = new TypeRef<>() {
 	};
 
 	/** Initial delay before the first keepAlive call */

--- a/mcp/src/test/java/io/modelcontextprotocol/MockMcpClientTransport.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/MockMcpClientTransport.java
@@ -9,8 +9,8 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.spec.json.TypeRef;
+import io.modelcontextprotocol.spec.json.jackson.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.JSONRPCNotification;
@@ -99,8 +99,8 @@ public class MockMcpClientTransport implements McpClientTransport {
 	}
 
 	@Override
-	public <T> T unmarshalFrom(Object data, TypeReference<T> typeRef) {
-		return new ObjectMapper().convertValue(data, typeRef);
+	public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+		return new JacksonMcpJsonMapper(new com.fasterxml.jackson.databind.ObjectMapper()).convertValue(data, typeRef);
 	}
 
 }

--- a/mcp/src/test/java/io/modelcontextprotocol/MockMcpServerTransport.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/MockMcpServerTransport.java
@@ -8,8 +8,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiConsumer;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.spec.json.TypeRef;
+import io.modelcontextprotocol.spec.json.jackson.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.JSONRPCNotification;
 import io.modelcontextprotocol.spec.McpSchema.JSONRPCRequest;
@@ -67,8 +67,8 @@ public class MockMcpServerTransport implements McpServerTransport {
 	}
 
 	@Override
-	public <T> T unmarshalFrom(Object data, TypeReference<T> typeRef) {
-		return new ObjectMapper().convertValue(data, typeRef);
+	public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+		return new JacksonMcpJsonMapper(new com.fasterxml.jackson.databind.ObjectMapper()).convertValue(data, typeRef);
 	}
 
 }

--- a/mcp/src/test/java/io/modelcontextprotocol/client/McpAsyncClientResponseHandlerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/McpAsyncClientResponseHandlerTests.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
+import io.modelcontextprotocol.spec.json.TypeRef;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.MockMcpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -321,7 +321,7 @@ class McpAsyncClientResponseHandlerTests {
 		assertThat(response.error()).isNull();
 
 		McpSchema.CreateMessageResult result = transport.unmarshalFrom(response.result(),
-				new TypeReference<McpSchema.CreateMessageResult>() {
+				new TypeRef<McpSchema.CreateMessageResult>() {
 				});
 		assertThat(result).isNotNull();
 		assertThat(result.role()).isEqualTo(McpSchema.Role.ASSISTANT);
@@ -425,7 +425,7 @@ class McpAsyncClientResponseHandlerTests {
 		assertThat(response.id()).isEqualTo("test-id");
 		assertThat(response.error()).isNull();
 
-		McpSchema.ElicitResult result = transport.unmarshalFrom(response.result(), new TypeReference<>() {
+		McpSchema.ElicitResult result = transport.unmarshalFrom(response.result(), new TypeRef<>() {
 		});
 		assertThat(result).isNotNull();
 		assertThat(result.action()).isEqualTo(McpSchema.ElicitResult.Action.ACCEPT);
@@ -470,7 +470,7 @@ class McpAsyncClientResponseHandlerTests {
 		assertThat(response.id()).isEqualTo("test-id");
 		assertThat(response.error()).isNull();
 
-		McpSchema.ElicitResult result = transport.unmarshalFrom(response.result(), new TypeReference<>() {
+		McpSchema.ElicitResult result = transport.unmarshalFrom(response.result(), new TypeRef<>() {
 		});
 		assertThat(result).isNotNull();
 		assertThat(result.action()).isEqualTo(action);

--- a/mcp/src/test/java/io/modelcontextprotocol/client/McpAsyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/McpAsyncClientTests.java
@@ -4,7 +4,7 @@
 
 package io.modelcontextprotocol.client;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import io.modelcontextprotocol.spec.json.TypeRef;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -73,8 +73,13 @@ class McpAsyncClientTests {
 			}
 
 			@Override
-			public <T> T unmarshalFrom(Object data, TypeReference<T> typeRef) {
-				return OBJECT_MAPPER.convertValue(data, typeRef);
+			public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+				return OBJECT_MAPPER.convertValue(data, new com.fasterxml.jackson.core.type.TypeReference<T>() {
+					@Override
+					public java.lang.reflect.Type getType() {
+						return typeRef.getType();
+					}
+				});
 			}
 		};
 

--- a/mcp/src/test/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransportTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransportTests.java
@@ -14,14 +14,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.modelcontextprotocol.client.transport.customizer.McpAsyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.JSONRPCRequest;
 
+import io.modelcontextprotocol.spec.json.jackson.JacksonMcpJsonMapper;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -79,7 +78,8 @@ class HttpClientSseClientTransportTests {
 		public TestHttpClientSseClientTransport(final String baseUri) {
 			super(HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build(),
 					HttpRequest.newBuilder().header("Content-Type", "application/json"), baseUri, "/sse",
-					new ObjectMapper(), McpAsyncHttpClientRequestCustomizer.NOOP);
+					new JacksonMcpJsonMapper(new com.fasterxml.jackson.databind.ObjectMapper()),
+					McpAsyncHttpClientRequestCustomizer.NOOP);
 		}
 
 		public int getInboundMessageCount() {

--- a/mcp/src/test/java/io/modelcontextprotocol/server/McpAsyncServerExchangeTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/McpAsyncServerExchangeTests.java
@@ -10,10 +10,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpServerSession;
+import io.modelcontextprotocol.spec.json.TypeRef;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -66,7 +66,7 @@ class McpAsyncServerExchangeTests {
 		McpSchema.ListRootsResult singlePageResult = new McpSchema.ListRootsResult(roots, null);
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(McpSchema.PaginatedRequest.class),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.just(singlePageResult));
 
 		StepVerifier.create(exchange.listRoots()).assertNext(result -> {
@@ -94,11 +94,11 @@ class McpAsyncServerExchangeTests {
 		McpSchema.ListRootsResult page2Result = new McpSchema.ListRootsResult(page2Roots, null);
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), eq(new McpSchema.PaginatedRequest(null)),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.just(page1Result));
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), eq(new McpSchema.PaginatedRequest("cursor1")),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.just(page2Result));
 
 		StepVerifier.create(exchange.listRoots()).assertNext(result -> {
@@ -120,7 +120,7 @@ class McpAsyncServerExchangeTests {
 		McpSchema.ListRootsResult emptyResult = new McpSchema.ListRootsResult(new ArrayList<>(), null);
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(McpSchema.PaginatedRequest.class),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.just(emptyResult));
 
 		StepVerifier.create(exchange.listRoots()).assertNext(result -> {
@@ -140,7 +140,7 @@ class McpAsyncServerExchangeTests {
 		McpSchema.ListRootsResult result = new McpSchema.ListRootsResult(roots, "nextCursor");
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), eq(new McpSchema.PaginatedRequest("someCursor")),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.just(result));
 
 		StepVerifier.create(exchange.listRoots("someCursor")).assertNext(listResult -> {
@@ -154,7 +154,7 @@ class McpAsyncServerExchangeTests {
 	void testListRootsWithError() {
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(McpSchema.PaginatedRequest.class),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.error(new RuntimeException("Network error")));
 
 		// When & Then
@@ -175,11 +175,11 @@ class McpAsyncServerExchangeTests {
 		McpSchema.ListRootsResult page2Result = new McpSchema.ListRootsResult(page2Roots, null);
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), eq(new McpSchema.PaginatedRequest(null)),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.just(page1Result));
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), eq(new McpSchema.PaginatedRequest("cursor1")),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.just(page2Result));
 
 		StepVerifier.create(exchange.listRoots()).assertNext(result -> {
@@ -314,8 +314,7 @@ class McpAsyncServerExchangeTests {
 			});
 
 		// Verify that sendRequest was never called due to null capabilities
-		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), any(),
-				any(TypeReference.class));
+		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), any(), any(TypeRef.class));
 	}
 
 	@Test
@@ -339,8 +338,7 @@ class McpAsyncServerExchangeTests {
 
 		// Verify that sendRequest was never called due to missing elicitation
 		// capabilities
-		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), any(),
-				any(TypeReference.class));
+		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), any(), any(TypeRef.class));
 	}
 
 	@Test
@@ -374,8 +372,7 @@ class McpAsyncServerExchangeTests {
 			.content(responseContent)
 			.build();
 
-		when(mockSession.sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), eq(elicitRequest),
-				any(TypeReference.class)))
+		when(mockSession.sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), eq(elicitRequest), any(TypeRef.class)))
 			.thenReturn(Mono.just(expectedResult));
 
 		StepVerifier.create(exchangeWithElicitation.createElicitation(elicitRequest)).assertNext(result -> {
@@ -405,8 +402,7 @@ class McpAsyncServerExchangeTests {
 			.message(McpSchema.ElicitResult.Action.DECLINE)
 			.build();
 
-		when(mockSession.sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), eq(elicitRequest),
-				any(TypeReference.class)))
+		when(mockSession.sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), eq(elicitRequest), any(TypeRef.class)))
 			.thenReturn(Mono.just(expectedResult));
 
 		StepVerifier.create(exchangeWithElicitation.createElicitation(elicitRequest)).assertNext(result -> {
@@ -433,8 +429,7 @@ class McpAsyncServerExchangeTests {
 			.message(McpSchema.ElicitResult.Action.CANCEL)
 			.build();
 
-		when(mockSession.sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), eq(elicitRequest),
-				any(TypeReference.class)))
+		when(mockSession.sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), eq(elicitRequest), any(TypeRef.class)))
 			.thenReturn(Mono.just(expectedResult));
 
 		StepVerifier.create(exchangeWithElicitation.createElicitation(elicitRequest)).assertNext(result -> {
@@ -457,8 +452,7 @@ class McpAsyncServerExchangeTests {
 			.message("Please provide your name")
 			.build();
 
-		when(mockSession.sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), eq(elicitRequest),
-				any(TypeReference.class)))
+		when(mockSession.sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), eq(elicitRequest), any(TypeRef.class)))
 			.thenReturn(Mono.error(new RuntimeException("Session communication error")));
 
 		StepVerifier.create(exchangeWithElicitation.createElicitation(elicitRequest)).verifyErrorSatisfies(error -> {
@@ -488,7 +482,7 @@ class McpAsyncServerExchangeTests {
 
 		// Verify that sendRequest was never called due to null capabilities
 		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_SAMPLING_CREATE_MESSAGE), any(),
-				any(TypeReference.class));
+				any(TypeRef.class));
 	}
 
 	@Test
@@ -513,7 +507,7 @@ class McpAsyncServerExchangeTests {
 
 		// Verify that sendRequest was never called due to missing sampling capabilities
 		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_SAMPLING_CREATE_MESSAGE), any(),
-				any(TypeReference.class));
+				any(TypeRef.class));
 	}
 
 	@Test
@@ -539,7 +533,7 @@ class McpAsyncServerExchangeTests {
 			.build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_SAMPLING_CREATE_MESSAGE), eq(createMessageRequest),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.just(expectedResult));
 
 		StepVerifier.create(exchangeWithSampling.createMessage(createMessageRequest)).assertNext(result -> {
@@ -577,7 +571,7 @@ class McpAsyncServerExchangeTests {
 			.build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_SAMPLING_CREATE_MESSAGE), eq(createMessageRequest),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.just(expectedResult));
 
 		StepVerifier.create(exchangeWithSampling.createMessage(createMessageRequest)).assertNext(result -> {
@@ -603,7 +597,7 @@ class McpAsyncServerExchangeTests {
 			.build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_SAMPLING_CREATE_MESSAGE), eq(createMessageRequest),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.error(new RuntimeException("Session communication error")));
 
 		StepVerifier.create(exchangeWithSampling.createMessage(createMessageRequest)).verifyErrorSatisfies(error -> {
@@ -635,7 +629,7 @@ class McpAsyncServerExchangeTests {
 			.build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_SAMPLING_CREATE_MESSAGE), eq(createMessageRequest),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.just(expectedResult));
 
 		StepVerifier.create(exchangeWithSampling.createMessage(createMessageRequest)).assertNext(result -> {
@@ -653,7 +647,7 @@ class McpAsyncServerExchangeTests {
 
 		java.util.Map<String, Object> expectedResponse = java.util.Map.of();
 
-		when(mockSession.sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeReference.class)))
+		when(mockSession.sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeRef.class)))
 			.thenReturn(Mono.just(expectedResponse));
 
 		StepVerifier.create(exchange.ping()).assertNext(result -> {
@@ -662,14 +656,14 @@ class McpAsyncServerExchangeTests {
 		}).verifyComplete();
 
 		// Verify that sendRequest was called with correct parameters
-		verify(mockSession, times(1)).sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeReference.class));
+		verify(mockSession, times(1)).sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeRef.class));
 	}
 
 	@Test
 	void testPingWithMcpError() {
 		// Given - Mock an MCP-specific error during ping
 		McpError mcpError = new McpError("Server unavailable");
-		when(mockSession.sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeReference.class)))
+		when(mockSession.sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeRef.class)))
 			.thenReturn(Mono.error(mcpError));
 
 		// When & Then
@@ -677,13 +671,13 @@ class McpAsyncServerExchangeTests {
 			assertThat(error).isInstanceOf(McpError.class).hasMessage("Server unavailable");
 		});
 
-		verify(mockSession, times(1)).sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeReference.class));
+		verify(mockSession, times(1)).sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeRef.class));
 	}
 
 	@Test
 	void testPingMultipleCalls() {
 
-		when(mockSession.sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeReference.class)))
+		when(mockSession.sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeRef.class)))
 			.thenReturn(Mono.just(Map.of()))
 			.thenReturn(Mono.just(Map.of()));
 
@@ -698,7 +692,7 @@ class McpAsyncServerExchangeTests {
 		}).verifyComplete();
 
 		// Verify that sendRequest was called twice
-		verify(mockSession, times(2)).sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeReference.class));
+		verify(mockSession, times(2)).sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeRef.class));
 	}
 
 }

--- a/mcp/src/test/java/io/modelcontextprotocol/server/McpSyncServerExchangeTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/McpSyncServerExchangeTests.java
@@ -9,10 +9,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpServerSession;
+import io.modelcontextprotocol.spec.json.TypeRef;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -66,7 +66,7 @@ class McpSyncServerExchangeTests {
 		McpSchema.ListRootsResult singlePageResult = new McpSchema.ListRootsResult(roots, null);
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(McpSchema.PaginatedRequest.class),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.just(singlePageResult));
 
 		McpSchema.ListRootsResult result = exchange.listRoots();
@@ -94,11 +94,11 @@ class McpSyncServerExchangeTests {
 		McpSchema.ListRootsResult page2Result = new McpSchema.ListRootsResult(page2Roots, null);
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), eq(new McpSchema.PaginatedRequest(null)),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.just(page1Result));
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), eq(new McpSchema.PaginatedRequest("cursor1")),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.just(page2Result));
 
 		McpSchema.ListRootsResult result = exchange.listRoots();
@@ -120,7 +120,7 @@ class McpSyncServerExchangeTests {
 		McpSchema.ListRootsResult emptyResult = new McpSchema.ListRootsResult(new ArrayList<>(), null);
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(McpSchema.PaginatedRequest.class),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.just(emptyResult));
 
 		McpSchema.ListRootsResult result = exchange.listRoots();
@@ -140,7 +140,7 @@ class McpSyncServerExchangeTests {
 		McpSchema.ListRootsResult result = new McpSchema.ListRootsResult(roots, "nextCursor");
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), eq(new McpSchema.PaginatedRequest("someCursor")),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.just(result));
 
 		McpSchema.ListRootsResult listResult = exchange.listRoots("someCursor");
@@ -154,7 +154,7 @@ class McpSyncServerExchangeTests {
 	void testListRootsWithError() {
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(McpSchema.PaginatedRequest.class),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.error(new RuntimeException("Network error")));
 
 		// When & Then
@@ -173,11 +173,11 @@ class McpSyncServerExchangeTests {
 		McpSchema.ListRootsResult page2Result = new McpSchema.ListRootsResult(page2Roots, null);
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), eq(new McpSchema.PaginatedRequest(null)),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.just(page1Result));
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), eq(new McpSchema.PaginatedRequest("cursor1")),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.just(page2Result));
 
 		McpSchema.ListRootsResult result = exchange.listRoots();
@@ -308,8 +308,7 @@ class McpSyncServerExchangeTests {
 			.hasMessage("Client must be initialized. Call the initialize method first!");
 
 		// Verify that sendRequest was never called due to null capabilities
-		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), any(),
-				any(TypeReference.class));
+		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), any(), any(TypeRef.class));
 	}
 
 	@Test
@@ -333,8 +332,7 @@ class McpSyncServerExchangeTests {
 
 		// Verify that sendRequest was never called due to missing elicitation
 		// capabilities
-		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), any(),
-				any(TypeReference.class));
+		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), any(), any(TypeRef.class));
 	}
 
 	@Test
@@ -369,8 +367,7 @@ class McpSyncServerExchangeTests {
 			.content(responseContent)
 			.build();
 
-		when(mockSession.sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), eq(elicitRequest),
-				any(TypeReference.class)))
+		when(mockSession.sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), eq(elicitRequest), any(TypeRef.class)))
 			.thenReturn(Mono.just(expectedResult));
 
 		McpSchema.ElicitResult result = exchangeWithElicitation.createElicitation(elicitRequest);
@@ -401,8 +398,7 @@ class McpSyncServerExchangeTests {
 			.message(McpSchema.ElicitResult.Action.DECLINE)
 			.build();
 
-		when(mockSession.sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), eq(elicitRequest),
-				any(TypeReference.class)))
+		when(mockSession.sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), eq(elicitRequest), any(TypeRef.class)))
 			.thenReturn(Mono.just(expectedResult));
 
 		McpSchema.ElicitResult result = exchangeWithElicitation.createElicitation(elicitRequest);
@@ -430,8 +426,7 @@ class McpSyncServerExchangeTests {
 			.message(McpSchema.ElicitResult.Action.CANCEL)
 			.build();
 
-		when(mockSession.sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), eq(elicitRequest),
-				any(TypeReference.class)))
+		when(mockSession.sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), eq(elicitRequest), any(TypeRef.class)))
 			.thenReturn(Mono.just(expectedResult));
 
 		McpSchema.ElicitResult result = exchangeWithElicitation.createElicitation(elicitRequest);
@@ -455,8 +450,7 @@ class McpSyncServerExchangeTests {
 			.message("Please provide your name")
 			.build();
 
-		when(mockSession.sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), eq(elicitRequest),
-				any(TypeReference.class)))
+		when(mockSession.sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), eq(elicitRequest), any(TypeRef.class)))
 			.thenReturn(Mono.error(new RuntimeException("Session communication error")));
 
 		assertThatThrownBy(() -> exchangeWithElicitation.createElicitation(elicitRequest))
@@ -487,7 +481,7 @@ class McpSyncServerExchangeTests {
 
 		// Verify that sendRequest was never called due to null capabilities
 		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_SAMPLING_CREATE_MESSAGE), any(),
-				any(TypeReference.class));
+				any(TypeRef.class));
 	}
 
 	@Test
@@ -512,7 +506,7 @@ class McpSyncServerExchangeTests {
 
 		// Verify that sendRequest was never called due to missing sampling capabilities
 		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_SAMPLING_CREATE_MESSAGE), any(),
-				any(TypeReference.class));
+				any(TypeRef.class));
 	}
 
 	@Test
@@ -539,7 +533,7 @@ class McpSyncServerExchangeTests {
 			.build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_SAMPLING_CREATE_MESSAGE), eq(createMessageRequest),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.just(expectedResult));
 
 		McpSchema.CreateMessageResult result = exchangeWithSampling.createMessage(createMessageRequest);
@@ -578,7 +572,7 @@ class McpSyncServerExchangeTests {
 			.build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_SAMPLING_CREATE_MESSAGE), eq(createMessageRequest),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.just(expectedResult));
 
 		McpSchema.CreateMessageResult result = exchangeWithSampling.createMessage(createMessageRequest);
@@ -605,7 +599,7 @@ class McpSyncServerExchangeTests {
 			.build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_SAMPLING_CREATE_MESSAGE), eq(createMessageRequest),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.error(new RuntimeException("Session communication error")));
 
 		assertThatThrownBy(() -> exchangeWithSampling.createMessage(createMessageRequest))
@@ -638,7 +632,7 @@ class McpSyncServerExchangeTests {
 			.build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_SAMPLING_CREATE_MESSAGE), eq(createMessageRequest),
-				any(TypeReference.class)))
+				any(TypeRef.class)))
 			.thenReturn(Mono.just(expectedResult));
 
 		McpSchema.CreateMessageResult result = exchangeWithSampling.createMessage(createMessageRequest);
@@ -656,32 +650,32 @@ class McpSyncServerExchangeTests {
 
 		java.util.Map<String, Object> expectedResponse = java.util.Map.of();
 
-		when(mockSession.sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeReference.class)))
+		when(mockSession.sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeRef.class)))
 			.thenReturn(Mono.just(expectedResponse));
 
 		exchange.ping();
 
 		// Verify that sendRequest was called with correct parameters
-		verify(mockSession, times(1)).sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeReference.class));
+		verify(mockSession, times(1)).sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeRef.class));
 	}
 
 	@Test
 	void testPingWithMcpError() {
 		// Given - Mock an MCP-specific error during ping
 		McpError mcpError = new McpError("Server unavailable");
-		when(mockSession.sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeReference.class)))
+		when(mockSession.sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeRef.class)))
 			.thenReturn(Mono.error(mcpError));
 
 		// When & Then
 		assertThatThrownBy(() -> exchange.ping()).isInstanceOf(McpError.class).hasMessage("Server unavailable");
 
-		verify(mockSession, times(1)).sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeReference.class));
+		verify(mockSession, times(1)).sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeRef.class));
 	}
 
 	@Test
 	void testPingMultipleCalls() {
 
-		when(mockSession.sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeReference.class)))
+		when(mockSession.sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeRef.class)))
 			.thenReturn(Mono.just(Map.of()))
 			.thenReturn(Mono.just(Map.of()));
 
@@ -692,7 +686,7 @@ class McpSyncServerExchangeTests {
 		exchange.ping();
 
 		// Verify that sendRequest was called twice
-		verify(mockSession, times(2)).sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeReference.class));
+		verify(mockSession, times(2)).sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeRef.class));
 	}
 
 }

--- a/mcp/src/test/java/io/modelcontextprotocol/server/transport/StdioServerTransportProviderTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/transport/StdioServerTransportProviderTests.java
@@ -19,6 +19,7 @@ import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpServerSession;
 import io.modelcontextprotocol.spec.McpServerTransport;
+import io.modelcontextprotocol.spec.json.jackson.JacksonMcpJsonMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -75,7 +76,8 @@ class StdioServerTransportProviderTests {
 		when(mockSession.closeGracefully()).thenReturn(Mono.empty());
 		when(mockSession.sendNotification(any(), any())).thenReturn(Mono.empty());
 
-		transportProvider = new StdioServerTransportProvider(objectMapper, System.in, testOutPrintStream);
+		transportProvider = new StdioServerTransportProvider(new JacksonMcpJsonMapper(objectMapper), System.in,
+				testOutPrintStream);
 	}
 
 	@AfterEach
@@ -105,7 +107,8 @@ class StdioServerTransportProviderTests {
 		String jsonMessage = "{\"jsonrpc\":\"2.0\",\"method\":\"test\",\"params\":{},\"id\":1}\n";
 		InputStream stream = new ByteArrayInputStream(jsonMessage.getBytes(StandardCharsets.UTF_8));
 
-		transportProvider = new StdioServerTransportProvider(objectMapper, stream, System.out);
+		transportProvider = new StdioServerTransportProvider(new JacksonMcpJsonMapper(objectMapper), stream,
+				System.out);
 		// Set up a real session to capture the message
 		AtomicReference<McpSchema.JSONRPCMessage> capturedMessage = new AtomicReference<>();
 		CountDownLatch messageLatch = new CountDownLatch(1);
@@ -200,7 +203,8 @@ class StdioServerTransportProviderTests {
 		String jsonMessage = "{invalid json}\n";
 		InputStream stream = new ByteArrayInputStream(jsonMessage.getBytes(StandardCharsets.UTF_8));
 
-		transportProvider = new StdioServerTransportProvider(objectMapper, stream, testOutPrintStream);
+		transportProvider = new StdioServerTransportProvider(new JacksonMcpJsonMapper(objectMapper), stream,
+				testOutPrintStream);
 
 		// Set up a session factory
 		transportProvider.setSessionFactory(sessionFactory);

--- a/mcp/src/test/java/io/modelcontextprotocol/spec/McpClientSessionTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/spec/McpClientSessionTests.java
@@ -7,8 +7,8 @@ package io.modelcontextprotocol.spec;
 import java.time.Duration;
 import java.util.Map;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.modelcontextprotocol.MockMcpClientTransport;
+import io.modelcontextprotocol.spec.json.TypeRef;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -68,7 +68,7 @@ class McpClientSessionTests {
 			.hasMessageContaining("transport can not be null");
 	}
 
-	TypeReference<String> responseType = new TypeReference<>() {
+	TypeRef<String> responseType = new TypeRef<>() {
 	};
 
 	@Test

--- a/mcp/src/test/java/io/modelcontextprotocol/spec/json/gson/GsonMcpJsonMapper.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/spec/json/gson/GsonMcpJsonMapper.java
@@ -1,0 +1,97 @@
+package io.modelcontextprotocol.spec.json.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.ToNumberPolicy;
+import io.modelcontextprotocol.spec.json.McpJsonMapper;
+import io.modelcontextprotocol.spec.json.TypeRef;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Test-only Gson-based implementation of McpJsonMapper. This lives under src/test/java so
+ * it doesn't affect production code or dependencies.
+ */
+public final class GsonMcpJsonMapper implements McpJsonMapper {
+
+	private final Gson gson;
+
+	public GsonMcpJsonMapper() {
+		this(new GsonBuilder().serializeNulls()
+			// Ensure numeric values in untyped (Object) fields preserve integral numbers
+			// as Long
+			.setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+			.setNumberToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+			.create());
+	}
+
+	public GsonMcpJsonMapper(Gson gson) {
+		if (gson == null) {
+			throw new IllegalArgumentException("Gson must not be null");
+		}
+		this.gson = gson;
+	}
+
+	public Gson getGson() {
+		return gson;
+	}
+
+	@Override
+	public <T> T readValue(String content, Class<T> type) throws IOException {
+		try {
+			return gson.fromJson(content, type);
+		}
+		catch (Exception e) {
+			throw new IOException("Failed to deserialize JSON", e);
+		}
+	}
+
+	@Override
+	public <T> T readValue(byte[] content, Class<T> type) throws IOException {
+		return readValue(new String(content, StandardCharsets.UTF_8), type);
+	}
+
+	@Override
+	public <T> T readValue(String content, TypeRef<T> type) throws IOException {
+		try {
+			return gson.fromJson(content, type.getType());
+		}
+		catch (Exception e) {
+			throw new IOException("Failed to deserialize JSON", e);
+		}
+	}
+
+	@Override
+	public <T> T readValue(byte[] content, TypeRef<T> type) throws IOException {
+		return readValue(new String(content, StandardCharsets.UTF_8), type);
+	}
+
+	@Override
+	public <T> T convertValue(Object fromValue, Class<T> type) {
+		String json = gson.toJson(fromValue);
+		return gson.fromJson(json, type);
+	}
+
+	@Override
+	public <T> T convertValue(Object fromValue, TypeRef<T> type) {
+		String json = gson.toJson(fromValue);
+		return gson.fromJson(json, type.getType());
+	}
+
+	@Override
+	public String writeValueAsString(Object value) throws IOException {
+		try {
+			return gson.toJson(value);
+		}
+		catch (Exception e) {
+			throw new IOException("Failed to serialize to JSON", e);
+		}
+	}
+
+	@Override
+	public byte[] writeValueAsBytes(Object value) throws IOException {
+		return writeValueAsString(value).getBytes(StandardCharsets.UTF_8);
+	}
+
+}

--- a/mcp/src/test/java/io/modelcontextprotocol/spec/json/gson/GsonMcpJsonMapperTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/spec/json/gson/GsonMcpJsonMapperTests.java
@@ -1,0 +1,142 @@
+package io.modelcontextprotocol.spec.json.gson;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.json.TypeRef;
+import io.modelcontextprotocol.spec.json.jackson.JacksonMcpJsonMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GsonMcpJsonMapperTests {
+
+	record Person(String name, int age) {
+	}
+
+	@Test
+	void roundTripSimplePojo() throws IOException {
+		var mapper = new GsonMcpJsonMapper();
+
+		var input = new Person("Alice", 30);
+		String json = mapper.writeValueAsString(input);
+		assertNotNull(json);
+		assertTrue(json.contains("\"Alice\""));
+		assertTrue(json.contains("\"age\""));
+
+		var decoded = mapper.readValue(json, Person.class);
+		assertEquals(input, decoded);
+
+		byte[] bytes = mapper.writeValueAsBytes(input);
+		assertNotNull(bytes);
+		var decodedFromBytes = mapper.readValue(bytes, Person.class);
+		assertEquals(input, decodedFromBytes);
+	}
+
+	@Test
+	void readWriteParameterizedTypeWithTypeRef() throws IOException {
+		var mapper = new GsonMcpJsonMapper();
+		String json = "[\"a\", \"b\", \"c\"]";
+
+		List<String> list = mapper.readValue(json, new TypeRef<List<String>>() {
+		});
+		assertEquals(List.of("a", "b", "c"), list);
+
+		String encoded = mapper.writeValueAsString(list);
+		assertTrue(encoded.startsWith("["));
+		assertTrue(encoded.contains("\"a\""));
+	}
+
+	@Test
+	void convertValueMapToRecordAndParameterized() {
+		var mapper = new GsonMcpJsonMapper();
+		Map<String, Object> src = Map.of("name", "Bob", "age", 42);
+
+		// Convert to simple record
+		Person person = mapper.convertValue(src, Person.class);
+		assertEquals(new Person("Bob", 42), person);
+
+		// Convert to parameterized Map
+		Map<String, Object> toMap = mapper.convertValue(person, new TypeRef<Map<String, Object>>() {
+		});
+		assertEquals("Bob", toMap.get("name"));
+		assertEquals(42.0, ((Number) toMap.get("age")).doubleValue(), 0.0); // Gson may
+																			// emit double
+																			// for
+																			// primitives
+	}
+
+	@Test
+	void deserializeJsonRpcMessageRequestUsingCustomMapper() throws IOException {
+		var mapper = new GsonMcpJsonMapper();
+
+		String json = """
+				{
+				  "jsonrpc": "2.0",
+				  "id": 1,
+				  "method": "ping",
+				  "params": { "x": 1, "y": "z" }
+				}
+				""";
+
+		var msg = McpSchema.deserializeJsonRpcMessage(mapper, json);
+		assertTrue(msg instanceof McpSchema.JSONRPCRequest);
+
+		var req = (McpSchema.JSONRPCRequest) msg;
+		assertEquals("2.0", req.jsonrpc());
+		assertEquals("ping", req.method());
+		assertNotNull(req.id());
+		assertEquals("1", req.id().toString());
+
+		assertNotNull(req.params());
+		assertInstanceOf(Map.class, req.params());
+		@SuppressWarnings("unchecked")
+		var params = (Map<String, Object>) req.params();
+		assertEquals(1.0, ((Number) params.get("x")).doubleValue(), 0.0);
+		assertEquals("z", params.get("y"));
+	}
+
+	@Test
+	void integrateWithMcpSchemaStaticMapperForStringParsing() {
+		var gsonMapper = new GsonMcpJsonMapper();
+
+		// Save and restore static mapper to avoid affecting other tests
+		var originalMapper = new JacksonMcpJsonMapper(new com.fasterxml.jackson.databind.ObjectMapper());
+		try {
+			McpSchema.setJsonMapper(gsonMapper);
+
+			// Tool builder parsing of input/output schema strings
+			var tool = McpSchema.Tool.builder().name("echo").description("Echo tool").inputSchema("""
+					{
+					  "type": "object",
+					  "properties": { "x": { "type": "integer" } },
+					  "required": ["x"]
+					}
+					""").outputSchema("""
+					{
+					  "type": "object",
+					  "properties": { "y": { "type": "string" } }
+					}
+					""").build();
+
+			assertNotNull(tool.inputSchema());
+			assertNotNull(tool.outputSchema());
+			assertTrue(tool.outputSchema().containsKey("properties"));
+
+			// CallToolRequest builder parsing of JSON arguments string
+			var call = McpSchema.CallToolRequest.builder().name("echo").arguments("{\"x\": 123}").build();
+
+			assertEquals("echo", call.name());
+			assertNotNull(call.arguments());
+			assertTrue(call.arguments().get("x") instanceof Number);
+			assertEquals(123.0, ((Number) call.arguments().get("x")).doubleValue(), 0.0);
+		}
+		finally {
+			// restore to a Jackson-backed default to avoid side effects
+			McpSchema.setJsonMapper(originalMapper);
+		}
+	}
+
+}

--- a/mcp/src/test/java/io/modelcontextprotocol/util/KeepAliveSchedulerTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/util/KeepAliveSchedulerTests.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import io.modelcontextprotocol.spec.json.TypeRef;
 
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSession;
@@ -259,7 +259,7 @@ class KeepAliveSchedulerTests {
 		private boolean shouldFailPing = false;
 
 		@Override
-		public <T> Mono<T> sendRequest(String method, Object requestParams, TypeReference<T> typeRef) {
+		public <T> Mono<T> sendRequest(String method, Object requestParams, TypeRef<T> typeRef) {
 			if (McpSchema.METHOD_PING.equals(method)) {
 				pingCount.incrementAndGet();
 				if (shouldFailPing) {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
The current MCP SDK is coupled to Jackson which prevents the use of other JSON serialization libraries and techniques.

## How Has This Been Tested?
Yes tests included.

## Breaking Changes
There are deprecations but the intent is to keep breaking changes to a minimum in this PR. Ideally one would remove the Jackson APIs completely from the public interfaces, but that would constitute a breaking change.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x ] My code follows the repository's style guidelines
- [x ] New and existing tests pass locally
- [x ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
