### PR TITLE
Polish HttpServlet server transports

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStatelessServerTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStatelessServerTransport.java
@@ -32,6 +32,7 @@ import reactor.core.publisher.Mono;
  *
  * @author Christian Tzolov
  * @author Dariusz Jędrzejczyk
+ * @author Yanming Zhou
  */
 @WebServlet(asyncSupported = true)
 public class HttpServletStatelessServerTransport extends HttpServlet implements McpStatelessServerTransport {
@@ -200,13 +201,19 @@ public class HttpServletStatelessServerTransport extends HttpServlet implements 
 	 * @throws IOException If an I/O error occurs
 	 */
 	private void responseError(HttpServletResponse response, int httpCode, McpError mcpError) throws IOException {
-		response.setContentType(APPLICATION_JSON);
-		response.setCharacterEncoding(UTF_8);
-		response.setStatus(httpCode);
-		String jsonError = jsonMapper.writeValueAsString(mcpError);
-		PrintWriter writer = response.getWriter();
-		writer.write(jsonError);
-		writer.flush();
+		try {
+			response.setContentType(APPLICATION_JSON);
+			response.setCharacterEncoding(UTF_8);
+			response.setStatus(httpCode);
+			String jsonError = jsonMapper.writeValueAsString(mcpError);
+			PrintWriter writer = response.getWriter();
+			writer.write(jsonError);
+			writer.flush();
+		}
+		catch (IOException ex) {
+			logger.error(FAILED_TO_SEND_ERROR_RESPONSE, ex.getMessage());
+			response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Error processing message");
+		}
 	}
 
 	/**

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
@@ -54,6 +54,7 @@ import reactor.core.publisher.Mono;
  * @author Zachary German
  * @author Christian Tzolov
  * @author Dariusz Jędrzejczyk
+ * @author Yanming Zhou
  * @see McpStreamableServerTransportProvider
  * @see HttpServlet
  */
@@ -503,14 +504,8 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 		}
 		catch (Exception e) {
 			logger.error("Error handling message: {}", e.getMessage());
-			try {
-				this.responseError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-						new McpError("Error processing message: " + e.getMessage()));
-			}
-			catch (IOException ex) {
-				logger.error(FAILED_TO_SEND_ERROR_RESPONSE, ex.getMessage());
-				response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Error processing message");
-			}
+			this.responseError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+					new McpError("Error processing message: " + e.getMessage()));
 		}
 	}
 
@@ -564,26 +559,24 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 		}
 		catch (Exception e) {
 			logger.error("Failed to delete session {}: {}", sessionId, e.getMessage());
-			try {
-				this.responseError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-						new McpError(e.getMessage()));
-			}
-			catch (IOException ex) {
-				logger.error(FAILED_TO_SEND_ERROR_RESPONSE, ex.getMessage());
-				response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Error deleting session");
-			}
+			this.responseError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, new McpError(e.getMessage()));
 		}
 	}
 
 	public void responseError(HttpServletResponse response, int httpCode, McpError mcpError) throws IOException {
-		response.setContentType(APPLICATION_JSON);
-		response.setCharacterEncoding(UTF_8);
-		response.setStatus(httpCode);
-		String jsonError = jsonMapper.writeValueAsString(mcpError);
-		PrintWriter writer = response.getWriter();
-		writer.write(jsonError);
-		writer.flush();
-		return;
+		try {
+			response.setContentType(APPLICATION_JSON);
+			response.setCharacterEncoding(UTF_8);
+			response.setStatus(httpCode);
+			String jsonError = jsonMapper.writeValueAsString(mcpError);
+			PrintWriter writer = response.getWriter();
+			writer.write(jsonError);
+			writer.flush();
+		}
+		catch (IOException ex) {
+			logger.error(FAILED_TO_SEND_ERROR_RESPONSE, ex.getMessage());
+			response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Error processing message");
+		}
 	}
 
 	/**


### PR DESCRIPTION
1. Fix `HttpServletStatelessServerTransport.FAILED_TO_SEND_ERROR_RESPONSE` is unused
2. refactor to log error message in method `responseError` instead of caller method