### PR TITLE
Fix lifecycleinitializer onerror

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/client/LifecycleInitializer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/client/LifecycleInitializer.java
@@ -289,6 +289,7 @@ class LifecycleInitializer {
 			return initializationJob.map(initializeResult -> this.initializationRef.get())
 				.timeout(this.initializationTimeout)
 				.onErrorResume(ex -> {
+					this.initializationRef.compareAndSet(newInit, null);
 					return Mono.error(new RuntimeException("Client failed to initialize " + actionName, ex));
 				})
 				.flatMap(operation);


### PR DESCRIPTION
## Motivation and Context

Bug: When an error happens during `LifecycleInitializer#doInitialize`  (e.g. HTTP error), then the initializer caches the error and can never re-initialize.

This fix allows the initializer to recover, and subsequent init calls will work.

## How Has This Been Tested?

Tested with Spring Security which throws dedicated exceptions to signal that an OAuth2 token should be fetched.
Without this fix, the MCP client gets stuck in an error state ; this fix allows the flow to continue normally.

## Breaking Changes

None

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

n/a