### PR TITLE
fix: support arrays in tool structured content output

### DIFF
--- a/mcp-test/src/main/java/io/modelcontextprotocol/AbstractMcpClientServerIntegrationTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/AbstractMcpClientServerIntegrationTests.java
@@ -1411,7 +1411,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 
 			// In WebMVC, structured content is returned properly
 			if (response.structuredContent() != null) {
-				assertThat(response.structuredContent()).containsEntry("result", 5.0)
+				assertThat((Map<String, Object>) response.structuredContent()).containsEntry("result", 5.0)
 					.containsEntry("operation", "2 + 3")
 					.containsEntry("timestamp", "2024-01-01T10:00:00Z");
 			}
@@ -1433,7 +1433,66 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = { "httpclient", "webflux" })
+	@ValueSource(strings = { "httpclient" })
+	void testStructuredOutputOfObjectArrayValidationSuccess(String clientType) {
+		var clientBuilder = clientBuilders.get(clientType);
+
+		// Create a tool with output schema that returns an array of objects
+		Map<String, Object> outputSchema = Map
+			.of( // @formatter:off
+			"type", "array",
+			"items", Map.of(
+				"type", "object",
+				"properties", Map.of(
+					"name", Map.of("type", "string"),
+					"age", Map.of("type", "number")),					
+				"required", List.of("name", "age"))); // @formatter:on
+
+		Tool calculatorTool = Tool.builder()
+			.name("getMembers")
+			.description("Returns a list of members")
+			.outputSchema(outputSchema)
+			.build();
+
+		McpServerFeatures.SyncToolSpecification tool = McpServerFeatures.SyncToolSpecification.builder()
+			.tool(calculatorTool)
+			.callHandler((exchange, request) -> {
+				return CallToolResult.builder()
+					.structuredContent(List.of(Map.of("name", "John", "age", 30), Map.of("name", "Peter", "age", 25)))
+					.build();
+			})
+			.build();
+
+		var mcpServer = prepareSyncServerBuilder().serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().tools(true).build())
+			.tools(tool)
+			.build();
+
+		try (var mcpClient = clientBuilder.build()) {
+			assertThat(mcpClient.initialize()).isNotNull();
+
+			// Call tool with valid structured output of type array
+			CallToolResult response = mcpClient.callTool(new McpSchema.CallToolRequest("getMembers", Map.of()));
+
+			assertThat(response).isNotNull();
+			assertThat(response.isError()).isFalse();
+
+			assertThat(response.structuredContent()).isNotNull();
+			assertThatJson(response.structuredContent()).when(Option.IGNORING_ARRAY_ORDER)
+				.when(Option.IGNORING_EXTRA_ARRAY_ITEMS)
+				.isArray()
+				.hasSize(2)
+				.containsExactlyInAnyOrder(json("""
+						{"name":"John","age":30}"""), json("""
+						{"name":"Peter","age":25}"""));
+		}
+		finally {
+			mcpServer.closeGracefully();
+		}
+	}
+
+	@ParameterizedTest(name = "{0} : {displayName} ")
+	@ValueSource(strings = { "httpclient" })
 	void testStructuredOutputWithInHandlerError(String clientType) {
 		var clientBuilder = clientBuilders.get(clientType);
 
@@ -1449,16 +1508,13 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			.outputSchema(outputSchema)
 			.build();
 
-		// Handler that throws an exception to simulate an error
+		// Handler that returns an error result
 		McpServerFeatures.SyncToolSpecification tool = McpServerFeatures.SyncToolSpecification.builder()
 			.tool(calculatorTool)
-			.callHandler((exchange, request) -> {
-
-				return CallToolResult.builder()
-					.isError(true)
-					.content(List.of(new TextContent("Error calling tool: Simulated in-handler error")))
-					.build();
-			})
+			.callHandler((exchange, request) -> CallToolResult.builder()
+				.isError(true)
+				.content(List.of(new TextContent("Error calling tool: Simulated in-handler error")))
+				.build())
 			.build();
 
 		var mcpServer = prepareSyncServerBuilder().serverInfo("test-server", "1.0.0")

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -15,15 +15,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiFunction;
 
-import io.modelcontextprotocol.spec.DefaultMcpStreamableServerSessionFactory;
-import io.modelcontextprotocol.spec.McpServerTransportProviderBase;
-import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
+import io.modelcontextprotocol.spec.DefaultMcpStreamableServerSessionFactory;
 import io.modelcontextprotocol.spec.JsonSchemaValidator;
 import io.modelcontextprotocol.spec.McpClientSession;
 import io.modelcontextprotocol.spec.McpError;
@@ -34,14 +28,17 @@ import io.modelcontextprotocol.spec.McpSchema.LoggingLevel;
 import io.modelcontextprotocol.spec.McpSchema.LoggingMessageNotification;
 import io.modelcontextprotocol.spec.McpSchema.ResourceTemplate;
 import io.modelcontextprotocol.spec.McpSchema.SetLevelRequest;
-import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import io.modelcontextprotocol.spec.McpServerSession;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
+import io.modelcontextprotocol.spec.McpServerTransportProviderBase;
+import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
 import io.modelcontextprotocol.util.Assert;
 import io.modelcontextprotocol.util.DeafaultMcpUriTemplateManagerFactory;
 import io.modelcontextprotocol.util.McpUriTemplateManagerFactory;
 import io.modelcontextprotocol.util.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -420,8 +417,11 @@ public class McpAsyncServer {
 					// TextContent block.)
 					// https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content
 
-					return new CallToolResult(List.of(new McpSchema.TextContent(validation.jsonStructuredOutput())),
-							result.isError(), result.structuredContent());
+					return CallToolResult.builder()
+						.content(List.of(new McpSchema.TextContent(validation.jsonStructuredOutput())))
+						.isError(result.isError())
+						.structuredContent(result.structuredContent())
+						.build();
 				}
 
 				return result;

--- a/mcp/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
@@ -293,8 +293,11 @@ public class McpStatelessAsyncServer {
 					// TextContent block.)
 					// https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content
 
-					return new CallToolResult(List.of(new McpSchema.TextContent(validation.jsonStructuredOutput())),
-							result.isError(), result.structuredContent());
+					return CallToolResult.builder()
+						.content(List.of(new McpSchema.TextContent(validation.jsonStructuredOutput())))
+						.isError(result.isError())
+						.structuredContent(result.structuredContent())
+						.build();
 				}
 
 				return result;

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/DefaultJsonSchemaValidator.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/DefaultJsonSchemaValidator.java
@@ -51,7 +51,7 @@ public class DefaultJsonSchemaValidator implements JsonSchemaValidator {
 	}
 
 	@Override
-	public ValidationResponse validate(Map<String, Object> schema, Map<String, Object> structuredContent) {
+	public ValidationResponse validate(Map<String, Object> schema, Object structuredContent) {
 
 		Assert.notNull(schema, "Schema must not be null");
 		Assert.notNull(structuredContent, "Structured content must not be null");

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/JsonSchemaValidator.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/JsonSchemaValidator.java
@@ -40,6 +40,6 @@ public interface JsonSchemaValidator {
 	 * @return A ValidationResponse indicating whether the validation was successful or
 	 * not.
 	 */
-	ValidationResponse validate(Map<String, Object> schema, Map<String, Object> structuredContent);
+	ValidationResponse validate(Map<String, Object> schema, Object structuredContent);
 
 }

--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -11,9 +11,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -23,8 +20,9 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.modelcontextprotocol.util.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Based on the <a href="http://www.jsonrpc.org/specification">JSON-RPC 2.0
@@ -1508,15 +1506,21 @@ public final class McpSchema {
 	public record CallToolResult( // @formatter:off
 		@JsonProperty("content") List<Content> content,
 		@JsonProperty("isError") Boolean isError,
-		@JsonProperty("structuredContent") Map<String, Object> structuredContent,
+		@JsonProperty("structuredContent") Object structuredContent,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Result { // @formatter:on
 
-		// backwards compatibility constructor
+		/**
+		 * @deprecated use the builder instead.
+		 */
+		@Deprecated
 		public CallToolResult(List<Content> content, Boolean isError) {
-			this(content, isError, null, null);
+			this(content, isError, (Object) null, null);
 		}
 
-		// backwards compatibility constructor
+		/**
+		 * @deprecated use the builder instead.
+		 */
+		@Deprecated
 		public CallToolResult(List<Content> content, Boolean isError, Map<String, Object> structuredContent) {
 			this(content, isError, structuredContent, null);
 		}
@@ -1551,7 +1555,7 @@ public final class McpSchema {
 
 			private Boolean isError = false;
 
-			private Map<String, Object> structuredContent;
+			private Object structuredContent;
 
 			private Map<String, Object> meta;
 
@@ -1566,7 +1570,7 @@ public final class McpSchema {
 				return this;
 			}
 
-			public Builder structuredContent(Map<String, Object> structuredContent) {
+			public Builder structuredContent(Object structuredContent) {
 				Assert.notNull(structuredContent, "structuredContent must not be null");
 				this.structuredContent = structuredContent;
 				return this;
@@ -1644,7 +1648,7 @@ public final class McpSchema {
 			 * @return a new CallToolResult instance
 			 */
 			public CallToolResult build() {
-				return new CallToolResult(content, isError, structuredContent, meta);
+				return new CallToolResult(content, isError, (Object) structuredContent, meta);
 			}
 
 		}

--- a/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpClientServerIntegrationTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/AbstractMcpClientServerIntegrationTests.java
@@ -1407,7 +1407,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 
 			// In WebMVC, structured content is returned properly
 			if (response.structuredContent() != null) {
-				assertThat(response.structuredContent()).containsEntry("result", 5.0)
+				assertThat((Map<String, Object>) response.structuredContent()).containsEntry("result", 5.0)
 					.containsEntry("operation", "2 + 3")
 					.containsEntry("timestamp", "2024-01-01T10:00:00Z");
 			}
@@ -1422,6 +1422,65 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 				.isObject()
 				.isEqualTo(json("""
 						{"result":5.0,"operation":"2 + 3","timestamp":"2024-01-01T10:00:00Z"}"""));
+		}
+		finally {
+			mcpServer.closeGracefully();
+		}
+	}
+
+	@ParameterizedTest(name = "{0} : {displayName} ")
+	@ValueSource(strings = { "httpclient" })
+	void testStructuredOutputOfObjectArrayValidationSuccess(String clientType) {
+		var clientBuilder = clientBuilders.get(clientType);
+
+		// Create a tool with output schema that returns an array of objects
+		Map<String, Object> outputSchema = Map
+			.of( // @formatter:off
+			"type", "array",
+			"items", Map.of(
+				"type", "object",
+				"properties", Map.of(
+					"name", Map.of("type", "string"),
+					"age", Map.of("type", "number")),					
+				"required", List.of("name", "age"))); // @formatter:on
+
+		Tool calculatorTool = Tool.builder()
+			.name("getMembers")
+			.description("Returns a list of members")
+			.outputSchema(outputSchema)
+			.build();
+
+		McpServerFeatures.SyncToolSpecification tool = McpServerFeatures.SyncToolSpecification.builder()
+			.tool(calculatorTool)
+			.callHandler((exchange, request) -> {
+				return CallToolResult.builder()
+					.structuredContent(List.of(Map.of("name", "John", "age", 30), Map.of("name", "Peter", "age", 25)))
+					.build();
+			})
+			.build();
+
+		var mcpServer = prepareSyncServerBuilder().serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().tools(true).build())
+			.tools(tool)
+			.build();
+
+		try (var mcpClient = clientBuilder.build()) {
+			assertThat(mcpClient.initialize()).isNotNull();
+
+			// Call tool with valid structured output of type array
+			CallToolResult response = mcpClient.callTool(new McpSchema.CallToolRequest("getMembers", Map.of()));
+
+			assertThat(response).isNotNull();
+			assertThat(response.isError()).isFalse();
+
+			assertThat(response.structuredContent()).isNotNull();
+			assertThatJson(response.structuredContent()).when(Option.IGNORING_ARRAY_ORDER)
+				.when(Option.IGNORING_EXTRA_ARRAY_ITEMS)
+				.isArray()
+				.hasSize(2)
+				.containsExactlyInAnyOrder(json("""
+						{"name":"John","age":30}"""), json("""
+						{"name":"Peter","age":25}"""));
 		}
 		finally {
 			mcpServer.closeGracefully();

--- a/mcp/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
@@ -1206,7 +1206,9 @@ public class McpSchemaTests {
 	void testCallToolResult() throws Exception {
 		McpSchema.TextContent content = new McpSchema.TextContent("Tool execution result");
 
-		McpSchema.CallToolResult result = new McpSchema.CallToolResult(Collections.singletonList(content), false);
+		McpSchema.CallToolResult result = McpSchema.CallToolResult.builder()
+			.content(Collections.singletonList(content))
+			.build();
 
 		String value = mapper.writeValueAsString(result);
 


### PR DESCRIPTION
- Change CallToolResult.structuredContent type from Map<String,Object> to Object to support both objects and arrays
- Update JsonSchemaValidator to validate any Object type, not just Maps
- Add test cases for array-type structured output validation
- Fix type casting in existing tests to handle the more generic Object type
- Deprecate CallToolResult constructors in favor of builder pattern
- Update server implementations to use CallToolResult builder

This allows tools to return arrays as structured content, not just objects, which is required by the MCP specification for tools with array-type output schemas.

It is related to MPC spec fix: https://github.com/modelcontextprotocol/modelcontextprotocol/issues/834

Fixes #550

<!-- Provide a brief summary of your changes -->
This PR extends the MCP Java SDK to support arrays as structured content output from tools, not just objects. The main change is updating `CallToolResult.structuredContent` from `Map<String,Object>` to `Object` to accommodate both object and array return types.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
This change addresses issue #550. Previously, the SDK only supported tools that returned objects as structured content, but the MCP specification allows tools to define output schemas that return arrays. This limitation prevented developers from creating tools that return lists of items (e.g., a tool that returns a list of users, search results, or any collection of structured data).

Without this change, tools with array-type output schemas would fail validation or cause runtime errors when trying to return array data.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
- Added new test cases `testStructuredOutputOfObjectArrayValidationSuccess` in multiple test classes to verify array support
- Existing tests updated to handle the new Object type with proper casting
- Test coverage includes:
  - HttpClient transport
  - WebFlux transport (where applicable)
  - Stateless and stateful server implementations
  - JSON schema validation for array types

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
**Yes, this is a breaking change.** Users will need to update their code when:

1. **Accessing `CallToolResult.structuredContent()`**: Add explicit casting since it now returns `Object` instead of `Map<String,Object>`
   ```java
   // Before
   result.structuredContent().get("key")
   
   // After
   ((Map<String,Object>) result.structuredContent()).get("key")
   ```

2. **Creating `CallToolResult` instances**: The constructors are deprecated, use the builder pattern
   ```java
   // Before
   new CallToolResult(content, isError, structuredContent)
   
   // After
   CallToolResult.builder()
     .content(content)
     .isError(isError)
     .structuredContent(structuredContent)
     .build()
   ```

3. **Implementing custom `JsonSchemaValidator`**: Update the validate method signature
   ```java
   // Before
   validate(Map<String,Object> schema, Map<String,Object> structuredContent)
   
   // After
   validate(Map<String,Object> schema, Object structuredContent)
   ```

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
### Design Decisions:
- Changed `structuredContent` to `Object` type to support both Maps and Lists, aligning with JSON's two container types
- Used builder pattern for `CallToolResult` to provide a cleaner API and better forward compatibility
- Maintained backward compatibility where possible by keeping deprecated constructors (marked with `@Deprecated`)
- Updated all server implementations (McpAsyncServer, McpStatelessAsyncServer) to use the builder pattern consistently

### Migration Path:
The deprecated constructors are retained for backward compatibility but should be removed in a future major version. Users are encouraged to migrate to the builder pattern immediately.

### Related MCP Specification:
This change aligns with the [MCP Tools Specification](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content) which states that structured content can be any valid JSON value, including arrays.

https://github.com/modelcontextprotocol/modelcontextprotocol/issues/834
