### PR TITLE
fix: Add JsonInclude annotation to notification records for proper serialization

### DIFF
--- a/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -2203,6 +2203,7 @@ public final class McpSchema {
 	 * @param uri The updated resource uri.
 	 * @param meta See specification for notes on _meta usage
 	 */
+	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ResourcesUpdatedNotification(// @formatter:off
 		@JsonProperty("uri") String uri,
@@ -2224,6 +2225,7 @@ public final class McpSchema {
 	 * @param data JSON-serializable logging data.
 	 * @param meta See specification for notes on _meta usage
 	 */
+	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record LoggingMessageNotification( // @formatter:off
 		@JsonProperty("level") LoggingLevel level,


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Add JsonInclude annotations to notification records to ensure proper JSON serialization by excluding absent (null/Optional.empty()) fields from the serialized output.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The `ResourcesUpdatedNotification` and `LoggingMessageNotification` records were missing the `@JsonInclude(JsonInclude.Include.NON_ABSENT)` annotation, which could lead to unnecessary null/absent fields being included in the JSON output. This change ensures consistent serialization behavior across all notification types and prevents potential issues with clients that may not handle absent fields correctly.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
- Verified that notification records serialize correctly without including absent fields
- Tested with both populated and null optional fields to ensure proper exclusion
- Existing test suite continues to pass

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes. This change only affects the JSON serialization output by excluding absent fields, which should not impact existing functionality. Clients will receive cleaner JSON without unnecessary null fields.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
This change aligns the notification records with the existing pattern used throughout the codebase where `@JsonInclude(JsonInclude.Include.NON_ABSENT)` is applied to ensure clean JSON serialization. The annotation specifically handles both null values and Optional.empty() cases, preventing them from appearing in the serialized JSON output.
