### PR TITLE
fix(mcp): skip source/javadoc generation for aggregator module

### DIFF
--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -61,6 +61,24 @@
 					</archive>
 				</configuration>
 			</plugin>
+
+			<!-- Skip source plugin for aggregator module -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<configuration>
+					<skipSource>true</skipSource>
+				</configuration>
+			</plugin>
+
+			<!-- Skip javadoc plugin for aggregator module -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
The mcp module packages dependencies but has no sources, causing Maven release failures. Skip source and javadoc JAR generation to fix deployment errors.
