### PR TITLE
fix: handle resource not found according to spec

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpError.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpError.java
@@ -7,7 +7,18 @@ package io.modelcontextprotocol.spec;
 import io.modelcontextprotocol.spec.McpSchema.JSONRPCResponse.JSONRPCError;
 import io.modelcontextprotocol.util.Assert;
 
+import java.util.Map;
+import java.util.function.Function;
+
 public class McpError extends RuntimeException {
+
+	/**
+	 * <a href=
+	 * "https://modelcontextprotocol.io/specification/2025-06-18/server/resources#error-handling">Resource
+	 * Error Handling</a>
+	 */
+	public static final Function<String, McpError> RESOURCE_NOT_FOUND = resourceUri -> new McpError(new JSONRPCError(
+			McpSchema.ErrorCodes.RESOURCE_NOT_FOUND, "Resource not found", Map.of("uri", resourceUri)));
 
 	private JSONRPCError jsonRpcError;
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -143,6 +143,11 @@ public final class McpSchema {
 		 */
 		public static final int INTERNAL_ERROR = -32603;
 
+		/**
+		 * Resource not found.
+		 */
+		public static final int RESOURCE_NOT_FOUND = -32002;
+
 	}
 
 	public sealed interface Request

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/McpErrorTest.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/McpErrorTest.java
@@ -1,0 +1,21 @@
+package io.modelcontextprotocol.spec;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class McpErrorTest {
+
+	@Test
+	void testNotFound() {
+		String uri = "file:///nonexistent.txt";
+		McpError mcpError = McpError.RESOURCE_NOT_FOUND.apply(uri);
+		assertNotNull(mcpError.getJsonRpcError());
+		assertEquals(-32002, mcpError.getJsonRpcError().code());
+		assertEquals("Resource not found", mcpError.getJsonRpcError().message());
+		assertEquals(Map.of("uri", uri), mcpError.getJsonRpcError().data());
+	}
+
+}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

This pull-request fixes the handling of resource not found to be as described in the specification. 

see: https://modelcontextprotocol.io/specification/2025-06-18/server/resources#error-handling

Resource not found should send a JSON RPC response such as:

```json
{
  "jsonrpc": "2.0",
  "id": 5,
  "error": {
    "code": -32002,
    "message": "Resource not found",
    "data": {
      "uri": "file:///nonexistent.txt"
    }
  }
}
```

## How Has This Been Tested?

I added a unit tests. 

## Breaking Changes

This is not a breaking change but bug fix. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

This PR also changes some instances where a `McpError` was thrown instead of being passed in the reactive chain with `Mono.error`