### PR TITLE
fix: when using JsonTypeInfo.DEDUCTION don’t add include

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -1064,7 +1064,7 @@ public final class McpSchema {
 	/**
 	 * The contents of a specific resource or sub-resource.
 	 */
-	@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION, include = As.PROPERTY)
+	@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
 	@JsonSubTypes({ @JsonSubTypes.Type(value = TextResourceContents.class, name = "text"),
 			@JsonSubTypes.Type(value = BlobResourceContents.class, name = "blob") })
 	public sealed interface ResourceContents extends Meta permits TextResourceContents, BlobResourceContents {


### PR DESCRIPTION
From the JSonTypeInfo Javadocs:

> If deduction is being used annotation properties visible, property and include are ignored.

This is causing issues with serialization downstream.
