### PR TITLE
Client: handle server responses with Content-Length: 0

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
@@ -18,14 +18,13 @@ import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import io.modelcontextprotocol.json.McpJsonMapper;
-import io.modelcontextprotocol.json.TypeRef;
-
+import io.modelcontextprotocol.client.transport.ResponseSubscribers.ResponseEvent;
 import io.modelcontextprotocol.client.transport.customizer.McpAsyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
-import io.modelcontextprotocol.client.transport.ResponseSubscribers.ResponseEvent;
 import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.spec.HttpHeaders;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.JSONRPCMessage;
@@ -469,7 +468,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 		return Mono.deferContextual(ctx -> {
 			var builder = this.requestBuilder.copy()
 				.uri(requestUri)
-				.header("Content-Type", "application/json")
+				.header(HttpHeaders.CONTENT_TYPE, "application/json")
 				.header(MCP_PROTOCOL_VERSION_HEADER_NAME, MCP_PROTOCOL_VERSION)
 				.POST(HttpRequest.BodyPublishers.ofString(body));
 			var transportContext = ctx.getOrDefault(McpTransportContext.KEY, McpTransportContext.EMPTY);

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/HttpHeaders.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/HttpHeaders.java
@@ -26,4 +26,31 @@ public interface HttpHeaders {
 	 */
 	String PROTOCOL_VERSION = "MCP-Protocol-Version";
 
+	/**
+	 * The HTTP Content-Length header.
+	 * @see <a href=
+	 * "https://httpwg.org/specs/rfc9110.html#field.content-length">RFC9110</a>
+	 */
+	String CONTENT_LENGTH = "Content-Length";
+
+	/**
+	 * The HTTP Content-Type header.
+	 * @see <a href=
+	 * "https://httpwg.org/specs/rfc9110.html#field.content-type">RFC9110</a>
+	 */
+	String CONTENT_TYPE = "Content-Type";
+
+	/**
+	 * The HTTP Accept header.
+	 * @see <a href= "https://httpwg.org/specs/rfc9110.html#field.accept">RFC9110</a>
+	 */
+	String ACCEPT = "Accept";
+
+	/**
+	 * The HTTP Cache-Control header.
+	 * @see <a href=
+	 * "https://httpwg.org/specs/rfc9111.html#field.cache-control">RFC9111</a>
+	 */
+	String CACHE_CONTROL = "Cache-Control";
+
 }

--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebClientStreamableHttpTransport.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebClientStreamableHttpTransport.java
@@ -293,9 +293,10 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 					// 200 OK for notifications
 					if (response.statusCode().is2xxSuccessful()) {
 						Optional<MediaType> contentType = response.headers().contentType();
+						long contentLength = response.headers().contentLength().orElse(-1);
 						// Existing SDKs consume notifications with no response body nor
 						// content type
-						if (contentType.isEmpty()) {
+						if (contentType.isEmpty() || contentLength == 0) {
 							logger.trace("Message was successfully sent via POST for session {}",
 									sessionRepresentation);
 							// signal the caller that the message was successfully


### PR DESCRIPTION
- When the client sends `notification/initalized`, servers MUST respond with HTTP 202 and an empty body. Before this PR, we checked for the absence of a Content-Type header to know whether the body was empty.
- However, some servers will send an empty body with a Content-Type header, and that header may have an unsupported, default type such as `text/html` or `text/plain`.
- Now we we also use the Content-Length header to check for an empty body. This header is optional in HTTP/2, so we do not make it our primary mechanism for detecting empty bodies.
- Fixes #582 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update