### PR TITLE
fix: Handle non-compliant notification responses

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
@@ -507,8 +507,9 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 					else if (contentType.contains(APPLICATION_JSON)) {
 						deliveredSink.success();
 						String data = ((ResponseSubscribers.AggregateResponseEvent) responseEvent).data();
-						if (sentMessage instanceof McpSchema.JSONRPCNotification && Utils.hasText(data)) {
-							logger.warn("Notification: {} received non-compliant response: {}", sentMessage, data);
+						if (sentMessage instanceof McpSchema.JSONRPCNotification) {
+							logger.warn("Notification: {} received non-compliant response: {}", sentMessage,
+									Utils.hasText(data) ? data : "[empty]");
 							return Mono.empty();
 						}
 

--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebClientStreamableHttpTransport.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebClientStreamableHttpTransport.java
@@ -423,8 +423,9 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 			ClientResponse response) {
 		return response.bodyToMono(String.class).<Iterable<McpSchema.JSONRPCMessage>>handle((responseMessage, s) -> {
 			try {
-				if (sentMessage instanceof McpSchema.JSONRPCNotification && Utils.hasText(responseMessage)) {
-					logger.warn("Notification: {} received non-compliant response: {}", sentMessage, responseMessage);
+				if (sentMessage instanceof McpSchema.JSONRPCNotification) {
+					logger.warn("Notification: {} received non-compliant response: {}", sentMessage,
+							Utils.hasText(responseMessage) ? responseMessage : "[empty]");
 					s.complete();
 				}
 				else {


### PR DESCRIPTION
Ensure warnings are logged for all non-compliant responses to JSON-RPC notifications, including empty responses. Empty responses now display as "[empty]" in log messages for better clarity.

Resolves #586

