### PR TITLE
fix remove name when using deduction

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -1064,8 +1064,8 @@ public final class McpSchema {
 	 * The contents of a specific resource or sub-resource.
 	 */
 	@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
-	@JsonSubTypes({ @JsonSubTypes.Type(value = TextResourceContents.class, name = "text"),
-			@JsonSubTypes.Type(value = BlobResourceContents.class, name = "blob") })
+	@JsonSubTypes({ @JsonSubTypes.Type(value = TextResourceContents.class),
+			@JsonSubTypes.Type(value = BlobResourceContents.class) })
 	public sealed interface ResourceContents extends Meta permits TextResourceContents, BlobResourceContents {
 
 		/**


### PR DESCRIPTION
This pull-request removes the name member from the @JsonSubTypes.Type annotations when using JsonTypeInfo.Id.DEDUCTION.

With DEDUCTION, Jackson ignores the name entirely because it's inferring the type from the structure.

## Motivation and Context
The incorrect usage of `name` was causing serialization issues downstream.

## How Has This Been Tested?
Existing tests in the project still pass

## Breaking Changes
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed