### PR TITLE
define explicitely that values should always be included in code completions

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -2501,7 +2501,7 @@ public final class McpSchema {
 		 * @param hasMore Indicates whether there are additional completion options beyond
 		 * those provided in the current response, even if the exact total is unknown
 		 */
-        @JsonInclude(JsonInclude.Include.ALWAYS)
+		@JsonInclude(JsonInclude.Include.ALWAYS)
 		public record CompleteCompletion( // @formatter:off
 				@JsonProperty("values") List<String> values,
 				@JsonProperty("total") Integer total,

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/CompleteCompletionSerializationTest.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/CompleteCompletionSerializationTest.java
@@ -8,20 +8,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CompleteCompletionSerializationTest {
 
-    @Test
-    void codeCompletionSerialization() throws IOException {
-        McpJsonMapper jsonMapper = McpJsonMapper.getDefault();
-        McpSchema.CompleteResult.CompleteCompletion codeComplete
-                = new McpSchema.CompleteResult.CompleteCompletion(Collections.emptyList(), 0, false);
-        String json = jsonMapper.writeValueAsString(codeComplete);
-        String expected = """
-        {"values":[],"total":0,"hasMore":false}""";
-        assertEquals(expected, json, json);
+	@Test
+	void codeCompletionSerialization() throws IOException {
+		McpJsonMapper jsonMapper = McpJsonMapper.getDefault();
+		McpSchema.CompleteResult.CompleteCompletion codeComplete = new McpSchema.CompleteResult.CompleteCompletion(
+				Collections.emptyList(), 0, false);
+		String json = jsonMapper.writeValueAsString(codeComplete);
+		String expected = """
+				{"values":[],"total":0,"hasMore":false}""";
+		assertEquals(expected, json, json);
 
-        McpSchema.CompleteResult completeResult = new McpSchema.CompleteResult(codeComplete);
-        json = jsonMapper.writeValueAsString(completeResult);
-        expected = """
-        {"completion":{"values":[],"total":0,"hasMore":false}}""";
-        assertEquals(expected, json, json);
-    }
+		McpSchema.CompleteResult completeResult = new McpSchema.CompleteResult(codeComplete);
+		json = jsonMapper.writeValueAsString(completeResult);
+		expected = """
+				{"completion":{"values":[],"total":0,"hasMore":false}}""";
+		assertEquals(expected, json, json);
+	}
+
 }


### PR DESCRIPTION
## Motivation and Context
For empty responses in resource completions, I am seeing such errors if values are not included:

<img width="830" height="358" alt="497570535-c7c74043-55a8-473f-aafe-41beb5afe8d9" src="https://github.com/user-attachments/assets/a1065a0b-8fe4-48d6-82ed-99c405e5498f" />

This PR adds explicitly the `@JsonInclude(JsonInclude.Include.ALWAYS)` annotation and a test.

## How Has This Been Tested?
yes, a test is included

## Breaking Changes
no. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
