### PR TITLE
fix: Avoid NPE in McpClientSession

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpClientSession.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpClientSession.java
@@ -283,7 +283,15 @@ public class McpClientSession implements McpSession {
 					deliveredResponseSink.complete();
 				}
 				else {
-					deliveredResponseSink.next(this.transport.unmarshalFrom(jsonRpcResponse.result(), typeRef));
+					var result = jsonRpcResponse.result();
+					var unmarshalled = this.transport.unmarshalFrom(result, typeRef);
+					// https://github.com/modelcontextprotocol/java-sdk/issues/605
+					if (unmarshalled != null)
+						deliveredResponseSink.next(unmarshalled);
+					else
+						// NB: next() cannot be called with null
+						deliveredResponseSink
+							.error(new IllegalStateException("Failed to unmarshal response: " + jsonRpcResponse));
 				}
 			}
 		});


### PR DESCRIPTION
## Motivation and Context

Fixes NPE seen in the wild as described in #605.

## How Has This Been Tested?

As described in #605, unfortunately I'm unable to reproduce that NPE locally even myself, but I am consistently seeing this on a failing CI build. However I'm confident that this change improves the robustness of `McpClientSession` and will provide a much more clear and actionable error message when this occurs again next time.

## Breaking Changes

No.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally? No, see #606 - but that's unrelated to this change.
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed