### PR TITLE
fix: use valid JPMS module name for mcp-core

### DIFF
--- a/mcp-core/pom.xml
+++ b/mcp-core/pom.xml
@@ -38,7 +38,7 @@
 								version:                ${versionmask;===;${version_cleanup;${project.version}}}
 								Bundle-SymbolicName:    ${project.groupId}.${project.artifactId}
 								Bundle-Version:         ${version}
-								Automatic-Module-Name:  ${project.groupId}.${project.artifactId}
+								Automatic-Module-Name:  io.modelcontextprotocol.sdk.mcp.core
 								Import-Package:         jakarta.*;resolution:=optional, \
 								                        *;
 								Export-Package:         io.modelcontextprotocol.*;version="${version}";-noimport:=true


### PR DESCRIPTION
## Summary
Fixes #560

- Fixed `Automatic-Module-Name` in `mcp-core/pom.xml` to use a valid JPMS module name
- Changed from `io.modelcontextprotocol.sdk.mcp-core` (invalid - contains dash) to `io.modelcontextprotocol.sdk.mcp.core`
- OSGI `Bundle-SymbolicName` kept as `io.modelcontextprotocol.sdk.mcp-core` for backward compatibility

## Problem
JPMS module names must be valid Java identifiers and cannot contain dashes. The previous automatic module name `io.modelcontextprotocol.sdk.mcp-core` prevented usage in modular Java applications.

## Solution
Hard-coded the `Automatic-Module-Name` to `io.modelcontextprotocol.sdk.mcp.core`. 

Alternative: Could use BND's substitution macro `${subst;${project.groupId}.${project.artifactId};-;.}` if dynamic generation is preferred by maintainers.

## Compatibility
OSGI's `Bundle-SymbolicName` remains unchanged with the dash (`mcp-core`) as OSGI allows dashes in symbolic names. Having different names for JPMS and OSGI is acceptable and common.

## Test plan
- [x] Built `mcp-core` module successfully
- [x] Verified manifest contains `Automatic-Module-Name: io.modelcontextprotocol.sdk.mcp.core`
- [x] Verified `Bundle-SymbolicName` remains `io.modelcontextprotocol.sdk.mcp-core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)