### PR TITLE
fix(docs): Remove broken @see link in McpServer.java Javadoc

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServer.java
@@ -599,7 +599,6 @@ public interface McpServer {
 		 * null.
 		 * @return This builder instance for method chaining
 		 * @throws IllegalArgumentException if resourceTemplates is null.
-		 * @see #resourceTemplates(ResourceTemplate...)
 		 */
 		public AsyncSpecification<S> resourceTemplates(
 				List<McpServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates) {
@@ -1196,7 +1195,6 @@ public interface McpServer {
 		 * null.
 		 * @return This builder instance for method chaining
 		 * @throws IllegalArgumentException if resourceTemplates is null.
-		 * @see #resourceTemplates(ResourceTemplate...)
 		 */
 		public SyncSpecification<S> resourceTemplates(
 				List<McpServerFeatures.SyncResourceTemplateSpecification> resourceTemplates) {
@@ -1704,7 +1702,6 @@ public interface McpServer {
 		 * templates.
 		 * @return This builder instance for method chaining
 		 * @throws IllegalArgumentException if resourceTemplates is null.
-		 * @see #resourceTemplates(ResourceTemplate...)
 		 */
 		public StatelessAsyncSpecification resourceTemplates(
 				List<McpStatelessServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates) {
@@ -2167,7 +2164,6 @@ public interface McpServer {
 		 * existing templates.
 		 * @return This builder instance for method chaining
 		 * @throws IllegalArgumentException if resourceTemplates is null.
-		 * @see #resourceTemplates(ResourceTemplate...)
 		 */
 		public StatelessSyncSpecification resourceTemplates(
 				List<McpStatelessServerFeatures.SyncResourceTemplateSpecification> resourceTemplatesSpec) {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
This PR removes a broken `@see` Javadoc link from the `resourceTemplates(List)` method in the `McpServer.java` class. The link pointed to a non-existent function overload, which causes IDE warnings and can be confusing for developers.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The primary motivation is to improve code quality and developer experience by cleaning up the documentation within the `McpServer` class. Removing the incorrect reference resolves IDE warnings and ensures the Javadoc is accurate and reliable.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
This is a documentation-only change and does not affect runtime behavior.

- I have confirmed in my IDE that the warning for the broken link in `McpServer.java` disappears after this change.
- The project builds successfully locally without any new warnings or errors.

No new automated tests are required for this type of change.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None. This is purely a documentation fix.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling *(N/A for this change)*
- [x] I have added or updated documentation as needed

