### PR TITLE
fix: allow additional properties by default per JSON Schema spec

### DIFF
--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/JSONRPCRequestMcpValidationTest.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/JSONRPCRequestMcpValidationTest.java
@@ -5,7 +5,10 @@
 package io.modelcontextprotocol.spec;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for MCP-specific validation of JSONRPCRequest ID requirements.

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/McpErrorTest.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/McpErrorTest.java
@@ -4,7 +4,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class McpErrorTest {
 

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/PromptReferenceEqualsTest.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/PromptReferenceEqualsTest.java
@@ -7,7 +7,9 @@ package io.modelcontextprotocol.spec;
 import io.modelcontextprotocol.spec.McpSchema.PromptReference;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test class to verify the equals method implementation for PromptReference.

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/json/gson/GsonMcpJsonMapperTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/json/gson/GsonMcpJsonMapperTests.java
@@ -8,7 +8,10 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 class GsonMcpJsonMapperTests {
 

--- a/mcp-core/src/test/java/io/modelcontextprotocol/util/AssertTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/util/AssertTests.java
@@ -8,7 +8,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class AssertTests {
 

--- a/mcp-json-jackson2/pom.xml
+++ b/mcp-json-jackson2/pom.xml
@@ -49,5 +49,31 @@
             <artifactId>json-schema-validator</artifactId>
             <version>${json-schema-validator.version}</version>
         </dependency>
+
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>${assert4j.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>${mockito.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 </project>


### PR DESCRIPTION
## Summary
Fix JSON Schema validation to comply with the official JSON Schema specification by allowing additional properties by default when not explicitly specified in schemas. Also adds support for String input in the validate() method.

- Remove automatic additionalProperties: false injection (JSON Schema spec compliance)
- Support String input for structuredContent in validate() method
- Move tests to mcp-json-jackson2 module with proper dependencies
- Replace wildcard imports with explicit imports

Complies with JSON Schema Test Suite:
https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/15e4505/tests/draft2020-12/additionalProperties.json#L112

Fixes #584

## Motivation and Context

This fix ensures the SDK behaves correctly according to the JSON Schema specification, preventing false validation failures and improving interoperability with other JSON Schema validators.

Additionally, the validator now supports String input for `structuredContent`, allowing direct JSON string validation without requiring pre-parsing.

## Breaking Changes
**YES - This is a breaking change.**

Users who relied on the previous non-compliant behavior (additional properties rejected by default) will need to update their schemas to explicitly set `"additionalProperties": false` if they want to disallow additional properties.

**Migration guide:**
```json
// Before (implicit rejection of additional properties)
{
  "type": "object",
  "properties": {
    "name": {"type": "string"}
  }
}

// After (explicit rejection required)
{
  "type": "object",
  "properties": {
    "name": {"type": "string"}
  },
  "additionalProperties": false
}
```

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
