### PR TITLE
Polish webflux server transports

### DIFF
--- a/mcp-spring/mcp-spring-webflux/README.md
+++ b/mcp-spring/mcp-spring-webflux/README.md
@@ -22,7 +22,7 @@ static class MyConfig {
 	// Router function for SSE transport used by Spring WebFlux to start an HTTP
 	// server.
 	@Bean
-	public RouterFunction<?> mcpRouterFunction(WebFluxSseServerTransport transport) {
+	public RouterFunction<ServerResponse> mcpRouterFunction(WebFluxSseServerTransport transport) {
 		return transport.getRouterFunction();
 	}
 

--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxSseServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxSseServerTransportProvider.java
@@ -109,7 +109,7 @@ public class WebFluxSseServerTransportProvider implements McpServerTransportProv
 
 	private final String sseEndpoint;
 
-	private final RouterFunction<?> routerFunction;
+	private final RouterFunction<ServerResponse> routerFunction;
 
 	private McpServerSession.Factory sessionFactory;
 
@@ -256,7 +256,7 @@ public class WebFluxSseServerTransportProvider implements McpServerTransportProv
 	 * </ul>
 	 * @return The configured {@link RouterFunction} for handling HTTP requests
 	 */
-	public RouterFunction<?> getRouterFunction() {
+	public RouterFunction<ServerResponse> getRouterFunction() {
 		return this.routerFunction;
 	}
 

--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxStatelessServerTransport.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxStatelessServerTransport.java
@@ -38,7 +38,7 @@ public class WebFluxStatelessServerTransport implements McpStatelessServerTransp
 
 	private final String mcpEndpoint;
 
-	private final RouterFunction<?> routerFunction;
+	private final RouterFunction<ServerResponse> routerFunction;
 
 	private McpStatelessServerHandler mcpHandler;
 
@@ -83,7 +83,7 @@ public class WebFluxStatelessServerTransport implements McpStatelessServerTransp
 	 * </ul>
 	 * @return The configured {@link RouterFunction} for handling HTTP requests
 	 */
-	public RouterFunction<?> getRouterFunction() {
+	public RouterFunction<ServerResponse> getRouterFunction() {
 		return this.routerFunction;
 	}
 

--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxStreamableServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxStreamableServerTransportProvider.java
@@ -55,7 +55,7 @@ public class WebFluxStreamableServerTransportProvider implements McpStreamableSe
 
 	private final boolean disallowDelete;
 
-	private final RouterFunction<?> routerFunction;
+	private final RouterFunction<ServerResponse> routerFunction;
 
 	private McpStreamableServerSession.Factory sessionFactory;
 
@@ -152,7 +152,7 @@ public class WebFluxStreamableServerTransportProvider implements McpStreamableSe
 	 * </ul>
 	 * @return The configured {@link RouterFunction} for handling HTTP requests
 	 */
-	public RouterFunction<?> getRouterFunction() {
+	public RouterFunction<ServerResponse> getRouterFunction() {
 		return this.routerFunction;
 	}
 


### PR DESCRIPTION
Use `RouterFunction<ServerResponse>` instead of `RouterFunction<?>` to align with webmvc server transports