### PR TITLE
Support o.s.h.HttpHeaders from both 6.x and 7.x Spring branches

### DIFF
--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxStreamableServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxStreamableServerTransportProvider.java
@@ -174,7 +174,7 @@ public class WebFluxStreamableServerTransportProvider implements McpStreamableSe
 				return ServerResponse.badRequest().build();
 			}
 
-			if (!request.headers().asHttpHeaders().containsKey(HttpHeaders.MCP_SESSION_ID)) {
+			if (request.headers().header(HttpHeaders.MCP_SESSION_ID).isEmpty()) {
 				return ServerResponse.badRequest().build(); // TODO: say we need a session
 															// id
 			}
@@ -187,7 +187,7 @@ public class WebFluxStreamableServerTransportProvider implements McpStreamableSe
 				return ServerResponse.notFound().build();
 			}
 
-			if (request.headers().asHttpHeaders().containsKey(HttpHeaders.LAST_EVENT_ID)) {
+			if (!request.headers().header(HttpHeaders.LAST_EVENT_ID).isEmpty()) {
 				String lastId = request.headers().asHttpHeaders().getFirst(HttpHeaders.LAST_EVENT_ID);
 				return ServerResponse.ok()
 					.contentType(MediaType.TEXT_EVENT_STREAM)
@@ -258,7 +258,7 @@ public class WebFluxStreamableServerTransportProvider implements McpStreamableSe
 							.bodyValue(initResult));
 				}
 
-				if (!request.headers().asHttpHeaders().containsKey(HttpHeaders.MCP_SESSION_ID)) {
+				if (request.headers().header(HttpHeaders.MCP_SESSION_ID).isEmpty()) {
 					return ServerResponse.badRequest().bodyValue(new McpError("Session ID missing"));
 				}
 
@@ -313,7 +313,7 @@ public class WebFluxStreamableServerTransportProvider implements McpStreamableSe
 		McpTransportContext transportContext = this.contextExtractor.extract(request);
 
 		return Mono.defer(() -> {
-			if (!request.headers().asHttpHeaders().containsKey(HttpHeaders.MCP_SESSION_ID)) {
+			if (request.headers().header(HttpHeaders.MCP_SESSION_ID).isEmpty()) {
 				return ServerResponse.badRequest().build(); // TODO: say we need a session
 															// id
 			}

--- a/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcStreamableServerTransportProvider.java
+++ b/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcStreamableServerTransportProvider.java
@@ -240,7 +240,7 @@ public class WebMvcStreamableServerTransportProvider implements McpStreamableSer
 
 		McpTransportContext transportContext = this.contextExtractor.extract(request);
 
-		if (!request.headers().asHttpHeaders().containsKey(HttpHeaders.MCP_SESSION_ID)) {
+		if (request.headers().header(HttpHeaders.MCP_SESSION_ID).isEmpty()) {
 			return ServerResponse.badRequest().body("Session ID required in mcp-session-id header");
 		}
 
@@ -263,7 +263,7 @@ public class WebMvcStreamableServerTransportProvider implements McpStreamableSer
 						sessionId, sseBuilder);
 
 				// Check if this is a replay request
-				if (request.headers().asHttpHeaders().containsKey(HttpHeaders.LAST_EVENT_ID)) {
+				if (!request.headers().header(HttpHeaders.LAST_EVENT_ID).isEmpty()) {
 					String lastId = request.headers().asHttpHeaders().getFirst(HttpHeaders.LAST_EVENT_ID);
 
 					try {
@@ -354,7 +354,7 @@ public class WebMvcStreamableServerTransportProvider implements McpStreamableSer
 			}
 
 			// Handle other messages that require a session
-			if (!request.headers().asHttpHeaders().containsKey(HttpHeaders.MCP_SESSION_ID)) {
+			if (request.headers().header(HttpHeaders.MCP_SESSION_ID).isEmpty()) {
 				return ServerResponse.badRequest().body(new McpError("Session ID missing"));
 			}
 
@@ -433,7 +433,7 @@ public class WebMvcStreamableServerTransportProvider implements McpStreamableSer
 
 		McpTransportContext transportContext = this.contextExtractor.extract(request);
 
-		if (!request.headers().asHttpHeaders().containsKey(HttpHeaders.MCP_SESSION_ID)) {
+		if (request.headers().header(HttpHeaders.MCP_SESSION_ID).isEmpty()) {
 			return ServerResponse.badRequest().body("Session ID required in mcp-session-id header");
 		}
 


### PR DESCRIPTION
Replace invocation of `org.springframework.web.reactive.function.server.ServerRequest.headers().asHttpHeaders().containsKey()` with `!org.springframework.web.reactive.function.server.ServerRequest.headers().header().isEmpty()` to support Spring Framework 7.x

## Motivation and Context
Spring Boot 4.0 and Spring Framework 7.0 release candidates are now available
Spring AI will use them as a baseline in version 2.0

There's a breaking change in Spring Framework 7.0 with few APIs removed from class `org.springframework.http.HttpHeaders`

One of removed methods is `containsKey()` which is used by `modelcontextprotocol/java-sdk`

This changed replaces it with `!org.springframework.web.reactive.function.server.ServerRequest.headers().header().isEmpty()` which would work both with Spring Framework 6.x and 7.x and thus enable the migration and early adoption of new framework versions.

## How Has This Been Tested?
all tests are green

## Breaking Changes
no breaking changes

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
N/A