### PR TITLE
Update dependencies minor versions to fix build on JDK 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,16 +59,16 @@
 		<maven.compiler.target>17</maven.compiler.target>
 		<surefireArgLine/>
 
-		<assert4j.version>3.26.3</assert4j.version>
+		<assert4j.version>3.27.6</assert4j.version>
 		<junit.version>5.10.2</junit.version>
-		<mockito.version>5.17.0</mockito.version>
+		<mockito.version>5.20.0</mockito.version>
 		<testcontainers.version>1.20.4</testcontainers.version>
-		<byte-buddy.version>1.17.5</byte-buddy.version>
+		<byte-buddy.version>1.17.8</byte-buddy.version>
 		<toxiproxy.version>1.21.0</toxiproxy.version>
 
 		<slf4j-api.version>2.0.16</slf4j-api.version>
 		<logback.version>1.5.15</logback.version>
-		<jackson.version>2.17.0</jackson.version>
+		<jackson.version>2.19.2</jackson.version>
 		<springframework.version>6.2.1</springframework.version>
 
 		<!-- plugin versions -->


### PR DESCRIPTION
Update `assert4j` from 3.26.3 to 3.27.6
Update `mockito` from 5.17.0 to 5.20.0
Update `byte-buddy` from 1.17.5 to 1.17.8
Update `jackson` from 2.17.0 to 2.19.2

It converges dependencies on `byte-buddy` and brings the version which fully supports JDK25 and works with `modelcontextprotocol/java-sdk`

## Motivation and Context
JDK 25 is the new LTS version of Java.
`modelcontextprotocol/java-sdk` build fails on JDK 25 mostly due to old version of `net.bytebuddy:byte-buddy` library
This PR updates all libraries which depends on `net.bytebuddy:byte-buddy` transitively 

## How Has This Been Tested?
all tests are green

## Breaking Changes
No breaking changes. No major upgrades of dependencies

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
N/A
