### PR TITLE
Add method to get the MCP handler

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStatelessServerTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStatelessServerTransport.java
@@ -75,6 +75,11 @@ public class HttpServletStatelessServerTransport extends HttpServlet implements 
 	}
 
 	@Override
+	public McpStatelessServerHandler getMcpHandler() {
+		return mcpHandler;
+	}
+
+	@Override
 	public Mono<Void> closeGracefully() {
 		return Mono.fromRunnable(() -> this.isClosing = true);
 	}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpStatelessServerTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpStatelessServerTransport.java
@@ -4,14 +4,16 @@
 
 package io.modelcontextprotocol.spec;
 
-import java.util.List;
-
 import io.modelcontextprotocol.server.McpStatelessServerHandler;
 import reactor.core.publisher.Mono;
+
+import java.util.List;
 
 public interface McpStatelessServerTransport {
 
 	void setMcpHandler(McpStatelessServerHandler mcpHandler);
+
+	McpStatelessServerHandler getMcpHandler();
 
 	/**
 	 * Immediately closes all the transports with connected clients and releases any

--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxStatelessServerTransport.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/server/transport/WebFluxStatelessServerTransport.java
@@ -67,6 +67,11 @@ public class WebFluxStatelessServerTransport implements McpStatelessServerTransp
 	}
 
 	@Override
+	public McpStatelessServerHandler getMcpHandler() {
+		return mcpHandler;
+	}
+
+	@Override
 	public Mono<Void> closeGracefully() {
 		return Mono.fromRunnable(() -> this.isClosing = true);
 	}

--- a/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcStatelessServerTransport.java
+++ b/mcp-spring/mcp-spring-webmvc/src/main/java/io/modelcontextprotocol/server/transport/WebMvcStatelessServerTransport.java
@@ -71,6 +71,11 @@ public class WebMvcStatelessServerTransport implements McpStatelessServerTranspo
 	}
 
 	@Override
+	public McpStatelessServerHandler getMcpHandler() {
+		return mcpHandler;
+	}
+
+	@Override
 	public Mono<Void> closeGracefully() {
 		return Mono.fromRunnable(() -> this.isClosing = true);
 	}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

Add method to get the MCP handler

## Motivation and Context

This will allow setting custom MCP handlers that defer to the handler that is set by the framework


## How Has This Been Tested?

Tests aren't really necessary as this is merely a simple getter

## Breaking Changes

Adds a new method to `McpStatelessServerTransport`. As an alternative, we could add a `default` implementation that throws `UnsupportedOperation`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
