### PR TITLE
fix: JSONRPCResponse JavaDoc

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -277,12 +277,12 @@ public final class McpSchema {
 	}
 
 	/**
-	 * A successful (non-error) response to a request.
+	 * A response to a request (successful, or error).
 	 *
 	 * @param jsonrpc The JSON-RPC version (must be "2.0")
 	 * @param id The request identifier that this response corresponds to
-	 * @param result The result of the successful request
-	 * @param error Error information if the request failed
+	 * @param result The result of the successful request; null if error
+	 * @param error Error information if the request failed; null if has result
 	 */
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)


### PR DESCRIPTION
Fix the clearly wrong JavaDoc on the `McpSchema.JSONRPCResponse`.

## Motivation and Context

Triggered by reading it while debugging #605.

Complimentary to #607.

## How Has This Been Tested?

N/A, as it's just a JavaDoc fix.

## Breaking Changes

No, as it's just a JavaDoc fix.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed