### PR TITLE
fix: Validate JSONRPCResponse in constructor (fixes #605)

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -250,13 +250,17 @@ public final class McpSchema {
 		/**
 		 * Constructor that validates MCP-specific ID requirements. Unlike base JSON-RPC,
 		 * MCP requires that: (1) Requests MUST include a string or integer ID; (2) The ID
-		 * MUST NOT be null
+		 * MUST NOT be null.
 		 */
 		public JSONRPCRequest {
-			Assert.notNull(id, "MCP requests MUST include an ID - null IDs are not allowed");
-			Assert.isTrue(id instanceof String || id instanceof Integer || id instanceof Long,
-					"MCP requests MUST have an ID that is either a string or integer");
+			validateID(id);
 		}
+	}
+
+	private static void validateID(Object id) {
+		Assert.notNull(id, "MCP requests/responses MUST include an ID - null IDs are not allowed");
+		Assert.isTrue(id instanceof String || id instanceof Integer || id instanceof Long,
+				"MCP requests/responses MUST have an ID that is either a string or integer");
 	}
 
 	/**
@@ -293,6 +297,16 @@ public final class McpSchema {
 		@JsonProperty("id") Object id,
 		@JsonProperty("result") Object result,
 		@JsonProperty("error") JSONRPCError error) implements JSONRPCMessage { // @formatter:on
+
+		/**
+		 * Constructor that validates (a) MCP-specific ID requirements (unlike base
+		 * JSON-RPC, MCP requires that: (1) Requests MUST include a string or integer ID;
+		 * (2) The ID MUST NOT be null.) and (b) that EITHER result OR error are non-null.
+		 */
+		public JSONRPCResponse {
+			validateID(id);
+			Assert.isTrue(result != null || error != null, "MCP responses MUST have EITHER a result OR an error");
+		}
 
 		/**
 		 * A response to a request that indicates an error occurred.


### PR DESCRIPTION
## Motivation and Context

Catch the root cause of #605 earlier if it ever happens again in the future.

## How Has This Been Tested?

Not really, but hopefully it's safe; I would welcome code review!

## Breaking Changes

Nope, this is an internal change for safety, which (hopefully) should have no impact.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context

@tzolov do you think this makes sense? I'm proposing this as a follow-up (NOT an alternative) to #607 (and #657), which IMHO makes sense either way as well.