### PR TITLE
feat(schema): support Object type for progressToken

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -167,9 +167,9 @@ public final class McpSchema {
 			permits InitializeRequest, CallToolRequest, CreateMessageRequest, ElicitRequest, CompleteRequest,
 			GetPromptRequest, ReadResourceRequest, SubscribeRequest, UnsubscribeRequest, PaginatedRequest {
 
-		default String progressToken() {
+		default Object progressToken() {
 			if (meta() != null && meta().containsKey("progressToken")) {
-				return meta().get("progressToken").toString();
+				return meta().get("progressToken");
 			}
 			return null;
 		}
@@ -1502,7 +1502,7 @@ public final class McpSchema {
 				return this;
 			}
 
-			public Builder progressToken(String progressToken) {
+			public Builder progressToken(Object progressToken) {
 				if (this.meta == null) {
 					this.meta = new HashMap<>();
 				}
@@ -1912,7 +1912,7 @@ public final class McpSchema {
 				return this;
 			}
 
-			public Builder progressToken(String progressToken) {
+			public Builder progressToken(Object progressToken) {
 				if (this.meta == null) {
 					this.meta = new HashMap<>();
 				}
@@ -2080,7 +2080,7 @@ public final class McpSchema {
 				return this;
 			}
 
-			public Builder progressToken(String progressToken) {
+			public Builder progressToken(Object progressToken) {
 				if (this.meta == null) {
 					this.meta = new HashMap<>();
 				}
@@ -2217,13 +2217,13 @@ public final class McpSchema {
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ProgressNotification( // @formatter:off
-		@JsonProperty("progressToken") String progressToken,
+		@JsonProperty("progressToken") Object progressToken,
 		@JsonProperty("progress") Double progress,
 		@JsonProperty("total") Double total,
 		@JsonProperty("message") String message,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Notification { // @formatter:on
 
-		public ProgressNotification(String progressToken, double progress, Double total, String message) {
+		public ProgressNotification(Object progressToken, double progress, Double total, String message) {
 			this(progressToken, progress, total, message, null);
 		}
 	}


### PR DESCRIPTION
Change progressToken from String to Object throughout McpSchema to allow both String and Number token types.
This makes it compliant with the MCP spec.

Resolves: #659

