### PR TITLE
Revert "WebClientStreamableHttpTransport: use Spring-5 compatible met…hods (#649)"

### DIFF
--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebClientStreamableHttpTransport.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebClientStreamableHttpTransport.java
@@ -313,7 +313,7 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 
 					// The spec mentions only ACCEPTED, but the existing SDKs can return
 					// 200 OK for notifications
-					if (is2xx(response)) {
+					if (response.statusCode().is2xxSuccessful()) {
 						Optional<MediaType> contentType = response.headers().contentType();
 						long contentLength = response.headers().contentLength().orElse(-1);
 						// Existing SDKs consume notifications with no response body nor
@@ -397,15 +397,14 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 			}
 			catch (IOException ex) {
 				toPropagate = new McpTransportException("Sending request failed, " + e.getMessage(), e);
-				logger.debug("Received content together with {} HTTP code response: {}", response.rawStatusCode(),
-						body);
+				logger.debug("Received content together with {} HTTP code response: {}", response.statusCode(), body);
 			}
 
 			// Some implementations can return 400 when presented with a
 			// session id that it doesn't know about, so we will
 			// invalidate the session
 			// https://github.com/modelcontextprotocol/typescript-sdk/issues/389
-			if (isBadRequest(responseException)) {
+			if (responseException.getStatusCode().isSameCodeAs(HttpStatus.BAD_REQUEST)) {
 				if (!sessionRepresentation.equals(MISSING_SESSION_ID)) {
 					return Mono.error(new McpTransportSessionNotFoundException(sessionRepresentation, toPropagate));
 				}
@@ -425,8 +424,16 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 		return Flux.from(sessionStream.consumeSseStream(idWithMessages));
 	}
 
+	private static boolean isNotFound(ClientResponse response) {
+		return response.statusCode().isSameCodeAs(HttpStatus.NOT_FOUND);
+	}
+
+	private static boolean isNotAllowed(ClientResponse response) {
+		return response.statusCode().isSameCodeAs(HttpStatus.METHOD_NOT_ALLOWED);
+	}
+
 	private static boolean isEventStream(ClientResponse response) {
-		return is2xx(response) && response.headers().contentType().isPresent()
+		return response.statusCode().is2xxSuccessful() && response.headers().contentType().isPresent()
 				&& response.headers().contentType().get().isCompatibleWith(MediaType.TEXT_EVENT_STREAM);
 	}
 
@@ -603,38 +610,6 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 					webClientBuilder, endpoint, resumableStreams, openConnectionOnStartup, supportedProtocolVersions);
 		}
 
-	}
-
-	/**
-	 * Needed for Spring 5 compatibility
-	 */
-	@SuppressWarnings("deprecation")
-	private static boolean isBadRequest(final WebClientResponseException responseException) {
-		return responseException.getRawStatusCode() == HttpStatus.BAD_REQUEST.value();
-	}
-
-	/**
-	 * Needed for Spring 5 compatibility
-	 */
-	@SuppressWarnings("deprecation")
-	private static boolean isNotFound(ClientResponse response) {
-		return response.rawStatusCode() == HttpStatus.NOT_FOUND.value();
-	}
-
-	/**
-	 * Needed for Spring 5 compatibility
-	 */
-	@SuppressWarnings("deprecation")
-	private static boolean isNotAllowed(ClientResponse response) {
-		return response.rawStatusCode() == HttpStatus.METHOD_NOT_ALLOWED.value();
-	}
-
-	/**
-	 * Needed for Spring 5 compatibility
-	 */
-	@SuppressWarnings("deprecation")
-	private static boolean is2xx(final ClientResponse response) {
-		return response.rawStatusCode() >= 200 && response.rawStatusCode() < 300;
 	}
 
 }


### PR DESCRIPTION
Unfortunately the #649 breaks compatibility with Spring Framework 7.  

Spring Framework 7 compatibility takes priority over Spring Framework 5 support.

Remove deprecated rawStatusCode() API usage in WebClientStreamableHttpTransport
that breaks Spring Framework 7 compatibility. Replace with modern statusCode()
API methods including is2xxSuccessful() and isSameCodeAs().

