### PR TITLE
Fix mcp-spring incompatibility issue with Spring Framework 6.x and 7.0

### DIFF
--- a/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebClientStreamableHttpTransport.java
+++ b/mcp-spring/mcp-spring-webflux/src/main/java/io/modelcontextprotocol/client/transport/WebClientStreamableHttpTransport.java
@@ -397,7 +397,7 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 			}
 			catch (IOException ex) {
 				toPropagate = new McpTransportException("Sending request failed, " + e.getMessage(), e);
-				logger.debug("Received content together with {} HTTP code response: {}", response.rawStatusCode(),
+				logger.debug("Received content together with {} HTTP code response: {}", response.statusCode().value(),
 						body);
 			}
 
@@ -608,33 +608,29 @@ public class WebClientStreamableHttpTransport implements McpClientTransport {
 	/**
 	 * Needed for Spring 5 compatibility
 	 */
-	@SuppressWarnings("deprecation")
 	private static boolean isBadRequest(final WebClientResponseException responseException) {
-		return responseException.getRawStatusCode() == HttpStatus.BAD_REQUEST.value();
+		return responseException.getStatusCode().value() == HttpStatus.BAD_REQUEST.value();
 	}
 
 	/**
 	 * Needed for Spring 5 compatibility
 	 */
-	@SuppressWarnings("deprecation")
 	private static boolean isNotFound(ClientResponse response) {
-		return response.rawStatusCode() == HttpStatus.NOT_FOUND.value();
+		return response.statusCode().value() == HttpStatus.NOT_FOUND.value();
 	}
 
 	/**
 	 * Needed for Spring 5 compatibility
 	 */
-	@SuppressWarnings("deprecation")
 	private static boolean isNotAllowed(ClientResponse response) {
-		return response.rawStatusCode() == HttpStatus.METHOD_NOT_ALLOWED.value();
+		return response.statusCode().value() == HttpStatus.METHOD_NOT_ALLOWED.value();
 	}
 
 	/**
 	 * Needed for Spring 5 compatibility
 	 */
-	@SuppressWarnings("deprecation")
 	private static boolean is2xx(final ClientResponse response) {
-		return response.rawStatusCode() >= 200 && response.rawStatusCode() < 300;
+		return response.statusCode().value() >= 200 && response.statusCode().value() < 300;
 	}
 
 }


### PR DESCRIPTION
  - Replace deprecated rawStatusCode() for Spring Framework 7.0 compatibility in WebClientStreamableHttpTransport

   - Replace usage of rawStatusCode() and getRawStatusCode() methods with statusCode().value() to ensure compatibility with Spring Framework 7.0 where these deprecated methods have been removed.