### PR TITLE
fix unit tests fail in offline environment (#636)

### DIFF
--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/AbstractMcpClientServerIntegrationTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/AbstractMcpClientServerIntegrationTests.java
@@ -4,10 +4,13 @@
 
 package io.modelcontextprotocol.server;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +48,7 @@ import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import io.modelcontextprotocol.util.Utils;
 import net.javacrumbs.jsonunit.core.Option;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -58,17 +62,29 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertWith;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public abstract class AbstractMcpClientServerIntegrationTests {
 
 	protected ConcurrentHashMap<String, McpClient.SyncSpec> clientBuilders = new ConcurrentHashMap<>();
+
+	protected static HttpClient mockClient = mock(HttpClient.class);
 
 	abstract protected void prepareClients(int port, String mcpEndpoint);
 
 	abstract protected McpServer.AsyncSpecification<?> prepareAsyncServerBuilder();
 
 	abstract protected McpServer.SyncSpecification<?> prepareSyncServerBuilder();
+
+	@BeforeAll
+	protected static void initMockClient() throws IOException, InterruptedException {
+		HttpResponse<String> mockResponse = mock(HttpResponse.class);
+		when(mockResponse.body()).thenReturn(Files.readString(Path.of("pom.xml").toAbsolutePath()));
+		when(mockResponse.statusCode()).thenReturn(200);
+		when(mockClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(mockResponse);
+	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
 	@MethodSource("clientsForTesting")
@@ -774,12 +790,11 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			.callHandler((exchange, request) -> {
 
 				try {
-					HttpResponse<String> response = HttpClient.newHttpClient()
-						.send(HttpRequest.newBuilder()
-							.uri(URI.create(
-									"https://raw.githubusercontent.com/modelcontextprotocol/java-sdk/refs/heads/main/README.md"))
-							.GET()
-							.build(), HttpResponse.BodyHandlers.ofString());
+					HttpResponse<String> response = mockClient.send(HttpRequest.newBuilder()
+						.uri(URI.create(
+								"https://raw.githubusercontent.com/modelcontextprotocol/java-sdk/refs/heads/main/README.md"))
+						.GET()
+						.build(), HttpResponse.BodyHandlers.ofString());
 					String responseBody = response.body();
 					responseBodyIsNullOrBlank.set(!Utils.hasText(responseBody));
 				}
@@ -923,12 +938,11 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			.callHandler((exchange, request) -> {
 				// perform a blocking call to a remote service
 				try {
-					HttpResponse<String> response = HttpClient.newHttpClient()
-						.send(HttpRequest.newBuilder()
-							.uri(URI.create(
-									"https://raw.githubusercontent.com/modelcontextprotocol/java-sdk/refs/heads/main/README.md"))
-							.GET()
-							.build(), HttpResponse.BodyHandlers.ofString());
+					HttpResponse<String> response = mockClient.send(HttpRequest.newBuilder()
+						.uri(URI.create(
+								"https://raw.githubusercontent.com/modelcontextprotocol/java-sdk/refs/heads/main/README.md"))
+						.GET()
+						.build(), HttpResponse.BodyHandlers.ofString());
 					String responseBody = response.body();
 					assertThat(responseBody).isNotBlank();
 				}
@@ -948,12 +962,11 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 		try (var mcpClient = clientBuilder.toolsChangeConsumer(toolsUpdate -> {
 			// perform a blocking call to a remote service
 			try {
-				HttpResponse<String> response = HttpClient.newHttpClient()
-					.send(HttpRequest.newBuilder()
-						.uri(URI.create(
-								"https://raw.githubusercontent.com/modelcontextprotocol/java-sdk/refs/heads/main/README.md"))
-						.GET()
-						.build(), HttpResponse.BodyHandlers.ofString());
+				HttpResponse<String> response = mockClient.send(HttpRequest.newBuilder()
+					.uri(URI.create(
+							"https://raw.githubusercontent.com/modelcontextprotocol/java-sdk/refs/heads/main/README.md"))
+					.GET()
+					.build(), HttpResponse.BodyHandlers.ofString());
 				String responseBody = response.body();
 				assertThat(responseBody).isNotBlank();
 				toolsRef.set(toolsUpdate);

--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/HttpServletStatelessIntegrationTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/HttpServletStatelessIntegrationTests.java
@@ -43,7 +43,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.web.client.RestClient;
 
 import static io.modelcontextprotocol.server.transport.HttpServletStatelessServerTransport.APPLICATION_JSON;
 import static io.modelcontextprotocol.server.transport.HttpServletStatelessServerTransport.TEXT_EVENT_STREAM;
@@ -122,12 +121,14 @@ class HttpServletStatelessIntegrationTests {
 				Tool.builder().name("tool1").title("tool1 description").inputSchema(EMPTY_JSON_SCHEMA).build(),
 				(transportContext, request) -> {
 					// perform a blocking call to a remote service
-					String response = RestClient.create()
-						.get()
-						.uri("https://raw.githubusercontent.com/modelcontextprotocol/java-sdk/refs/heads/main/README.md")
-						.retrieve()
-						.body(String.class);
+					String response = "{\"result\":\"test result\"}";
 					assertThat(response).isNotBlank();
+					try {
+						Thread.sleep(1000L);
+					}
+					catch (InterruptedException e) {
+						throw new RuntimeException(e);
+					}
 					return callResponse;
 				});
 

--- a/mcp-test/src/main/java/io/modelcontextprotocol/AbstractStatelessIntegrationTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/AbstractStatelessIntegrationTests.java
@@ -4,10 +4,13 @@
 
 package io.modelcontextprotocol;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -27,9 +30,9 @@ import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import net.javacrumbs.jsonunit.core.Option;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.publisher.Mono;
 
 import static io.modelcontextprotocol.util.ToolsUtils.EMPTY_JSON_SCHEMA;
@@ -38,16 +41,29 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public abstract class AbstractStatelessIntegrationTests {
 
 	protected ConcurrentHashMap<String, McpClient.SyncSpec> clientBuilders = new ConcurrentHashMap<>();
+
+	protected static HttpClient mockClient = mock(HttpClient.class);
 
 	abstract protected void prepareClients(int port, String mcpEndpoint);
 
 	abstract protected StatelessAsyncSpecification prepareAsyncServerBuilder();
 
 	abstract protected StatelessSyncSpecification prepareSyncServerBuilder();
+
+	@BeforeAll
+	protected static void initMockClient() throws IOException, InterruptedException {
+		HttpResponse<String> mockResponse = mock(HttpResponse.class);
+		when(mockResponse.body()).thenReturn(Files.readString(Path.of("pom.xml").toAbsolutePath()));
+		when(mockResponse.statusCode()).thenReturn(200);
+		when(mockClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(mockResponse);
+	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
 	@MethodSource("clientsForTesting")
@@ -89,12 +105,11 @@ public abstract class AbstractStatelessIntegrationTests {
 			.callHandler((ctx, request) -> {
 
 				try {
-					HttpResponse<String> response = HttpClient.newHttpClient()
-						.send(HttpRequest.newBuilder()
-							.uri(URI.create(
-									"https://raw.githubusercontent.com/modelcontextprotocol/java-sdk/refs/heads/main/README.md"))
-							.GET()
-							.build(), HttpResponse.BodyHandlers.ofString());
+					HttpResponse<String> response = mockClient.send(HttpRequest.newBuilder()
+						.uri(URI.create(
+								"https://raw.githubusercontent.com/modelcontextprotocol/java-sdk/refs/heads/main/README.md"))
+						.GET()
+						.build(), HttpResponse.BodyHandlers.ofString());
 					String responseBody = response.body();
 					assertThat(responseBody).isNotBlank();
 				}
@@ -177,12 +192,11 @@ public abstract class AbstractStatelessIntegrationTests {
 			.callHandler((ctx, request) -> {
 				// perform a blocking call to a remote service
 				try {
-					HttpResponse<String> response = HttpClient.newHttpClient()
-						.send(HttpRequest.newBuilder()
-							.uri(URI.create(
-									"https://raw.githubusercontent.com/modelcontextprotocol/java-sdk/refs/heads/main/README.md"))
-							.GET()
-							.build(), HttpResponse.BodyHandlers.ofString());
+					HttpResponse<String> response = mockClient.send(HttpRequest.newBuilder()
+						.uri(URI.create(
+								"https://raw.githubusercontent.com/modelcontextprotocol/java-sdk/refs/heads/main/README.md"))
+						.GET()
+						.build(), HttpResponse.BodyHandlers.ofString());
 					String responseBody = response.body();
 					assertThat(responseBody).isNotBlank();
 				}
@@ -202,12 +216,11 @@ public abstract class AbstractStatelessIntegrationTests {
 		try (var mcpClient = clientBuilder.toolsChangeConsumer(toolsUpdate -> {
 			// perform a blocking call to a remote service
 			try {
-				HttpResponse<String> response = HttpClient.newHttpClient()
-					.send(HttpRequest.newBuilder()
-						.uri(URI.create(
-								"https://raw.githubusercontent.com/modelcontextprotocol/java-sdk/refs/heads/main/README.md"))
-						.GET()
-						.build(), HttpResponse.BodyHandlers.ofString());
+				HttpResponse<String> response = mockClient.send(HttpRequest.newBuilder()
+					.uri(URI.create(
+							"https://raw.githubusercontent.com/modelcontextprotocol/java-sdk/refs/heads/main/README.md"))
+					.GET()
+					.build(), HttpResponse.BodyHandlers.ofString());
 				String responseBody = response.body();
 				assertThat(responseBody).isNotBlank();
 			}


### PR DESCRIPTION
(#636)

<!-- Provide a brief summary of your changes -->
Added mock http client to test cases that depends on a GET request to [raw.githubusercontent.com/modelcontextprotocol/java-sdk/refs/heads/main/README.md](https://raw.githubusercontent.com/modelcontextprotocol/java-sdk/refs/heads/main/README.md), which could fail if the request timed out. 
The mock http client will read pom.xml (which is guaranteed to exist in user.dir) as a mock response. 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
For offline CI environments, the test cases could be modified to avoid dependency on connectivity to github server. 

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
This is a modification to test cases, the modified test cases have passed and also manually debugged to make sure that they went through the same code branch before changes. 

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes to source code. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
