### PR TITLE
feat: mvc sse session support session timeout configuration

### DIFF
--- a/mcp-spring/mcp-spring-webmvc/src/test/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransportProviderTests.java
+++ b/mcp-spring/mcp-spring-webmvc/src/test/java/io/modelcontextprotocol/server/transport/WebMvcSseServerTransportProviderTests.java
@@ -24,6 +24,9 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.function.RouterFunction;
 import org.springframework.web.servlet.function.ServerResponse;
 
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -66,7 +69,7 @@ class WebMvcSseServerTransportProviderTests {
 	}
 
 	@Test
-	void validBaseUrl() {
+	void validBaseUrl() throws InterruptedException {
 		McpServer.async(mcpServerTransportProvider).serverInfo("test-server", "1.0.0").build();
 		try (var client = clientBuilder.clientInfo(new McpSchema.Implementation("Sample " + "client", "0.0.0"))
 			.build()) {
@@ -106,6 +109,7 @@ class WebMvcSseServerTransportProviderTests {
 				.sseEndpoint(WebMvcSseServerTransportProvider.DEFAULT_SSE_ENDPOINT)
 				.jsonMapper(McpJsonMapper.getDefault())
 				.contextExtractor(req -> McpTransportContext.EMPTY)
+				.sessionTimeout(Duration.ofSeconds(1))
 				.build();
 		}
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

In certain specific scenarios, it's necessary to configure a session timeout for the SSE server. Currently, the default behavior is to never time out, and we'd like to support custom timeout configuration.



## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
