### PR TITLE
fix: regressed invalid automatic module name in 0.13.0+

### DIFF
--- a/mcp-core/pom.xml
+++ b/mcp-core/pom.xml
@@ -38,7 +38,6 @@
 								version:                ${versionmask;===;${version_cleanup;${project.version}}}
 								Bundle-SymbolicName:    ${project.groupId}.${project.artifactId}
 								Bundle-Version:         ${version}
-								Automatic-Module-Name:  ${project.groupId}.${project.artifactId}
 								Import-Package:         jakarta.*;resolution:=optional, \
 								                        *;
 								Export-Package:         io.modelcontextprotocol.*;version="${version}";-noimport:=true

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
 		<bnd-maven-plugin.version>7.1.0</bnd-maven-plugin.version>
 		<json-unit-assertj.version>4.1.0</json-unit-assertj.version>
 		<json-schema-validator.version>2.0.0</json-schema-validator.version>
-
+        <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
 	</properties>
 
 	<modules>
@@ -113,6 +113,28 @@
 
 	<build>
 		<plugins>
+            <!-- Derive automatic module name from groupId, artifactId, replacing '-' with '.' -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>${build-helper-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>rename-property</id>
+                        <goals>
+                            <goal>regex-property</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <name>automatic.module.name</name>
+                            <value>${project.groupId}.${project.artifactId}</value>
+                            <regex>-</regex>
+                            <replacement>.</replacement>
+                            <failIfNoMatch>false</failIfNoMatch>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 			<plugin>
 				<groupId>io.spring.javaformat</groupId>
 				<artifactId>spring-javaformat-maven-plugin</artifactId>
@@ -206,6 +228,7 @@
 						<manifestEntries>
 							<Implementation-Title>${project.artifactId}</Implementation-Title>
 							<Implementation-Version>${project.version}</Implementation-Version>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
 						</manifestEntries>
 					</archive>
 				</configuration>


### PR DESCRIPTION
Fixes #560

- Uses `build-helper-maven-plugin` to generate a Maven property named `automatic.module.name` generated from `${project.groupId}.${project.artifactId}`, whilst ensuring the value is a syntactically valid Java Module name, by replacing any `-` characters with `.` characters
- Remove legacy configuration of `Automatic-Module-Name` in `./mcp-core/pom.xml` `bnd-maven-plugin` configuration which was generating a value with an invalid value (Java Module names cannot contain the `-` character)
- Modifies `./pom.xml` `maven-jar-plugin` configuration to add `Automatic-Module-Name` property to the JAR manifest. Doing this here, ensures each sub-project JAR has a valid automatic module name

## Motivation and Context
In versions 0.12.1  and older, the SDK consisted of a single module, `mcp`. The `Automatic-Module-Name` manifest attribute was generated by the `bnd-maven-plugin`. Note that the single module name does not contain any dash (`-`) characters.

In 0.13.0 and later, the SDK was refactored into multiple modules, `mcp-core`, `mcp-json` etc. Note the addition of the `-` character in the artifactId. The existing logic for generating `Automatic-Module-Name` was not updated, resulting in syntactically invalid values being generated for the value, as Java module names are not allowed contain the `-` character:

```
Automatic-Module-Name: io.modelcontextprotocol.sdk.mcp-core
```
- This invalid module name prevents use of 0.13.0 and later versions of the SDK in any Java application that uses Java Modules.

With the changes described above, this becomes:

```
Automatic-Module-Name: io.modelcontextprotocol.sdk.mcp.core
```
- Java module based applications can once again use the MCP SDK

## How Has This Been Tested?
- [x] Checked the contents of `META/MANIFEST.MF` in each jar is a valid Java module name
- [x] Rebuilt the downstream application that was regressed by this issue using the rebuilt jars. Compile time error previously reported no longer occurs

## Breaking Changes
No breaking changes, no change required by users.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
- One new maven plugin: `org.codehaus.mojo:build-helper-maven-plugin` is added to the root `pom.xml`. This purpose of this plugin is to generate and rewrite the value of `${automatic.module.name}` property into a syntactically valid Java module name
- Configuring `Automatic-Module-Name` is moved from the `bnd-maven-plugin` configuration to the `maven-jar-plugin` configuration, so it can be uniformly applied to all sub-modules. 
