### PR TITLE
issue#626 Allow dynamic generation of tool definition

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServerFeatures.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServerFeatures.java
@@ -45,7 +45,9 @@ public class McpServerFeatures {
 			Map<String, McpServerFeatures.AsyncPromptSpecification> prompts,
 			Map<McpSchema.CompleteReference, McpServerFeatures.AsyncCompletionSpecification> completions,
 			List<BiFunction<McpAsyncServerExchange, List<McpSchema.Root>, Mono<Void>>> rootsChangeConsumers,
-			String instructions) {
+			String instructions,
+			boolean callGetToolCallbacksEverytime,
+			List<ToolCallbackProvider> toolCallbackProviders) {
 
 		/**
 		 * Create an instance and validate the arguments.
@@ -58,6 +60,8 @@ public class McpServerFeatures {
 		 * @param rootsChangeConsumers The list of consumers that will be notified when
 		 * the roots list changes
 		 * @param instructions The server instructions text
+		 * @param callGetToolCallbacksEverytime If true, call getToolCallbacks on every tools/list request
+		 * @param toolCallbackProviders The list of tool callback providers
 		 */
 		Async(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
 				List<McpServerFeatures.AsyncToolSpecification> tools, Map<String, AsyncResourceSpecification> resources,
@@ -65,7 +69,9 @@ public class McpServerFeatures {
 				Map<String, McpServerFeatures.AsyncPromptSpecification> prompts,
 				Map<McpSchema.CompleteReference, McpServerFeatures.AsyncCompletionSpecification> completions,
 				List<BiFunction<McpAsyncServerExchange, List<McpSchema.Root>, Mono<Void>>> rootsChangeConsumers,
-				String instructions) {
+				String instructions,
+				boolean callGetToolCallbacksEverytime,
+				List<ToolCallbackProvider> toolCallbackProviders) {
 
 			Assert.notNull(serverInfo, "Server info must not be null");
 
@@ -89,6 +95,8 @@ public class McpServerFeatures {
 			this.completions = (completions != null) ? completions : Map.of();
 			this.rootsChangeConsumers = (rootsChangeConsumers != null) ? rootsChangeConsumers : List.of();
 			this.instructions = instructions;
+			this.callGetToolCallbacksEverytime = callGetToolCallbacksEverytime;
+			this.toolCallbackProviders = (toolCallbackProviders != null) ? toolCallbackProviders : List.of();
 		}
 
 		/**
@@ -136,7 +144,8 @@ public class McpServerFeatures {
 			}
 
 			return new Async(syncSpec.serverInfo(), syncSpec.serverCapabilities(), tools, resources, resourceTemplates,
-					prompts, completions, rootChangeConsumers, syncSpec.instructions());
+					prompts, completions, rootChangeConsumers, syncSpec.instructions(),
+					syncSpec.callGetToolCallbacksEverytime(), syncSpec.toolCallbackProviders());
 		}
 	}
 
@@ -159,7 +168,9 @@ public class McpServerFeatures {
 			Map<String, McpServerFeatures.SyncResourceTemplateSpecification> resourceTemplates,
 			Map<String, McpServerFeatures.SyncPromptSpecification> prompts,
 			Map<McpSchema.CompleteReference, McpServerFeatures.SyncCompletionSpecification> completions,
-			List<BiConsumer<McpSyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumers, String instructions) {
+			List<BiConsumer<McpSyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumers, String instructions,
+			boolean callGetToolCallbacksEverytime,
+			List<ToolCallbackProvider> toolCallbackProviders) {
 
 		/**
 		 * Create an instance and validate the arguments.
@@ -172,6 +183,8 @@ public class McpServerFeatures {
 		 * @param rootsChangeConsumers The list of consumers that will be notified when
 		 * the roots list changes
 		 * @param instructions The server instructions text
+		 * @param callGetToolCallbacksEverytime If true, call getToolCallbacks on every tools/list request
+		 * @param toolCallbackProviders The list of tool callback providers
 		 */
 		Sync(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
 				List<McpServerFeatures.SyncToolSpecification> tools,
@@ -180,7 +193,9 @@ public class McpServerFeatures {
 				Map<String, McpServerFeatures.SyncPromptSpecification> prompts,
 				Map<McpSchema.CompleteReference, McpServerFeatures.SyncCompletionSpecification> completions,
 				List<BiConsumer<McpSyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumers,
-				String instructions) {
+				String instructions,
+				boolean callGetToolCallbacksEverytime,
+				List<ToolCallbackProvider> toolCallbackProviders) {
 
 			Assert.notNull(serverInfo, "Server info must not be null");
 
@@ -204,6 +219,8 @@ public class McpServerFeatures {
 			this.completions = (completions != null) ? completions : new HashMap<>();
 			this.rootsChangeConsumers = (rootsChangeConsumers != null) ? rootsChangeConsumers : new ArrayList<>();
 			this.instructions = instructions;
+			this.callGetToolCallbacksEverytime = callGetToolCallbacksEverytime;
+			this.toolCallbackProviders = (toolCallbackProviders != null) ? toolCallbackProviders : new ArrayList<>();
 		}
 
 	}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessServerFeatures.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessServerFeatures.java
@@ -44,7 +44,9 @@ public class McpStatelessServerFeatures {
 			Map<String, McpStatelessServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates,
 			Map<String, McpStatelessServerFeatures.AsyncPromptSpecification> prompts,
 			Map<McpSchema.CompleteReference, McpStatelessServerFeatures.AsyncCompletionSpecification> completions,
-			String instructions) {
+			String instructions,
+			boolean callGetToolCallbacksEverytime,
+			List<ToolCallbackProvider> toolCallbackProviders) {
 
 		/**
 		 * Create an instance and validate the arguments.
@@ -55,6 +57,8 @@ public class McpStatelessServerFeatures {
 		 * @param resourceTemplates The map of resource templates
 		 * @param prompts The map of prompt specifications
 		 * @param instructions The server instructions text
+		 * @param callGetToolCallbacksEverytime If true, call getToolCallbacks on every tools/list request
+		 * @param toolCallbackProviders The list of tool callback providers
 		 */
 		Async(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
 				List<McpStatelessServerFeatures.AsyncToolSpecification> tools,
@@ -62,7 +66,9 @@ public class McpStatelessServerFeatures {
 				Map<String, McpStatelessServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates,
 				Map<String, McpStatelessServerFeatures.AsyncPromptSpecification> prompts,
 				Map<McpSchema.CompleteReference, McpStatelessServerFeatures.AsyncCompletionSpecification> completions,
-				String instructions) {
+				String instructions,
+				boolean callGetToolCallbacksEverytime,
+				List<ToolCallbackProvider> toolCallbackProviders) {
 
 			Assert.notNull(serverInfo, "Server info must not be null");
 
@@ -82,6 +88,8 @@ public class McpStatelessServerFeatures {
 			this.prompts = (prompts != null) ? prompts : Map.of();
 			this.completions = (completions != null) ? completions : Map.of();
 			this.instructions = instructions;
+			this.callGetToolCallbacksEverytime = callGetToolCallbacksEverytime;
+			this.toolCallbackProviders = (toolCallbackProviders != null) ? toolCallbackProviders : List.of();
 		}
 
 		/**
@@ -121,7 +129,8 @@ public class McpStatelessServerFeatures {
 			});
 
 			return new Async(syncSpec.serverInfo(), syncSpec.serverCapabilities(), tools, resources, resourceTemplates,
-					prompts, completions, syncSpec.instructions());
+					prompts, completions, syncSpec.instructions(),
+					syncSpec.callGetToolCallbacksEverytime(), syncSpec.toolCallbackProviders());
 		}
 	}
 
@@ -142,7 +151,9 @@ public class McpStatelessServerFeatures {
 			Map<String, McpStatelessServerFeatures.SyncResourceTemplateSpecification> resourceTemplates,
 			Map<String, McpStatelessServerFeatures.SyncPromptSpecification> prompts,
 			Map<McpSchema.CompleteReference, McpStatelessServerFeatures.SyncCompletionSpecification> completions,
-			String instructions) {
+			String instructions,
+			boolean callGetToolCallbacksEverytime,
+			List<ToolCallbackProvider> toolCallbackProviders) {
 
 		/**
 		 * Create an instance and validate the arguments.
@@ -153,6 +164,8 @@ public class McpStatelessServerFeatures {
 		 * @param resourceTemplates The map of resource templates
 		 * @param prompts The map of prompt specifications
 		 * @param instructions The server instructions text
+		 * @param callGetToolCallbacksEverytime If true, call getToolCallbacks on every tools/list request
+		 * @param toolCallbackProviders The list of tool callback providers
 		 */
 		Sync(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
 				List<McpStatelessServerFeatures.SyncToolSpecification> tools,
@@ -160,7 +173,9 @@ public class McpStatelessServerFeatures {
 				Map<String, McpStatelessServerFeatures.SyncResourceTemplateSpecification> resourceTemplates,
 				Map<String, McpStatelessServerFeatures.SyncPromptSpecification> prompts,
 				Map<McpSchema.CompleteReference, McpStatelessServerFeatures.SyncCompletionSpecification> completions,
-				String instructions) {
+				String instructions,
+				boolean callGetToolCallbacksEverytime,
+				List<ToolCallbackProvider> toolCallbackProviders) {
 
 			Assert.notNull(serverInfo, "Server info must not be null");
 
@@ -183,6 +198,8 @@ public class McpStatelessServerFeatures {
 			this.prompts = (prompts != null) ? prompts : new HashMap<>();
 			this.completions = (completions != null) ? completions : new HashMap<>();
 			this.instructions = instructions;
+			this.callGetToolCallbacksEverytime = callGetToolCallbacksEverytime;
+			this.toolCallbackProviders = (toolCallbackProviders != null) ? toolCallbackProviders : new ArrayList<>();
 		}
 
 	}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/ToolCallbackProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/ToolCallbackProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import java.util.List;
+
+/**
+ * Provider interface for dynamically generating tool definitions.
+ * When {@code callGetToolCallbacksEverytime} is enabled, this provider's
+ * {@link #getToolCallbacks()} method will be called on every tools/list request,
+ * allowing for dynamic tool generation based on the current request context.
+ *
+ * @author Generated
+ */
+public interface ToolCallbackProvider {
+
+    /**
+     * Returns a list of tool specifications that should be included in the tools/list response.
+     * This method is called either during server startup (when {@code callGetToolCallbacksEverytime}
+     * is false) or on every tools/list request (when {@code callGetToolCallbacksEverytime} is true).
+     *
+     * @return A list of tool specifications. Must not be null, but can be empty.
+     */
+    List<McpServerFeatures.AsyncToolSpecification> getToolCallbacks();
+
+}
+


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
This change implements generating tool definitions dynamically in MCP Server everytime it receives a tools/list call from an MCP Client. This change implements issue# 626 
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Sometimes it is desirable to generate list of tools based on the user signing in or using the MCP Client. 
## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
No
## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No. The change is backward compatible
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ X] My code follows the repository's style guidelines
- [X ] New and existing tests pass locally
- [X ] I have added appropriate error handling
- [ X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
