### PR TITLE
fix: Fixed html encoding in javadoc

### DIFF
--- a/mcp-json/src/main/java/io/modelcontextprotocol/json/TypeRef.java
+++ b/mcp-json/src/main/java/io/modelcontextprotocol/json/TypeRef.java
@@ -9,7 +9,7 @@ import java.lang.reflect.Type;
 
 /**
  * Captures generic type information at runtime for parameterized JSON (de)serialization.
- * Usage: TypeRef<List<Foo>> ref = new TypeRef<>(){};
+ * Usage: TypeRef&lt;List&lt;Foo&gt;&gt; ref = new TypeRef&lt;&gt;(){};
  */
 public abstract class TypeRef<T> {
 


### PR DESCRIPTION
Fix for javadoc generation: html encoding in TypeRef.java
Together with OSGi related [PR](https://github.com/modelcontextprotocol/java-sdk/pull/705) will fix javadoc generation with command `mvn javadoc:javadoc -Pjavadoc`