### PR TITLE
add 2025-11-25 version to ProtocolVersions

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/ProtocolVersions.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/ProtocolVersions.java
@@ -20,4 +20,9 @@ public interface ProtocolVersions {
 	 */
 	String MCP_2025_06_18 = "2025-06-18";
 
+    /**
+     * MCP protocol version for 2025-11-25.
+     * https://modelcontextprotocol.io/specification/2025-11-25
+     */
+    String MCP_2025_11_25 = "2025-11-25";
 }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
The [25 of November 2025 protocol version](https://modelcontextprotocol.io/specification/2025-11-25) was missing from  the `ProtocolVersions` enum.

## How Has This Been Tested?
No test. 

## Breaking Changes
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
