### PR TITLE
Expose resourcesUpdateConsumer() in sync client

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/McpClient.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/McpClient.java
@@ -4,17 +4,8 @@
 
 package io.modelcontextprotocol.client;
 
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Supplier;
-
-import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
 import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.ClientCapabilities;
@@ -27,6 +18,15 @@ import io.modelcontextprotocol.spec.McpSchema.Root;
 import io.modelcontextprotocol.spec.McpTransport;
 import io.modelcontextprotocol.util.Assert;
 import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Factory class for creating Model Context Protocol (MCP) clients. MCP is a protocol that
@@ -75,6 +75,7 @@ import reactor.core.publisher.Mono;
  *     .resourcesChangeConsumer(resources -> Mono.fromRunnable(() -> System.out.println("Resources updated: " + resources)))
  *     .promptsChangeConsumer(prompts -> Mono.fromRunnable(() -> System.out.println("Prompts updated: " + prompts)))
  *     .loggingConsumer(message -> Mono.fromRunnable(() -> System.out.println("Log message: " + message)))
+ *     .resourcesUpdateConsumer(resourceContents -> Mono.fromRunnable(() -> System.out.println("Resources contents updated: " + resourceContents)))
  *     .build();
  * }</pre>
  *
@@ -343,6 +344,22 @@ public interface McpClient {
 		public SyncSpec resourcesChangeConsumer(Consumer<List<McpSchema.Resource>> resourcesChangeConsumer) {
 			Assert.notNull(resourcesChangeConsumer, "Resources change consumer must not be null");
 			this.resourcesChangeConsumers.add(resourcesChangeConsumer);
+			return this;
+		}
+
+		/**
+		 * Adds a consumer to be notified when a specific resource is updated. This allows
+		 * the client to react to changes in individual resources, such as updates to
+		 * their content or metadata.
+		 * @param resourcesUpdateConsumer A consumer function that processes the updated
+		 * resource and returns a Mono indicating the completion of the processing. Must
+		 * not be null.
+		 * @return This builder instance for method chaining.
+		 * @throws IllegalArgumentException If the resourcesUpdateConsumer is null.
+		 */
+		public SyncSpec resourcesUpdateConsumer(Consumer<List<McpSchema.ResourceContents>> resourcesUpdateConsumer) {
+			Assert.notNull(resourcesUpdateConsumer, "Resources update consumer must not be null");
+			this.resourcesUpdateConsumers.add(resourcesUpdateConsumer);
 			return this;
 		}
 

--- a/mcp-core/src/test/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
@@ -536,11 +536,13 @@ public abstract class AbstractMcpSyncClientTests {
 		AtomicBoolean toolsNotificationReceived = new AtomicBoolean(false);
 		AtomicBoolean resourcesNotificationReceived = new AtomicBoolean(false);
 		AtomicBoolean promptsNotificationReceived = new AtomicBoolean(false);
+		AtomicBoolean resourcesUpdatedNotificationReceived = new AtomicBoolean(false);
 
 		withClient(createMcpTransport(),
 				builder -> builder.toolsChangeConsumer(tools -> toolsNotificationReceived.set(true))
 					.resourcesChangeConsumer(resources -> resourcesNotificationReceived.set(true))
-					.promptsChangeConsumer(prompts -> promptsNotificationReceived.set(true)),
+					.promptsChangeConsumer(prompts -> promptsNotificationReceived.set(true))
+					.resourcesUpdateConsumer(resources -> resourcesUpdatedNotificationReceived.set(true)),
 				client -> {
 
 					assertThatCode(() -> {

--- a/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
@@ -535,11 +535,13 @@ public abstract class AbstractMcpSyncClientTests {
 		AtomicBoolean toolsNotificationReceived = new AtomicBoolean(false);
 		AtomicBoolean resourcesNotificationReceived = new AtomicBoolean(false);
 		AtomicBoolean promptsNotificationReceived = new AtomicBoolean(false);
+		AtomicBoolean resourcesUpdatedNotificationReceived = new AtomicBoolean(false);
 
 		withClient(createMcpTransport(),
 				builder -> builder.toolsChangeConsumer(tools -> toolsNotificationReceived.set(true))
 					.resourcesChangeConsumer(resources -> resourcesNotificationReceived.set(true))
-					.promptsChangeConsumer(prompts -> promptsNotificationReceived.set(true)),
+					.promptsChangeConsumer(prompts -> promptsNotificationReceived.set(true))
+					.resourcesUpdateConsumer(resources -> resourcesUpdatedNotificationReceived.set(true)),
 				client -> {
 
 					assertThatCode(() -> {


### PR DESCRIPTION
`resourcesUpdateConsumer()` was missing from the sync client. Add it.

## Motivation and Context
Because it's missing

## How Has This Been Tested?
Integrated with existing, similar tests (which are very minimal)

## Breaking Changes
None

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
n/a
