### PR TITLE
Upgrade to testcontainers 1.21.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 		<assert4j.version>3.27.6</assert4j.version>
 		<junit.version>5.10.2</junit.version>
 		<mockito.version>5.20.0</mockito.version>
-		<testcontainers.version>1.20.4</testcontainers.version>
+		<testcontainers.version>1.21.4</testcontainers.version>
 		<byte-buddy.version>1.17.8</byte-buddy.version>
 		<toxiproxy.version>1.21.0</toxiproxy.version>
 


### PR DESCRIPTION
To fix a "docker-machine executable was not found on PATH" error with recent Docker versions (impact at least Docker 4.55 and 4.56).