### PR TITLE
Use junit.version for all junit dependencies

### DIFF
--- a/mcp-spring/mcp-spring-webflux/pom.xml
+++ b/mcp-spring/mcp-spring-webflux/pom.xml
@@ -131,7 +131,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-params</artifactId>
-			<version>${junit-jupiter.version}</version>
+			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,6 @@
 		<org.maven.antora-version>1.0.0-alpha.4</org.maven.antora-version>
 		<io.spring.maven.antora-version>0.0.4</io.spring.maven.antora-version>
 		<asciidoctorj-pdf.version>1.6.2</asciidoctorj-pdf.version>
-		<junit-jupiter.version>5.10.5</junit-jupiter.version>
 		<tomcat.version>11.0.2</tomcat.version>
 		<jakarta.servlet.version>6.1.0</jakarta.servlet.version>
 		<awaitility.version>4.2.0</awaitility.version>


### PR DESCRIPTION
While working on the Jackson 3 support I noticed that there were 2 maven properties for handling the junit versions. With this PR this is being cleaned up and aligned to use a single junit version properties for all junit dependencies