### PR TITLE
Decouple mcp-test and mcp-spring modules from Jackson implementation

### DIFF
--- a/mcp-spring/mcp-spring-webflux/pom.xml
+++ b/mcp-spring/mcp-spring-webflux/pom.xml
@@ -22,15 +22,10 @@
 	</scm>
 
 	<dependencies>
-        <dependency>
-            <groupId>io.modelcontextprotocol.sdk</groupId>
-            <artifactId>mcp-json-jackson2</artifactId>
-            <version>0.18.0-SNAPSHOT</version>
-        </dependency>
 
         <dependency>
 			<groupId>io.modelcontextprotocol.sdk</groupId>
-			<artifactId>mcp</artifactId>
+			<artifactId>mcp-core</artifactId>
 			<version>0.18.0-SNAPSHOT</version>
 		</dependency>
 
@@ -45,6 +40,13 @@
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-webflux</artifactId>
 			<version>${springframework.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<artifactId>mcp-json-jackson2</artifactId>
+			<version>0.18.0-SNAPSHOT</version>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>

--- a/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransportTests.java
+++ b/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransportTests.java
@@ -10,8 +10,9 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.modelcontextprotocol.json.McpJsonMapper;
-import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.JSONRPCRequest;
 import org.junit.jupiter.api.AfterAll;
@@ -26,7 +27,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
 import reactor.test.StepVerifier;
-import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.web.reactive.function.client.WebClient;

--- a/mcp-spring/mcp-spring-webmvc/pom.xml
+++ b/mcp-spring/mcp-spring-webmvc/pom.xml
@@ -22,15 +22,10 @@
 	</scm>
 
 	<dependencies>
-        <dependency>
-            <groupId>io.modelcontextprotocol.sdk</groupId>
-            <artifactId>mcp-json-jackson2</artifactId>
-            <version>0.18.0-SNAPSHOT</version>
-        </dependency>
 
         <dependency>
 			<groupId>io.modelcontextprotocol.sdk</groupId>
-			<artifactId>mcp</artifactId>
+			<artifactId>mcp-core</artifactId>
 			<version>0.18.0-SNAPSHOT</version>
 		</dependency>
 
@@ -50,6 +45,13 @@
 		<dependency>
 			<groupId>io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp-spring-webflux</artifactId>
+			<version>0.18.0-SNAPSHOT</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<artifactId>mcp-json-jackson2</artifactId>
 			<version>0.18.0-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>

--- a/mcp-test/pom.xml
+++ b/mcp-test/pom.xml
@@ -23,7 +23,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>io.modelcontextprotocol.sdk</groupId>
-			<artifactId>mcp</artifactId>
+			<artifactId>mcp-core</artifactId>
 			<version>0.18.0-SNAPSHOT</version>
 		</dependency>
 


### PR DESCRIPTION
## Motivation and Context

This is a follow-up to #742.

The `mcp-test`, `mcp-spring-webflux`, and `mcp-spring-webmvc` depended on `mcp` module which transitively brought in Jackson 3 dependencies. These modules are now decoupled and only depend on `mcp-core`.

The test dependencies bring in Jackson 2 for the time being.

This is a breaking change but it is required to allow easily exchanging Jackson2 and Jackson3 modules.

## How Has This Been Tested?

Regular suite of tests.

## Breaking Changes

Yes, the Jackson dependency is no longer implicit and has to be brought in explicitly by users or libraries building on top of these modules. Only the convenience `mcp` module ships Jackson 3 to enable an easy getting-started experience.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
https://github.com/modelcontextprotocol/java-sdk/pull/742#issuecomment-3803950169
