### PR TITLE
Fix: Move markInitialized() and reconnect() after status code check

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
@@ -466,19 +466,21 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 					})).onErrorMap(CompletionException.class, t -> t.getCause()).onErrorComplete().subscribe();
 
 			})).flatMap(responseEvent -> {
-				if (transportSession.markInitialized(
-						responseEvent.responseInfo().headers().firstValue("mcp-session-id").orElseGet(() -> null))) {
-					// Once we have a session, we try to open an async stream for
-					// the server to send notifications and requests out-of-band.
-
-					reconnect(null).contextWrite(deliveredSink.contextView()).subscribe();
-				}
-
 				String sessionRepresentation = sessionIdOrPlaceholder(transportSession);
 
 				int statusCode = responseEvent.responseInfo().statusCode();
 
 				if (statusCode >= 200 && statusCode < 300) {
+					// Only initialize session and open async stream for successful
+					// responses
+					if (transportSession.markInitialized(responseEvent.responseInfo()
+						.headers()
+						.firstValue("mcp-session-id")
+						.orElseGet(() -> null))) {
+						// Once we have a session, we try to open an async stream for
+						// the server to send notifications and requests out-of-band.
+						reconnect(null).contextWrite(deliveredSink.contextView()).subscribe();
+					}
 
 					String contentType = responseEvent.responseInfo()
 						.headers()


### PR DESCRIPTION
## Summary

- Fix bug where `markInitialized()` and `reconnect()` were called before checking the HTTP status code
- This caused unnecessary GET requests when the server returns error status (e.g., 405 Method Not Allowed)
- Both `HttpClientStreamableHttpTransport` and `WebClientStreamableHttpTransport` are fixed

## Problem

When connecting to an MCP server that doesn't support Streamable HTTP transport (returns 405), the transports still called `markInitialized()` and `reconnect()`, triggering unnecessary GET requests. This caused duplicate SSE sessions on the upstream server when using transport fallback.

## Solution

Move `markInitialized()` and `reconnect()` inside the success status code check (2xx), so they are only called for successful responses.

## Test plan

- [x] Existing Streamable HTTP tests pass
- [x] Code compiles without errors

Fixes #773
Related to #362

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)