### PR TITLE
fix: propagate SSE stream errors to messageEndpointSink to prevent sendMessage() hang

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
@@ -11,6 +11,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -399,9 +400,13 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 						logger.warn("SSE stream observed an error", t);
 						sink.error(t);
 					}
+					this.messageEndpointSink.tryEmitError(t);
 					return true;
 				})
 				.doFinally(s -> {
+					this.messageEndpointSink
+						.tryEmitError(new CancellationException("SSE stream ended before receiving the endpoint event"));
+
 					Disposable ref = this.sseSubscription.getAndSet(null);
 					if (ref != null && !ref.isDisposed()) {
 						ref.dispose();


### PR DESCRIPTION
Propagate SSE stream errors to `messageEndpointSink` so that `sendMessage()` fails immediately instead of hanging forever when the SSE connection drops before receiving the endpoint event.

## Motivation and Context

When the SSE stream errors before the `endpoint` event arrives, `messageEndpointSink` is never signaled. Since `sendMessage()` depends on `messageEndpointSink.asMono()` with no timeout, it hangs indefinitely.

Originally reported in #323 (pre-0.11.0, `CountDownLatch`-based). The 0.11.0 refactoring switched to `Sinks.One`, but the core problem remains — and is worse, since `Sinks.One.asMono()` has no built-in timeout.

This PR propagates errors to `messageEndpointSink` in two places:

1. **`onErrorComplete`**: propagates the actual SSE stream error
2. **`doFinally`**: emits `CancellationException` as a safety net for stream completion without error

Duplicate `tryEmitError()` calls are safely ignored by `Sinks.One`.

## How Has This Been Tested?

Added `testSendMessageFailsWhenSseConnectionFails` — connects to a non-existent host, verifies `sendMessage()` returns an error instead of hanging. Without this fix, the test times out.

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Closes #323
Partially addresses #546