### PR TITLE
Deprecate Builder.customizeRequest() in favor of httpRequestCustomizer()

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
@@ -192,7 +192,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 		 * This constructor is deprecated and will be removed or made {@code protected} or
 		 * {@code private} in a future release.
 		 */
-		@Deprecated(forRemoval = true)
+		@Deprecated
 		public Builder(String baseUri) {
 			Assert.hasText(baseUri, "baseUri must not be empty");
 			this.baseUri = baseUri;
@@ -254,10 +254,24 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 		}
 
 		/**
-		 * Customizes the HTTP client builder.
+		 * Applies the given consumer to the shared {@link HttpRequest.Builder} <b>once,
+		 * at build time</b>. Any headers set here (e.g., {@code Authorization}) are
+		 * frozen into the template and copied to every subsequent request via
+		 * {@code requestBuilder.copy()}. They <b>cannot be updated</b> after the
+		 * transport is built.
+		 * <p>
+		 * For dynamic, per-request customization (e.g., OAuth token refresh), use
+		 * {@link #httpRequestCustomizer(McpSyncHttpClientRequestCustomizer)} or
+		 * {@link #asyncHttpRequestCustomizer(McpAsyncHttpClientRequestCustomizer)}
+		 * instead.
 		 * @param requestCustomizer the consumer to customize the HTTP request builder
 		 * @return this builder
+		 * @deprecated Use
+		 * {@link #httpRequestCustomizer(McpSyncHttpClientRequestCustomizer)} or
+		 * {@link #asyncHttpRequestCustomizer(McpAsyncHttpClientRequestCustomizer)} which
+		 * run on every request and support dynamic headers.
 		 */
+		@Deprecated
 		public Builder customizeRequest(final Consumer<HttpRequest.Builder> requestCustomizer) {
 			Assert.notNull(requestCustomizer, "requestCustomizer must not be null");
 			requestCustomizer.accept(requestBuilder);

--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
@@ -707,10 +707,24 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 		}
 
 		/**
-		 * Customizes the HTTP client builder.
+		 * Applies the given consumer to the shared {@link HttpRequest.Builder} <b>once,
+		 * at build time</b>. Any headers set here (e.g., {@code Authorization}) are
+		 * frozen into the template and copied to every subsequent request via
+		 * {@code requestBuilder.copy()}. They <b>cannot be updated</b> after the
+		 * transport is built.
+		 * <p>
+		 * For dynamic, per-request customization (e.g., OAuth token refresh), use
+		 * {@link #httpRequestCustomizer(McpSyncHttpClientRequestCustomizer)} or
+		 * {@link #asyncHttpRequestCustomizer(McpAsyncHttpClientRequestCustomizer)}
+		 * instead.
 		 * @param requestCustomizer the consumer to customize the HTTP request builder
 		 * @return this builder
+		 * @deprecated Use
+		 * {@link #httpRequestCustomizer(McpSyncHttpClientRequestCustomizer)} or
+		 * {@link #asyncHttpRequestCustomizer(McpAsyncHttpClientRequestCustomizer)} which
+		 * run on every request and support dynamic headers.
 		 */
+		@Deprecated
 		public Builder customizeRequest(final Consumer<HttpRequest.Builder> requestCustomizer) {
 			Assert.notNull(requestCustomizer, "requestCustomizer must not be null");
 			requestCustomizer.accept(requestBuilder);


### PR DESCRIPTION
## Motivation and Context

`Builder.customizeRequest()` in `HttpClientSseClientTransport` and `HttpClientStreamableHttpTransport` executes its consumer **once at build time**, mutating the shared `requestBuilder`. Any headers set here (e.g., `Authorization`) are frozen into the template and copied to every subsequent request via `requestBuilder.copy()`.

This silently breaks OAuth token refresh scenarios: after refreshing an access token, the transport continues sending the old expired token because the header was baked in at construction time.

The method name `customizeRequest` strongly suggests per-request behavior, making it easy to use incorrectly. The correct alternatives — `httpRequestCustomizer()` and `asyncHttpRequestCustomizer()` — already exist and run on every request, but there is no deprecation notice or Javadoc warning guiding users toward them.

We encountered this in production where our MCP connector's OAuth token refresh was completely non-functional due to this behavior.

## Changes

- Add `@Deprecated(forRemoval = true)` to `customizeRequest()` in both `HttpClientSseClientTransport.Builder` and `HttpClientStreamableHttpTransport.Builder`
- Update Javadoc to clearly describe the **build-time-only** semantics
- Point users toward `httpRequestCustomizer()` / `asyncHttpRequestCustomizer()` as the per-request alternatives

## How Has This Been Tested?

This is a Javadoc + annotation-only change. Verified compilation passes with `spring-javaformat:apply` and `mvn compile`.

## Breaking Changes

None. This only adds a deprecation warning — no behavioral changes.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Closes #788