### PR TITLE
Fix error behavior on unregistered handlers in stateless server handler

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/DefaultMcpStatelessServerHandler.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/DefaultMcpStatelessServerHandler.java
@@ -32,9 +32,9 @@ class DefaultMcpStatelessServerHandler implements McpStatelessServerHandler {
 			McpSchema.JSONRPCRequest request) {
 		McpStatelessRequestHandler<?> requestHandler = this.requestHandlers.get(request.method());
 		if (requestHandler == null) {
-			return Mono.error(McpError.builder(McpSchema.ErrorCodes.METHOD_NOT_FOUND)
-				.message("Missing handler for request type: " + request.method())
-				.build());
+			return Mono.just(new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), null,
+					new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.METHOD_NOT_FOUND,
+							"Method not found: " + request.method(), null)));
 		}
 		return requestHandler.handle(transportContext, request.params())
 			.map(result -> McpSchema.JSONRPCResponse.result(request.id(), result))

--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/DefaultMcpStatelessServerHandlerTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/DefaultMcpStatelessServerHandlerTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultMcpStatelessServerHandlerTests {
+
+	@Test
+	void testHandleRequestWithUnregisteredMethod() {
+		// no request/initialization handlers
+		DefaultMcpStatelessServerHandler handler = new DefaultMcpStatelessServerHandler(Collections.emptyMap(),
+				Collections.emptyMap());
+
+		// unregistered method
+		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, "resources/list",
+				"test-id-123", null);
+
+		StepVerifier.create(handler.handleRequest(McpTransportContext.EMPTY, request)).assertNext(response -> {
+			assertThat(response).isNotNull();
+			assertThat(response.jsonrpc()).isEqualTo(McpSchema.JSONRPC_VERSION);
+			assertThat(response.id()).isEqualTo("test-id-123");
+			assertThat(response.result()).isNull();
+
+			assertThat(response.error()).isNotNull();
+			assertThat(response.error().code()).isEqualTo(McpSchema.ErrorCodes.METHOD_NOT_FOUND);
+			assertThat(response.error().message()).isEqualTo("Method not found: resources/list");
+		}).verifyComplete();
+	}
+
+}

--- a/mcp-test/src/test/java/io/modelcontextprotocol/server/HttpServletStatelessIntegrationTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/server/HttpServletStatelessIntegrationTests.java
@@ -4,6 +4,10 @@
 
 package io.modelcontextprotocol.server;
 
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -448,7 +452,7 @@ class HttpServletStatelessIntegrationTests {
 				"type", "object",
 				"properties", Map.of(
 					"name", Map.of("type", "string"),
-					"age", Map.of("type", "number")),					
+					"age", Map.of("type", "number")),
 				"required", List.of("name", "age"))); // @formatter:on
 
 		Tool calculatorTool = Tool.builder("getMembers")
@@ -763,6 +767,42 @@ class HttpServletStatelessIntegrationTests {
 		assertThat(jsonrpcResponse.error().message()).isEqualTo("testing");
 
 		mcpServer.close();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "tools/list", "resources/list", "prompts/list" })
+	void testMissingHandlerReturnsMethodNotFoundError(String method) throws Exception {
+		var mcpServer = McpServer.sync(mcpStatelessServerTransport)
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().build())
+			.build();
+
+		HttpResponse<String> response;
+
+		try {
+			HttpRequest request = HttpRequest.newBuilder()
+				.uri(URI.create("http://localhost:" + PORT + CUSTOM_MESSAGE_ENDPOINT))
+				.header("Content-Type", "application/json")
+				.header("Accept", "application/json, text/event-stream")
+				.POST(HttpRequest.BodyPublishers.ofString("""
+						{
+							"jsonrpc": "2.0",
+							"method": "%s",
+							"id": "test-request-123",
+							"params": {}
+						}
+						""".formatted(method)))
+				.build();
+
+			response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+		}
+		finally {
+			mcpServer.closeGracefully();
+		}
+
+		final var responseBody = response.body();
+		assertThatJson(responseBody).inPath("error.code").isEqualTo(McpSchema.ErrorCodes.METHOD_NOT_FOUND);
+		assertThatJson(responseBody).inPath("error.message").isEqualTo("Method not found: " + method);
 	}
 
 	private double evaluateExpression(String expression) {

--- a/mcp-test/src/test/java/io/modelcontextprotocol/server/HttpServletStatelessIntegrationTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/server/HttpServletStatelessIntegrationTests.java
@@ -4,15 +4,12 @@
 
 package io.modelcontextprotocol.server;
 
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
@@ -49,6 +46,8 @@ import org.junit.jupiter.api.Timeout;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.client.RestClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import static io.modelcontextprotocol.server.transport.HttpServletStatelessServerTransport.APPLICATION_JSON;
 import static io.modelcontextprotocol.server.transport.HttpServletStatelessServerTransport.TEXT_EVENT_STREAM;
@@ -769,40 +768,46 @@ class HttpServletStatelessIntegrationTests {
 		mcpServer.close();
 	}
 
-	@ParameterizedTest
-	@ValueSource(strings = { "tools/list", "resources/list", "prompts/list" })
-	void testMissingHandlerReturnsMethodNotFoundError(String method) throws Exception {
+	@Test
+	void testMissingHandlerReturnsMethodNotFoundError() {
 		var mcpServer = McpServer.sync(mcpStatelessServerTransport)
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().build())
 			.build();
+		var clientTransport = HttpClientStreamableHttpTransport.builder("http://localhost:" + PORT)
+			.endpoint(CUSTOM_MESSAGE_ENDPOINT)
+			.build();
 
-		HttpResponse<String> response;
+		try (var mcpClient = McpClient.sync(clientTransport).build()) {
+			// Create a session using an MCP client
+			McpSchema.InitializeResult initResult = mcpClient.initialize();
+			assertThat(initResult).isNotNull();
 
-		try {
-			HttpRequest request = HttpRequest.newBuilder()
-				.uri(URI.create("http://localhost:" + PORT + CUSTOM_MESSAGE_ENDPOINT))
-				.header("Content-Type", "application/json")
-				.header("Accept", "application/json, text/event-stream")
-				.POST(HttpRequest.BodyPublishers.ofString("""
-						{
-							"jsonrpc": "2.0",
-							"method": "%s",
-							"id": "test-request-123",
-							"params": {}
+			// Override the response handler in the client to capture responses
+			AtomicReference<McpSchema.JSONRPCResponse> response = new AtomicReference<>();
+			var handler = (Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>>) (
+					message) -> message.doOnNext(r -> {
+						if (r instanceof McpSchema.JSONRPCResponse resp) {
+							response.set(resp);
 						}
-						""".formatted(method)))
-				.build();
+					});
+			StepVerifier.create(clientTransport.connect(handler)).verifyComplete();
 
-			response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+			// Send a request for a non-existent method through the transport, bypassing
+			// the client's capability checks
+			StepVerifier
+				.create(clientTransport.sendMessage(new McpSchema.JSONRPCRequest("foo/bar", "test-request-123")))
+				.verifyComplete();
+
+			// Wait until we've received the response
+			await().atMost(Duration.ofSeconds(1)).until(() -> response.get() != null);
+
+			assertThat(response.get().error().code()).isEqualTo(McpSchema.ErrorCodes.METHOD_NOT_FOUND);
+			assertThat(response.get().error().message()).isEqualTo("Method not found: foo/bar");
 		}
 		finally {
 			mcpServer.closeGracefully();
 		}
-
-		final var responseBody = response.body();
-		assertThatJson(responseBody).inPath("error.code").isEqualTo(McpSchema.ErrorCodes.METHOD_NOT_FOUND);
-		assertThatJson(responseBody).inPath("error.message").isEqualTo("Method not found: " + method);
 	}
 
 	private double evaluateExpression(String expression) {


### PR DESCRIPTION
When a client requests a resource without a registered handler despite a stateless server not advertising it, the server now returns with a JSON-RPC method not found error (-32601), aligned with the stateful implementation.

## Motivation and Context

Closes issue #784

## How Has This Been Tested?

Integration test covering unregistered handler response with stateless transport.

## Breaking Changes

Behavioral change to return a proper JSON-RPC error instead of a HTTP 500 response. Breaking only in terms of changed behavior in case of an error.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
