### PR TITLE
Support cancellation

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/McpSyncClient.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/McpSyncClient.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpRequestHandle;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.ClientCapabilities;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptRequest;
@@ -219,6 +220,20 @@ public class McpSyncClient implements AutoCloseable {
 	}
 
 	// --------------------------
+	// Cancellation
+	// --------------------------
+
+	/**
+	 * Cancels a previously issued request. IMPORTANT: This method MUST be called from a
+	 * different thread than the one blocked waiting on the request result.
+	 * @param requestId The ID of the request to cancel
+	 * @param reason An optional human-readable reason for the cancellation
+	 */
+	public void cancelRequest(Object requestId, String reason) {
+		withProvidedContext(this.delegate.cancelRequest(requestId, reason)).block();
+	}
+
+	// --------------------------
 	// Tools
 	// --------------------------
 	/**
@@ -234,7 +249,16 @@ public class McpSyncClient implements AutoCloseable {
 	 */
 	public McpSchema.CallToolResult callTool(McpSchema.CallToolRequest callToolRequest) {
 		return withProvidedContext(this.delegate.callTool(callToolRequest)).block();
+	}
 
+	/**
+	 * Calls a tool with a specific timeout.
+	 * @param callToolRequest The request containing the tool name and input parameters
+	 * @param timeout The maximum duration to wait for the result
+	 * @return The tool execution result
+	 */
+	public McpSchema.CallToolResult callTool(McpSchema.CallToolRequest callToolRequest, Duration timeout) {
+		return withProvidedContext(this.delegate.callTool(callToolRequest)).timeout(timeout).block();
 	}
 
 	/**

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/DefaultMcpStatelessServerHandler.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/DefaultMcpStatelessServerHandler.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
+import java.util.HashMap;
 import java.util.Map;
 
 class DefaultMcpStatelessServerHandler implements McpStatelessServerHandler {
@@ -24,7 +25,11 @@ class DefaultMcpStatelessServerHandler implements McpStatelessServerHandler {
 	public DefaultMcpStatelessServerHandler(Map<String, McpStatelessRequestHandler<?>> requestHandlers,
 			Map<String, McpStatelessNotificationHandler> notificationHandlers) {
 		this.requestHandlers = requestHandlers;
-		this.notificationHandlers = notificationHandlers;
+		this.notificationHandlers = new HashMap<>(notificationHandlers);
+		this.notificationHandlers.putIfAbsent(McpSchema.METHOD_NOTIFICATION_CANCELLED, (ctx, params) -> {
+			logger.debug("Ignoring cancellation in stateless mode");
+			return Mono.empty();
+		});
 	}
 
 	@Override

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -183,6 +183,16 @@ public class McpAsyncServer {
 
 		notificationHandlers.put(McpSchema.METHOD_NOTIFICATION_INITIALIZED, (exchange, params) -> Mono.empty());
 
+		notificationHandlers.put(McpSchema.METHOD_NOTIFICATION_CANCELLED, (exchange, params) -> {
+			if (features.cancellationConsumer() != null) {
+				McpSchema.CancelledNotification cancelled = jsonMapper.convertValue(params,
+						new TypeRef<McpSchema.CancelledNotification>() {
+						});
+				return features.cancellationConsumer().apply(exchange, cancelled);
+			}
+			return Mono.empty();
+		});
+
 		List<BiFunction<McpAsyncServerExchange, List<McpSchema.Root>, Mono<Void>>> rootsChangeConsumers = features
 			.rootsChangeConsumers();
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
@@ -248,6 +248,17 @@ public class McpAsyncServerExchange {
 	}
 
 	/**
+	 * Cancels a previously issued request to the client (server-to-client direction).
+	 * Sends a {@code notifications/cancelled} notification.
+	 * @param requestId The ID of the request to cancel
+	 * @param reason An optional human-readable reason for the cancellation
+	 * @return A Mono that completes when the cancellation notification is sent
+	 */
+	public Mono<Void> cancelRequest(Object requestId, String reason) {
+		return this.session.sendCancellation(requestId, reason);
+	}
+
+	/**
 	 * Set the minimum logging level for the client. Messages below this level will be
 	 * filtered out.
 	 * @param minLoggingLevel The minimum logging level

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServerFeatures.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServerFeatures.java
@@ -45,19 +45,11 @@ public class McpServerFeatures {
 			Map<String, McpServerFeatures.AsyncPromptSpecification> prompts,
 			Map<McpSchema.CompleteReference, McpServerFeatures.AsyncCompletionSpecification> completions,
 			List<BiFunction<McpAsyncServerExchange, List<McpSchema.Root>, Mono<Void>>> rootsChangeConsumers,
-			String instructions) {
+			String instructions,
+			BiFunction<McpAsyncServerExchange, McpSchema.CancelledNotification, Mono<Void>> cancellationConsumer) {
 
 		/**
-		 * Create an instance and validate the arguments.
-		 * @param serverInfo The server implementation details
-		 * @param serverCapabilities The server capabilities
-		 * @param tools The list of tool specifications
-		 * @param resources The map of resource specifications
-		 * @param resourceTemplates The map of resource templates
-		 * @param prompts The map of prompt specifications
-		 * @param rootsChangeConsumers The list of consumers that will be notified when
-		 * the roots list changes
-		 * @param instructions The server instructions text
+		 * Backwards-compatible constructor without cancellationConsumer.
 		 */
 		Async(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
 				List<McpServerFeatures.AsyncToolSpecification> tools, Map<String, AsyncResourceSpecification> resources,
@@ -66,6 +58,21 @@ public class McpServerFeatures {
 				Map<McpSchema.CompleteReference, McpServerFeatures.AsyncCompletionSpecification> completions,
 				List<BiFunction<McpAsyncServerExchange, List<McpSchema.Root>, Mono<Void>>> rootsChangeConsumers,
 				String instructions) {
+			this(serverInfo, serverCapabilities, tools, resources, resourceTemplates, prompts, completions,
+					rootsChangeConsumers, instructions, null);
+		}
+
+		/**
+		 * Create an instance and validate the arguments.
+		 */
+		Async(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
+				List<McpServerFeatures.AsyncToolSpecification> tools, Map<String, AsyncResourceSpecification> resources,
+				Map<String, McpServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates,
+				Map<String, McpServerFeatures.AsyncPromptSpecification> prompts,
+				Map<McpSchema.CompleteReference, McpServerFeatures.AsyncCompletionSpecification> completions,
+				List<BiFunction<McpAsyncServerExchange, List<McpSchema.Root>, Mono<Void>>> rootsChangeConsumers,
+				String instructions,
+				BiFunction<McpAsyncServerExchange, McpSchema.CancelledNotification, Mono<Void>> cancellationConsumer) {
 
 			Assert.notNull(serverInfo, "Server info must not be null");
 
@@ -89,6 +96,7 @@ public class McpServerFeatures {
 			this.completions = (completions != null) ? completions : Map.of();
 			this.rootsChangeConsumers = (rootsChangeConsumers != null) ? rootsChangeConsumers : List.of();
 			this.instructions = instructions;
+			this.cancellationConsumer = cancellationConsumer;
 		}
 
 		/**

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpSyncServerExchange.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpSyncServerExchange.java
@@ -143,4 +143,13 @@ public class McpSyncServerExchange {
 		return this.exchange.ping().block();
 	}
 
+	/**
+	 * Cancels a previously issued request to the client (server-to-client direction).
+	 * @param requestId The ID of the request to cancel
+	 * @param reason An optional human-readable reason for the cancellation
+	 */
+	public void cancelRequest(Object requestId, String reason) {
+		this.exchange.cancelRequest(requestId, reason).block();
+	}
+
 }

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpRequestHandle.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpRequestHandle.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ */
+
+package io.modelcontextprotocol.spec;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * A handle to a pending MCP request that allows cancellation without leaking session
+ * internals. The cancel function is a closure over the session's sendCancellation method.
+ *
+ * @param <T> the response type of the request
+ */
+public final class McpRequestHandle<T> {
+
+	private final Supplier<Object> requestIdSupplier;
+
+	private final Mono<T> responseMono;
+
+	private final Function<String, Mono<Void>> cancelFunction;
+
+	/**
+	 * Creates a handle with a known request ID.
+	 * @param requestId the request ID (may be null)
+	 * @param responseMono the Mono that will emit the response
+	 * @param cancelFunction the function to invoke for cancellation
+	 */
+	public McpRequestHandle(Object requestId, Mono<T> responseMono, Function<String, Mono<Void>> cancelFunction) {
+		this.requestIdSupplier = () -> requestId;
+		this.responseMono = responseMono;
+		this.cancelFunction = cancelFunction;
+	}
+
+	private McpRequestHandle(Supplier<Object> requestIdSupplier, Mono<T> responseMono,
+			Function<String, Mono<Void>> cancelFunction) {
+		this.requestIdSupplier = requestIdSupplier;
+		this.responseMono = responseMono;
+		this.cancelFunction = cancelFunction;
+	}
+
+	/**
+	 * Creates a handle with a lazily-resolved request ID. The ID may not be available
+	 * until the response Mono is subscribed to.
+	 * @param <T> the response type
+	 * @param requestIdRef an AtomicReference that will be populated with the request ID
+	 * @param responseMono the Mono that will emit the response
+	 * @param cancelFunction the function to invoke for cancellation
+	 * @return the handle
+	 */
+	public static <T> McpRequestHandle<T> lazy(AtomicReference<?> requestIdRef, Mono<T> responseMono,
+			Function<String, Mono<Void>> cancelFunction) {
+		return new McpRequestHandle<>(requestIdRef::get, responseMono, cancelFunction);
+	}
+
+	/**
+	 * Returns the ID of the underlying request. May return {@code null} if the request
+	 * has not yet been issued (i.e. the response Mono has not been subscribed to).
+	 * @return the request ID, or null if not yet available
+	 */
+	public Object requestId() {
+		return requestIdSupplier.get();
+	}
+
+	/**
+	 * Returns the Mono that will emit the response.
+	 * @return the response Mono
+	 */
+	public Mono<T> response() {
+		return responseMono;
+	}
+
+	/**
+	 * Cancel this request. Sends a cancellation notification to the other party.
+	 * @param reason an optional human-readable reason for the cancellation
+	 * @return a Mono that completes when the cancellation notification is sent
+	 */
+	public Mono<Void> cancel(String reason) {
+		return this.cancelFunction.apply(reason);
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -102,6 +102,9 @@ public final class McpSchema {
 
 	public static final String METHOD_NOTIFICATION_ROOTS_LIST_CHANGED = "notifications/roots/list_changed";
 
+	// Cancellation
+	public static final String METHOD_NOTIFICATION_CANCELLED = "notifications/cancelled";
+
 	// Sampling Methods
 	public static final String METHOD_SAMPLING_CREATE_MESSAGE = "sampling/createMessage";
 
@@ -146,6 +149,11 @@ public final class McpSchema {
 		 */
 		public static final int RESOURCE_NOT_FOUND = -32002;
 
+		/**
+		 * The request was cancelled.
+		 */
+		public static final int REQUEST_CANCELLED = -32800;
+
 	}
 
 	/**
@@ -182,8 +190,8 @@ public final class McpSchema {
 
 	}
 
-	public sealed interface Notification extends Meta
-			permits ProgressNotification, LoggingMessageNotification, ResourcesUpdatedNotification {
+	public sealed interface Notification extends Meta permits ProgressNotification, LoggingMessageNotification,
+			ResourcesUpdatedNotification, CancelledNotification {
 
 	}
 
@@ -2299,6 +2307,26 @@ public final class McpSchema {
 
 		public ResourcesUpdatedNotification(String uri) {
 			this(uri, null);
+		}
+	}
+
+	/**
+	 * Notification sent by either side to cancel a previously-issued request. Per the MCP
+	 * spec, cancellation MUST only reference requests issued in the same direction.
+	 *
+	 * @param requestId The ID of the request to cancel.
+	 * @param reason An optional human-readable reason for the cancellation.
+	 * @param meta See specification for notes on _meta usage
+	 */
+	@JsonInclude(JsonInclude.Include.NON_ABSENT)
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record CancelledNotification(// @formatter:off
+		@JsonProperty("requestId") Object requestId,
+		@JsonProperty("reason") String reason,
+		@JsonProperty("_meta") Map<String, Object> meta) implements Notification { // @formatter:on
+
+		public CancelledNotification(Object requestId, String reason) {
+			this(requestId, reason, null);
 		}
 	}
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
@@ -20,6 +20,8 @@ import io.modelcontextprotocol.json.TypeRef;
 import io.modelcontextprotocol.util.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.Disposable;
+import reactor.core.Disposables;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoSink;
 import reactor.core.publisher.Sinks;
@@ -62,6 +64,11 @@ public class McpServerSession implements McpLoggableSession {
 	private static final int STATE_INITIALIZED = 2;
 
 	private final AtomicInteger state = new AtomicInteger(STATE_UNINITIALIZED);
+
+	private final ConcurrentHashMap<String, Disposable> inProgressInbound = new ConcurrentHashMap<>();
+
+	private static final TypeRef<McpSchema.CancelledNotification> CANCELLED_NOTIFICATION_TYPE_REF = new TypeRef<>() {
+	};
 
 	private volatile McpSchema.LoggingLevel minLoggingLevel = McpSchema.LoggingLevel.INFO;
 
@@ -232,7 +239,15 @@ public class McpServerSession implements McpLoggableSession {
 							jsonRpcError);
 					// TODO: Should the error go to SSE or back as POST return?
 					return this.transport.sendMessage(errorResponse).then(Mono.empty());
-				}).flatMap(this.transport::sendMessage);
+				}).flatMap(this.transport::sendMessage).doOnSubscribe(sub -> {
+					if (request.id() != null) {
+						inProgressInbound.put(String.valueOf(request.id()), Disposables.composite(sub::cancel));
+					}
+				}).doFinally(signal -> {
+					if (request.id() != null) {
+						inProgressInbound.remove(String.valueOf(request.id()));
+					}
+				});
 			}
 			else if (message instanceof McpSchema.JSONRPCNotification notification) {
 				// TODO handle errors for communication to without initialization
@@ -314,6 +329,20 @@ public class McpServerSession implements McpLoggableSession {
 						clientInfo.get(), transportContext));
 			}
 
+			if (McpSchema.METHOD_NOTIFICATION_CANCELLED.equals(notification.method())) {
+				McpSchema.CancelledNotification cancelled = transport.unmarshalFrom(notification.params(),
+						CANCELLED_NOTIFICATION_TYPE_REF);
+				if (cancelled != null) {
+					String normalizedId = String.valueOf(cancelled.requestId());
+					logger.debug("Client cancelled request {}: {}", normalizedId, cancelled.reason());
+					var inbound = this.inProgressInbound.remove(normalizedId);
+					if (inbound != null && !inbound.isDisposed()) {
+						logger.debug("Disposing in-progress request pipeline for {}", normalizedId);
+						inbound.dispose();
+					}
+				}
+			}
+
 			var handler = notificationHandlers.get(notification.method());
 			if (handler == null) {
 				logger.warn("No handler registered for notification method: {}", notification);
@@ -341,6 +370,32 @@ public class McpServerSession implements McpLoggableSession {
 
 	private MethodNotFoundError getMethodNotFoundError(String method) {
 		return new MethodNotFoundError(method, "Method not found: " + method, null);
+	}
+
+	/**
+	 * Cancels a previously issued outbound request (server-to-client direction). The
+	 * pending response is errored locally and a cancellation notification is sent to the
+	 * client.
+	 * @param requestId The ID of the request to cancel
+	 * @param reason An optional human-readable reason
+	 * @return A Mono that completes when the cancellation notification is sent
+	 */
+	public Mono<Void> sendCancellation(Object requestId, String reason) {
+		return Mono.defer(() -> {
+			var pending = this.pendingResponses.remove(requestId);
+			if (pending != null) {
+				pending.error(
+						new McpError(new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.REQUEST_CANCELLED,
+								"Request cancelled locally" + (reason != null ? ": " + reason : ""), null)));
+			}
+			return this
+				.sendNotification(McpSchema.METHOD_NOTIFICATION_CANCELLED,
+						new McpSchema.CancelledNotification(requestId, reason))
+				.onErrorResume(e -> {
+					logger.warn("Failed to send cancellation notification for request {}", requestId, e);
+					return Mono.empty();
+				});
+		});
 	}
 
 	@Override

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSession.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSession.java
@@ -67,6 +67,24 @@ public interface McpSession {
 	Mono<Void> sendNotification(String method, Object params);
 
 	/**
+	 * Cancels a previously issued outbound request. The pending response is errored
+	 * locally and a {@code notifications/cancelled} notification is sent to the other
+	 * party.
+	 *
+	 * <p>
+	 * Implementations that track pending responses should override this to also error the
+	 * pending response before sending the notification.
+	 * </p>
+	 * @param requestId the ID of the request to cancel
+	 * @param reason an optional human-readable reason for the cancellation
+	 * @return a Mono that completes when the cancellation notification has been sent
+	 */
+	default Mono<Void> sendCancellation(Object requestId, String reason) {
+		return sendNotification(McpSchema.METHOD_NOTIFICATION_CANCELLED,
+				new McpSchema.CancelledNotification(requestId, reason));
+	}
+
+	/**
 	 * Closes the session and releases any associated resources asynchronously.
 	 * @return a {@link Mono<Void>} that completes when the session has been closed.
 	 */

--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/McpAsyncServerExchangeTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/McpAsyncServerExchangeTests.java
@@ -695,4 +695,46 @@ class McpAsyncServerExchangeTests {
 		verify(mockSession, times(2)).sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeRef.class));
 	}
 
+	// ---------------------------------------
+	// Cancel Request Tests
+	// ---------------------------------------
+
+	@Test
+	void testCancelRequestDelegatesToSendCancellation() {
+		when(mockSession.sendCancellation(any(), any())).thenReturn(Mono.empty());
+
+		StepVerifier.create(exchange.cancelRequest("req-123", "user aborted")).verifyComplete();
+
+		verify(mockSession, times(1)).sendCancellation("req-123", "user aborted");
+	}
+
+	@Test
+	void testCancelRequestWithNullReason() {
+		when(mockSession.sendCancellation(any(), any())).thenReturn(Mono.empty());
+
+		StepVerifier.create(exchange.cancelRequest("req-456", null)).verifyComplete();
+
+		verify(mockSession, times(1)).sendCancellation("req-456", null);
+	}
+
+	@Test
+	void testCancelRequestWithSessionError() {
+		when(mockSession.sendCancellation(any(), any()))
+			.thenReturn(Mono.error(new RuntimeException("Transport error")));
+
+		StepVerifier.create(exchange.cancelRequest("req-789", "timeout")).verifyErrorSatisfies(error -> {
+			assertThat(error).isInstanceOf(RuntimeException.class).hasMessage("Transport error");
+		});
+	}
+
+	@Test
+	void testCancelRequestMultipleTimes() {
+		when(mockSession.sendCancellation(any(), any())).thenReturn(Mono.empty());
+
+		StepVerifier.create(exchange.cancelRequest("req-1", "first cancel")).verifyComplete();
+		StepVerifier.create(exchange.cancelRequest("req-1", "second cancel")).verifyComplete();
+
+		verify(mockSession, times(2)).sendCancellation(eq("req-1"), any());
+	}
+
 }

--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/McpSyncServerExchangeTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/McpSyncServerExchangeTests.java
@@ -689,4 +689,35 @@ class McpSyncServerExchangeTests {
 		verify(mockSession, times(2)).sendRequest(eq(McpSchema.METHOD_PING), eq(null), any(TypeRef.class));
 	}
 
+	// ---------------------------------------
+	// Cancel Request Tests
+	// ---------------------------------------
+
+	@Test
+	void testCancelRequestDelegatesToSendCancellation() {
+		when(mockSession.sendCancellation(any(), any())).thenReturn(Mono.empty());
+
+		exchange.cancelRequest("req-sync-1", "test reason");
+
+		verify(mockSession, times(1)).sendCancellation("req-sync-1", "test reason");
+	}
+
+	@Test
+	void testCancelRequestWithNullReason() {
+		when(mockSession.sendCancellation(any(), any())).thenReturn(Mono.empty());
+
+		exchange.cancelRequest("req-sync-2", null);
+
+		verify(mockSession, times(1)).sendCancellation("req-sync-2", null);
+	}
+
+	@Test
+	void testCancelRequestWithSessionError() {
+		when(mockSession.sendCancellation(any(), any()))
+			.thenReturn(Mono.error(new RuntimeException("Transport error")));
+
+		assertThatThrownBy(() -> exchange.cancelRequest("req-sync-3", "timeout")).isInstanceOf(RuntimeException.class)
+			.hasMessage("Transport error");
+	}
+
 }

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/McpClientSessionCancellationTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/McpClientSessionCancellationTests.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ */
+
+package io.modelcontextprotocol.spec;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+import io.modelcontextprotocol.MockMcpClientTransport;
+import io.modelcontextprotocol.json.TypeRef;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for cancellation support in {@link McpClientSession}.
+ */
+class McpClientSessionCancellationTests {
+
+	private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+	private static final String ECHO_METHOD = "echo";
+
+	TypeRef<String> responseType = new TypeRef<>() {
+	};
+
+	// ------------------------------------------------------------------
+	// sendRequestWithId
+	// ------------------------------------------------------------------
+
+	@Test
+	void sendRequestWithIdReturnsRequestIdAndResponseMono() {
+		var transport = new MockMcpClientTransport();
+		var session = new McpClientSession(TIMEOUT, transport, Map.of(), Map.of(), Function.identity());
+
+		McpClientSession.RequestMono<String> rm = session.sendRequestWithId("test.method", "param", responseType);
+
+		assertThat(rm.requestId()).isNotNull();
+		assertThat(rm.requestId()).isNotEmpty();
+		assertThat(rm.response()).isNotNull();
+
+		StepVerifier.create(rm.response()).then(() -> {
+			McpSchema.JSONRPCRequest request = transport.getLastSentMessageAsRequest();
+			assertThat(request.id()).isEqualTo(rm.requestId());
+			assertThat(request.method()).isEqualTo("test.method");
+			transport.simulateIncomingMessage(
+					new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), "response-data", null));
+		}).expectNext("response-data").verifyComplete();
+
+		session.close();
+	}
+
+	@Test
+	void sendRequestWithIdHandlesErrorResponse() {
+		var transport = new MockMcpClientTransport();
+		var session = new McpClientSession(TIMEOUT, transport, Map.of(), Map.of(), Function.identity());
+
+		McpClientSession.RequestMono<String> rm = session.sendRequestWithId("test.method", "param", responseType);
+
+		StepVerifier.create(rm.response()).then(() -> {
+			McpSchema.JSONRPCResponse.JSONRPCError error = new McpSchema.JSONRPCResponse.JSONRPCError(
+					McpSchema.ErrorCodes.INTERNAL_ERROR, "Server error", null);
+			transport.simulateIncomingMessage(
+					new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, rm.requestId(), null, error));
+		}).expectError(McpError.class).verify();
+
+		session.close();
+	}
+
+	@Test
+	void sendRequestWithIdGeneratesUniqueIds() {
+		var transport = new MockMcpClientTransport();
+		var session = new McpClientSession(TIMEOUT, transport, Map.of(), Map.of(), Function.identity());
+
+		McpClientSession.RequestMono<String> rm1 = session.sendRequestWithId("m1", "p1", responseType);
+		McpClientSession.RequestMono<String> rm2 = session.sendRequestWithId("m2", "p2", responseType);
+
+		assertThat(rm1.requestId()).isNotEqualTo(rm2.requestId());
+
+		session.close();
+	}
+
+	// ------------------------------------------------------------------
+	// sendCancellation – outbound cancellation (client cancels own request)
+	// ------------------------------------------------------------------
+
+	@Test
+	void sendCancellationErrorsPendingResponseAndSendsNotification() {
+		var transport = new MockMcpClientTransport();
+		var session = new McpClientSession(TIMEOUT, transport, Map.of(), Map.of(), Function.identity());
+
+		McpClientSession.RequestMono<String> rm = session.sendRequestWithId("test.method", "param", responseType);
+
+		StepVerifier.create(rm.response()).then(() -> {
+			session.sendCancellation(rm.requestId(), "user aborted").block(Duration.ofSeconds(2));
+		}).expectErrorSatisfies(error -> {
+			assertThat(error).isInstanceOf(McpError.class);
+			McpError mcpError = (McpError) error;
+			assertThat(mcpError.getJsonRpcError()).isNotNull();
+			assertThat(mcpError.getJsonRpcError().code()).isEqualTo(McpSchema.ErrorCodes.REQUEST_CANCELLED);
+		}).verify(TIMEOUT);
+
+		McpSchema.JSONRPCMessage lastSent = transport.getLastSentMessage();
+		assertThat(lastSent).isInstanceOf(McpSchema.JSONRPCNotification.class);
+		McpSchema.JSONRPCNotification notification = (McpSchema.JSONRPCNotification) lastSent;
+		assertThat(notification.method()).isEqualTo(McpSchema.METHOD_NOTIFICATION_CANCELLED);
+
+		session.close();
+	}
+
+	@Test
+	void sendCancellationForUnknownRequestStillSendsNotification() {
+		var transport = new MockMcpClientTransport();
+		var session = new McpClientSession(TIMEOUT, transport, Map.of(), Map.of(), Function.identity());
+
+		StepVerifier.create(session.sendCancellation("non-existent-id", "cleanup")).verifyComplete();
+
+		McpSchema.JSONRPCMessage lastSent = transport.getLastSentMessage();
+		assertThat(lastSent).isInstanceOf(McpSchema.JSONRPCNotification.class);
+		McpSchema.JSONRPCNotification notification = (McpSchema.JSONRPCNotification) lastSent;
+		assertThat(notification.method()).isEqualTo(McpSchema.METHOD_NOTIFICATION_CANCELLED);
+
+		session.close();
+	}
+
+	@Test
+	void sendCancellationWithNullReasonFormatsMessageCorrectly() {
+		var transport = new MockMcpClientTransport();
+		var session = new McpClientSession(TIMEOUT, transport, Map.of(), Map.of(), Function.identity());
+
+		McpClientSession.RequestMono<String> rm = session.sendRequestWithId("test.method", "param", responseType);
+
+		StepVerifier.create(rm.response()).then(() -> {
+			session.sendCancellation(rm.requestId(), null).block(Duration.ofSeconds(2));
+		}).expectErrorSatisfies(error -> {
+			assertThat(error).isInstanceOf(McpError.class);
+			McpError mcpError = (McpError) error;
+			assertThat(mcpError.getJsonRpcError().code()).isEqualTo(McpSchema.ErrorCodes.REQUEST_CANCELLED);
+			assertThat(mcpError.getMessage()).doesNotContain("null");
+		}).verify(TIMEOUT);
+
+		session.close();
+	}
+
+	// ------------------------------------------------------------------
+	// Inbound cancellation – server cancels a request it sent to us
+	// ------------------------------------------------------------------
+
+	@Test
+	void inboundCancellationDisposesInProgressRequest() throws InterruptedException {
+		CountDownLatch handlerStarted = new CountDownLatch(1);
+		AtomicBoolean handlerCompleted = new AtomicBoolean(false);
+
+		Map<String, McpClientSession.RequestHandler<?>> requestHandlers = Map.of(ECHO_METHOD, params -> {
+			handlerStarted.countDown();
+			return Mono.delay(Duration.ofSeconds(10)).map(l -> {
+				handlerCompleted.set(true);
+				return params;
+			});
+		});
+
+		var transport = new MockMcpClientTransport();
+		var session = new McpClientSession(TIMEOUT, transport, requestHandlers, Map.of(), Function.identity());
+
+		McpSchema.JSONRPCRequest incomingRequest = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, ECHO_METHOD,
+				"server-req-1", "hello");
+		transport.simulateIncomingMessage(incomingRequest);
+
+		assertThat(handlerStarted.await(2, TimeUnit.SECONDS)).isTrue();
+
+		McpSchema.CancelledNotification cancelledNotification = new McpSchema.CancelledNotification("server-req-1",
+				"server timeout");
+		McpSchema.JSONRPCNotification notification = new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION,
+				McpSchema.METHOD_NOTIFICATION_CANCELLED, cancelledNotification);
+		transport.simulateIncomingMessage(notification);
+
+		Thread.sleep(200);
+		assertThat(handlerCompleted.get()).isFalse();
+
+		session.close();
+	}
+
+	@Test
+	void inboundCancellationForNonExistentRequestDoesNotThrow() {
+		var transport = new MockMcpClientTransport();
+		var session = new McpClientSession(TIMEOUT, transport, Map.of(), Map.of(), Function.identity());
+
+		McpSchema.CancelledNotification cancelledNotification = new McpSchema.CancelledNotification("unknown-id",
+				"cleanup");
+		McpSchema.JSONRPCNotification notification = new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION,
+				McpSchema.METHOD_NOTIFICATION_CANCELLED, cancelledNotification);
+
+		transport.simulateIncomingMessage(notification);
+
+		session.close();
+	}
+
+	@Test
+	void inboundCancellationWithNullDeserialization() {
+		var transport = new MockMcpClientTransport();
+		var session = new McpClientSession(TIMEOUT, transport, Map.of(), Map.of(), Function.identity());
+
+		McpSchema.JSONRPCNotification notification = new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION,
+				McpSchema.METHOD_NOTIFICATION_CANCELLED, null);
+
+		transport.simulateIncomingMessage(notification);
+
+		session.close();
+	}
+
+	// ------------------------------------------------------------------
+	// RequestMono record
+	// ------------------------------------------------------------------
+
+	@Test
+	void requestMonoRecordFieldAccess() {
+		Mono<String> mono = Mono.just("test");
+		McpClientSession.RequestMono<String> rm = new McpClientSession.RequestMono<>("req-123", mono);
+
+		assertThat(rm.requestId()).isEqualTo("req-123");
+		assertThat(rm.response()).isSameAs(mono);
+	}
+
+	@Test
+	void requestMonoRecordEquality() {
+		Mono<String> mono = Mono.just("test");
+		McpClientSession.RequestMono<String> rm1 = new McpClientSession.RequestMono<>("req-1", mono);
+		McpClientSession.RequestMono<String> rm2 = new McpClientSession.RequestMono<>("req-1", mono);
+		McpClientSession.RequestMono<String> rm3 = new McpClientSession.RequestMono<>("req-2", mono);
+
+		assertThat(rm1).isEqualTo(rm2);
+		assertThat(rm1).isNotEqualTo(rm3);
+	}
+
+	// ------------------------------------------------------------------
+	// doOnSubscribe / doFinally lifecycle tracking
+	// ------------------------------------------------------------------
+
+	@Test
+	void completedRequestIsClearedFromTracking() throws InterruptedException {
+		Sinks.One<Object> responseSent = Sinks.one();
+
+		Map<String, McpClientSession.RequestHandler<?>> requestHandlers = Map.of(ECHO_METHOD,
+				params -> Mono.just(params));
+		var transport = new MockMcpClientTransport();
+		var session = new McpClientSession(TIMEOUT, transport, requestHandlers, Map.of(), Function.identity());
+
+		McpSchema.JSONRPCRequest incomingRequest = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, ECHO_METHOD,
+				"req-track-1", "data");
+		transport.simulateIncomingMessage(incomingRequest);
+
+		Thread.sleep(200);
+
+		McpSchema.CancelledNotification cancelledNotification = new McpSchema.CancelledNotification("req-track-1",
+				"late cancel");
+		McpSchema.JSONRPCNotification notification = new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION,
+				McpSchema.METHOD_NOTIFICATION_CANCELLED, cancelledNotification);
+		transport.simulateIncomingMessage(notification);
+
+		session.close();
+	}
+
+}

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/McpRequestHandleTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/McpRequestHandleTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ */
+
+package io.modelcontextprotocol.spec;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link McpRequestHandle}.
+ */
+class McpRequestHandleTests {
+
+	@Test
+	void requestIdIsExposed() {
+		McpRequestHandle<String> handle = new McpRequestHandle<>("req-1", Mono.just("result"), reason -> Mono.empty());
+
+		assertThat(handle.requestId()).isEqualTo("req-1");
+	}
+
+	@Test
+	void responseMonoEmitsValue() {
+		McpRequestHandle<String> handle = new McpRequestHandle<>("req-1", Mono.just("result"), reason -> Mono.empty());
+
+		StepVerifier.create(handle.response()).expectNext("result").verifyComplete();
+	}
+
+	@Test
+	void cancelInvokesCancelFunction() {
+		AtomicReference<String> capturedReason = new AtomicReference<>();
+		McpRequestHandle<String> handle = new McpRequestHandle<>("req-1", Mono.just("result"), reason -> {
+			capturedReason.set(reason);
+			return Mono.empty();
+		});
+
+		StepVerifier.create(handle.cancel("user requested")).verifyComplete();
+		assertThat(capturedReason.get()).isEqualTo("user requested");
+	}
+
+	@Test
+	void cancelWithNullReason() {
+		AtomicReference<String> capturedReason = new AtomicReference<>("not-null");
+		McpRequestHandle<String> handle = new McpRequestHandle<>("req-1", Mono.just("result"), reason -> {
+			capturedReason.set(reason);
+			return Mono.empty();
+		});
+
+		StepVerifier.create(handle.cancel(null)).verifyComplete();
+		assertThat(capturedReason.get()).isNull();
+	}
+
+	@Test
+	void cancelPropagatesError() {
+		McpRequestHandle<String> handle = new McpRequestHandle<>("req-1", Mono.just("result"),
+				reason -> Mono.error(new RuntimeException("cancel failed")));
+
+		StepVerifier.create(handle.cancel("reason")).verifyErrorSatisfies(error -> {
+			assertThat(error).isInstanceOf(RuntimeException.class).hasMessage("cancel failed");
+		});
+	}
+
+	@Test
+	void handleWithNullRequestId() {
+		McpRequestHandle<String> handle = new McpRequestHandle<>(null, Mono.just("result"), reason -> Mono.empty());
+
+		assertThat(handle.requestId()).isNull();
+		StepVerifier.create(handle.response()).expectNext("result").verifyComplete();
+	}
+
+	@Test
+	void handleWithErrorResponse() {
+		McpRequestHandle<String> handle = new McpRequestHandle<>("req-err", Mono.error(new McpError("server error")),
+				reason -> Mono.empty());
+
+		StepVerifier.create(handle.response()).expectError(McpError.class).verify();
+	}
+
+	@Test
+	void requestIdResolvesLazilyFromAtomicReference() {
+		AtomicReference<String> idRef = new AtomicReference<>();
+		McpRequestHandle<String> handle = McpRequestHandle.lazy(idRef, Mono.just("result"), reason -> Mono.empty());
+
+		assertThat(handle.requestId()).isNull();
+
+		idRef.set("lazy-req-1");
+		assertThat(handle.requestId()).isEqualTo("lazy-req-1");
+	}
+
+}

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/McpServerSessionCancellationTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/McpServerSessionCancellationTests.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ */
+
+package io.modelcontextprotocol.spec;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.server.McpInitRequestHandler;
+import io.modelcontextprotocol.server.McpNotificationHandler;
+import io.modelcontextprotocol.server.McpRequestHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for cancellation support in {@link McpServerSession}.
+ */
+class McpServerSessionCancellationTests {
+
+	private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+	@Mock
+	private McpServerTransport mockTransport;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		when(mockTransport.sendMessage(any())).thenReturn(Mono.empty());
+		when(mockTransport.closeGracefully()).thenReturn(Mono.empty());
+		when(mockTransport.unmarshalFrom(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+	}
+
+	private McpServerSession createSession(Map<String, McpRequestHandler<?>> requestHandlers,
+			Map<String, McpNotificationHandler> notificationHandlers) {
+		McpInitRequestHandler initHandler = initializeRequest -> Mono.just(new McpSchema.InitializeResult(
+				McpSchema.LATEST_PROTOCOL_VERSION, McpSchema.ServerCapabilities.builder().build(),
+				new McpSchema.Implementation("test-server", "1.0.0"), null));
+
+		return new McpServerSession("test-session", TIMEOUT, mockTransport, initHandler, requestHandlers,
+				notificationHandlers);
+	}
+
+	private void performInitialization(McpServerSession session) {
+		McpSchema.InitializeRequest initReq = new McpSchema.InitializeRequest(McpSchema.LATEST_PROTOCOL_VERSION,
+				McpSchema.ClientCapabilities.builder().build(), new McpSchema.Implementation("client", "1.0"));
+		McpSchema.JSONRPCRequest initRequest = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION,
+				McpSchema.METHOD_INITIALIZE, "init-1", initReq);
+		session.handle(initRequest).block(Duration.ofSeconds(2));
+
+		McpSchema.JSONRPCNotification initializedNotification = new McpSchema.JSONRPCNotification(
+				McpSchema.JSONRPC_VERSION, McpSchema.METHOD_NOTIFICATION_INITIALIZED, null);
+		session.handle(initializedNotification).block(Duration.ofSeconds(2));
+	}
+
+	// ------------------------------------------------------------------
+	// Inbound cancellation – client cancels a request it sent to the server
+	// ------------------------------------------------------------------
+
+	@Test
+	void cancellationNotificationIsAcceptedBySession() {
+		McpServerSession session = createSession(new HashMap<>(), new HashMap<>());
+
+		McpSchema.CancelledNotification cancelledNotification = new McpSchema.CancelledNotification("req-1",
+				"user cancelled");
+		McpSchema.JSONRPCNotification notification = new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION,
+				McpSchema.METHOD_NOTIFICATION_CANCELLED, cancelledNotification);
+
+		StepVerifier.create(session.handle(notification)).verifyComplete();
+	}
+
+	@Test
+	void preEmptiveCancellationIsIgnoredAndResponseStillSent() throws InterruptedException {
+		Map<String, McpRequestHandler<?>> requestHandlers = new HashMap<>();
+		requestHandlers.put("fast.method", (exchange, params) -> Mono.just("result"));
+
+		McpServerSession session = createSession(requestHandlers, new HashMap<>());
+		performInitialization(session);
+
+		McpSchema.CancelledNotification cancelledNotification = new McpSchema.CancelledNotification("req-1",
+				"pre-emptive cancel");
+		McpSchema.JSONRPCNotification notification = new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION,
+				McpSchema.METHOD_NOTIFICATION_CANCELLED, cancelledNotification);
+		session.handle(notification).block(Duration.ofSeconds(2));
+
+		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, "fast.method",
+				"req-1", "param");
+		session.handle(request).block(Duration.ofSeconds(2));
+
+		Thread.sleep(100);
+
+		ArgumentCaptor<McpSchema.JSONRPCMessage> captor = ArgumentCaptor.forClass(McpSchema.JSONRPCMessage.class);
+		verify(mockTransport, atLeastOnce()).sendMessage(captor.capture());
+
+		boolean responseSent = captor.getAllValues().stream().anyMatch(msg -> {
+			if (msg instanceof McpSchema.JSONRPCResponse r) {
+				return "req-1".equals(r.id()) && r.error() == null;
+			}
+			return false;
+		});
+		assertThat(responseSent)
+			.as("Pre-emptive cancellation for non-existent request is ignored per MCP spec; response should still be sent")
+			.isTrue();
+	}
+
+	@Test
+	void cancelledRequestWithNullDeserialization() {
+		McpServerSession session = createSession(new HashMap<>(), new HashMap<>());
+
+		McpSchema.JSONRPCNotification notification = new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION,
+				McpSchema.METHOD_NOTIFICATION_CANCELLED, null);
+
+		StepVerifier.create(session.handle(notification)).verifyComplete();
+	}
+
+	@Test
+	void cancellationForNonExistentRequestDoesNotError() {
+		McpServerSession session = createSession(new HashMap<>(), new HashMap<>());
+
+		McpSchema.CancelledNotification cancelledNotification = new McpSchema.CancelledNotification("non-existent",
+				"cleanup");
+		McpSchema.JSONRPCNotification notification = new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION,
+				McpSchema.METHOD_NOTIFICATION_CANCELLED, cancelledNotification);
+
+		StepVerifier.create(session.handle(notification)).verifyComplete();
+	}
+
+	// ------------------------------------------------------------------
+	// sendCancellation – server cancels its own outbound request
+	// ------------------------------------------------------------------
+
+	@Test
+	void sendCancellationSendsNotificationToClient() {
+		McpServerSession session = createSession(new HashMap<>(), new HashMap<>());
+
+		StepVerifier.create(session.sendCancellation("outbound-req-1", "timeout")).verifyComplete();
+
+		ArgumentCaptor<McpSchema.JSONRPCMessage> captor = ArgumentCaptor.forClass(McpSchema.JSONRPCMessage.class);
+		verify(mockTransport, atLeastOnce()).sendMessage(captor.capture());
+
+		boolean foundCancellation = captor.getAllValues().stream().anyMatch(msg -> {
+			if (msg instanceof McpSchema.JSONRPCNotification n) {
+				return McpSchema.METHOD_NOTIFICATION_CANCELLED.equals(n.method());
+			}
+			return false;
+		});
+		assertThat(foundCancellation).isTrue();
+	}
+
+	@Test
+	void sendCancellationErrorsPendingOutboundResponse() {
+		McpServerSession session = createSession(new HashMap<>(), new HashMap<>());
+
+		Mono<Object> outboundResponse = session.sendRequest("sampling/createMessage", Map.of("prompt", "test"),
+				new TypeRef<>() {
+				});
+
+		StepVerifier.create(outboundResponse).then(() -> {
+			session.sendCancellation("test-session-0", "no longer needed").block(Duration.ofSeconds(2));
+		}).expectErrorSatisfies(error -> {
+			assertThat(error).isInstanceOf(McpError.class);
+			McpError mcpError = (McpError) error;
+			assertThat(mcpError.getJsonRpcError()).isNotNull();
+			assertThat(mcpError.getJsonRpcError().code()).isEqualTo(McpSchema.ErrorCodes.REQUEST_CANCELLED);
+		}).verify(TIMEOUT);
+	}
+
+	@Test
+	void sendCancellationWithNullReason() {
+		McpServerSession session = createSession(new HashMap<>(), new HashMap<>());
+
+		StepVerifier.create(session.sendCancellation("some-id", null)).verifyComplete();
+
+		ArgumentCaptor<McpSchema.JSONRPCMessage> captor = ArgumentCaptor.forClass(McpSchema.JSONRPCMessage.class);
+		verify(mockTransport, atLeastOnce()).sendMessage(captor.capture());
+
+		boolean foundCancellation = captor.getAllValues().stream().anyMatch(msg -> {
+			if (msg instanceof McpSchema.JSONRPCNotification n) {
+				return McpSchema.METHOD_NOTIFICATION_CANCELLED.equals(n.method());
+			}
+			return false;
+		});
+		assertThat(foundCancellation).isTrue();
+	}
+
+	@Test
+	void sendCancellationForUnknownIdStillSendsNotification() {
+		McpServerSession session = createSession(new HashMap<>(), new HashMap<>());
+
+		StepVerifier.create(session.sendCancellation("non-existent-outbound", "cleanup")).verifyComplete();
+
+		ArgumentCaptor<McpSchema.JSONRPCMessage> captor = ArgumentCaptor.forClass(McpSchema.JSONRPCMessage.class);
+		verify(mockTransport, atLeastOnce()).sendMessage(captor.capture());
+
+		boolean foundCancellation = captor.getAllValues().stream().anyMatch(msg -> {
+			if (msg instanceof McpSchema.JSONRPCNotification n) {
+				return McpSchema.METHOD_NOTIFICATION_CANCELLED.equals(n.method());
+			}
+			return false;
+		});
+		assertThat(foundCancellation).isTrue();
+	}
+
+	// ------------------------------------------------------------------
+	// Notification handler delegation
+	// ------------------------------------------------------------------
+
+	@Test
+	void cancellationNotificationStillInvokesRegisteredHandler() {
+		ConcurrentHashMap<String, Boolean> handlerCalled = new ConcurrentHashMap<>();
+		Map<String, McpNotificationHandler> notificationHandlers = new HashMap<>();
+		notificationHandlers.put(McpSchema.METHOD_NOTIFICATION_CANCELLED, (exchange, params) -> {
+			handlerCalled.put("called", true);
+			return Mono.empty();
+		});
+
+		McpServerSession session = createSession(new HashMap<>(), notificationHandlers);
+		performInitialization(session);
+
+		McpSchema.CancelledNotification cancelledNotification = new McpSchema.CancelledNotification("req-42",
+				"test reason");
+		McpSchema.JSONRPCNotification notification = new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION,
+				McpSchema.METHOD_NOTIFICATION_CANCELLED, cancelledNotification);
+
+		StepVerifier.create(session.handle(notification)).verifyComplete();
+
+		assertThat(handlerCalled).containsKey("called");
+	}
+
+}


### PR DESCRIPTION
## Summary

Implements the `notifications/cancelled` notification from the [MCP specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/cancellation#cancellation), enabling bidirectional request cancellation between clients and servers. Both sides can cancel in-flight requests they previously issued, with the receiver disposing the in-progress reactive pipeline.

## Motivation and Context

The MCP spec defines a cancellation mechanism where either party can send a `notifications/cancelled` notification to signal that a previously-issued request is no longer needed. Without this, long-running operations like tool calls have no way to be interrupted — the caller must wait for the full timeout or the operation to complete naturally.

This was a missing feature in the Java SDK that is required for full spec compliance.

## How Has This Been Tested?

- **Unit tests for `McpClientSession` cancellation** (`McpClientSessionCancellationTests`) — verifies outbound cancellation errors the local pending response with `-32800`, sends the notification over the wire, and that inbound cancellation disposes the in-progress request pipeline
- **Unit tests for `McpServerSession` cancellation** (`McpServerSessionCancellationTests`) — verifies the same behavior on the server side
- **Unit tests for `McpRequestHandle`** (`McpRequestHandleTests`) — verifies the lazy ID resolution pattern, the cancel closure, and the guard against cancelling before subscription
- **Updated `LifecycleInitializerTests`** and `LifecycleInitializerPostInitializationHookTests` — updated to work with `sendRequestWithId` (used for tracking the initialize request ID)
- **Updated `McpAsyncServerExchangeTests`** and `McpSyncServerExchangeTests` — cover the new `cancelRequest` method on the exchange
- Tested against the conformance test server to verify no regressions in the initialization and tool-call flows

## Breaking Changes

No breaking changes for existing users. All new APIs are additive:

- `McpAsyncClient.cancelRequest()` and `callToolWithHandle()` are new public methods
- `McpSyncClient.cancelRequest()` and `callTool(request, timeout)` are new public methods
- `McpAsyncServerExchange.cancelRequest()` / `McpSyncServerExchange.cancelRequest()` are new
- `McpServer` builder's `.cancellationConsumer()` is optional
- `McpServerFeatures.Async` record has a backwards-compatible constructor without `cancellationConsumer`
- `McpSession.sendCancellation()` is a default method on the interface

The only internal change is that `LifecycleInitializer` now uses `sendRequestWithId` instead of `sendRequest` for the initialize handshake, but this is an internal class not exposed to users.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

### Architecture

Cancellation touches three layers, each with a distinct responsibility:

**Schema layer** (`McpSchema`) — pure data types:
- `CancelledNotification` record with `requestId`, `reason`, `_meta`
- `ErrorCodes.REQUEST_CANCELLED = -32800`
- `METHOD_NOTIFICATION_CANCELLED = "notifications/cancelled"`

**Session layer** (`McpClientSession` / `McpServerSession` / `McpStreamableServerSession`) — protocol mechanics:
- **Outbound cancellation** via `sendCancellation(id, reason)`: errors the local `pendingResponses` sink with `-32800`, then sends `notifications/cancelled` over the wire
- **Inbound cancellation**: tracks each in-progress inbound request's `Subscription` in an `inProgressInbound` map using `doOnSubscribe`/`doFinally` lifecycle hooks. When a cancellation notification arrives, the `Subscription` is disposed, cancelling the reactive pipeline mid-flight

**Public API layer** (`McpAsyncClient` / `McpSyncClient` / Exchange classes) — user-facing:
- `cancelRequest(requestId, reason)` — cancel by ID with initialize-request protection
- `callToolWithHandle()` → `McpRequestHandle` — returns a handle with `requestId()`, `response()`, and `cancel(reason)` methods
- Server-side `exchange.cancelRequest()` for the server→client direction
- Optional `cancellationConsumer` on the server builder for app-level side-effects (logging, metrics)

### Cancellation flow (client → server)

```
CLIENT                                         SERVER
  │  ── JSONRPCRequest {id:"abc-1"} ──────────►  │
  │                                               │  handler processing...
  │  cancelRequest("abc-1", "timeout")            │
  │                                               │
  │  LOCAL:                                        │
  │    pendingResponses.remove("abc-1")            │
  │    sink.error(McpError -32800)                 │
  │                                               │
  │  ── notifications/cancelled ───────────────►  │
  │     {requestId:"abc-1", reason:"timeout"}     │
  │                                               │
  │                                               │  inProgressInbound.remove("abc-1")
  │                                               │  disposable.dispose()
  │                                               │  → reactive pipeline cancelled
```

### Spec compliance notes

- Cancellation is a **notification** (fire-and-forget), not a request
- Cancellation MUST only reference requests in the **same direction** — enforced by API design
- The `initialize` request **MUST NOT** be cancelled — enforced in `McpAsyncClient.cancelRequest()` by checking against the tracked initialize request ID
- Receivers SHOULD continue processing if already started — our dispose is best-effort
- `DefaultMcpStatelessServerHandler` registers a no-op handler to avoid "unknown notification" errors


**[Demo]**

https://github.com/user-attachments/assets/d157aff3-8b6f-431c-97bf-5172bedfc812


