### PR TITLE
Support last event Id for resumability of sse

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
@@ -17,6 +17,8 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.modelcontextprotocol.json.McpJsonDefaults;
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.json.TypeRef;
 
 import io.modelcontextprotocol.common.McpTransportContext;
@@ -29,8 +31,6 @@ import io.modelcontextprotocol.spec.McpStreamableServerTransport;
 import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
 import io.modelcontextprotocol.spec.ProtocolVersions;
 import io.modelcontextprotocol.util.Assert;
-import io.modelcontextprotocol.json.McpJsonDefaults;
-import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.util.KeepAliveScheduler;
 import jakarta.servlet.AsyncContext;
 import jakarta.servlet.ServletException;
@@ -319,9 +319,9 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 					session.replay(lastId)
 						.contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext))
 						.toIterable()
-						.forEach(message -> {
+						.forEach(storedEvent -> {
 							try {
-								sessionTransport.sendMessage(message)
+								sessionTransport.sendMessage(storedEvent.message(), storedEvent.messageId().value())
 									.contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext))
 									.block();
 							}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/DefaultMcpStreamableServerSessionFactory.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/DefaultMcpStreamableServerSessionFactory.java
@@ -4,12 +4,12 @@
 
 package io.modelcontextprotocol.spec;
 
-import io.modelcontextprotocol.server.McpNotificationHandler;
-import io.modelcontextprotocol.server.McpRequestHandler;
-
 import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
+
+import io.modelcontextprotocol.server.McpNotificationHandler;
+import io.modelcontextprotocol.server.McpRequestHandler;
 
 /**
  * A default implementation of {@link McpStreamableServerSession.Factory}.
@@ -26,21 +26,25 @@ public class DefaultMcpStreamableServerSessionFactory implements McpStreamableSe
 
 	Map<String, McpNotificationHandler> notificationHandlers;
 
+	McpEventStore eventStore;
+
 	/**
 	 * Constructs an instance
 	 * @param requestTimeout timeout for requests
 	 * @param initRequestHandler initialization request handler
 	 * @param requestHandlers map of MCP request handlers keyed by method name
 	 * @param notificationHandlers map of MCP notification handlers keyed by method name
+	 * @param eventStore message store for SSE resumability and replay
 	 */
 	public DefaultMcpStreamableServerSessionFactory(Duration requestTimeout,
 			McpStreamableServerSession.InitRequestHandler initRequestHandler,
-			Map<String, McpRequestHandler<?>> requestHandlers,
-			Map<String, McpNotificationHandler> notificationHandlers) {
+			Map<String, McpRequestHandler<?>> requestHandlers, Map<String, McpNotificationHandler> notificationHandlers,
+			McpEventStore eventStore) {
 		this.requestTimeout = requestTimeout;
 		this.initRequestHandler = initRequestHandler;
 		this.requestHandlers = requestHandlers;
 		this.notificationHandlers = notificationHandlers;
+		this.eventStore = eventStore;
 	}
 
 	@Override
@@ -48,7 +52,8 @@ public class DefaultMcpStreamableServerSessionFactory implements McpStreamableSe
 			McpSchema.InitializeRequest initializeRequest) {
 		return new McpStreamableServerSession.McpStreamableServerSessionInit(
 				new McpStreamableServerSession(UUID.randomUUID().toString(), initializeRequest.capabilities(),
-						initializeRequest.clientInfo(), requestTimeout, requestHandlers, notificationHandlers),
+						initializeRequest.clientInfo(), requestTimeout, requestHandlers, notificationHandlers,
+						eventStore),
 				this.initRequestHandler.handle(initializeRequest));
 	}
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/InMemoryMcpEventStore.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/InMemoryMcpEventStore.java
@@ -1,0 +1,139 @@
+package io.modelcontextprotocol.spec;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.LongSupplier;
+
+public class InMemoryMcpEventStore implements McpEventStore {
+
+	private final Integer maxEventsPerStream;
+
+	private final Duration eventTtl;
+
+	private final ConcurrentHashMap<String, Deque<StoredEvent>> eventStreams = new ConcurrentHashMap<>();
+
+	private final ConcurrentHashMap<String, StoredEvent> eventIndex = new ConcurrentHashMap<>();
+
+	private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+	private final LongSupplier currentTimeMillisSupplier;
+
+	public InMemoryMcpEventStore(Integer maxEventsPerStream, Duration eventTtl) {
+		this(maxEventsPerStream, eventTtl, System::currentTimeMillis);
+	}
+
+	InMemoryMcpEventStore(Integer maxEventsPerStream, Duration eventTtl, LongSupplier currentTimeMillisSupplier) {
+		if (maxEventsPerStream != null && maxEventsPerStream <= 0) {
+			throw new IllegalArgumentException("maxEventsPerStream must be positive");
+		}
+
+		if (eventTtl != null && (eventTtl.isNegative() || eventTtl.isZero())) {
+			throw new IllegalArgumentException("eventTtl must be non-negative");
+		}
+
+		if (currentTimeMillisSupplier == null) {
+			throw new IllegalArgumentException("currentTimeMillisSupplier must not be null");
+		}
+
+		this.maxEventsPerStream = maxEventsPerStream;
+		this.eventTtl = eventTtl;
+		this.currentTimeMillisSupplier = currentTimeMillisSupplier;
+	}
+
+	@Override
+	public Mono<String> storeEvent(String streamId, McpSchema.JSONRPCMessage message) {
+		return Mono.fromCallable(() -> {
+			String eventId = streamId + "_" + UUID.randomUUID();
+
+			StoredEvent storedEvent = new StoredEvent(eventId, streamId, message,
+					currentTimeMillisSupplier.getAsLong());
+
+			lock.writeLock().lock();
+			try {
+				Deque<StoredEvent> streamEvents = eventStreams.computeIfAbsent(streamId, s -> new LinkedList<>());
+				streamEvents.addLast(storedEvent);
+				eventIndex.put(eventId, storedEvent);
+
+				evictExpired(streamEvents);
+				evictMaxEvents(streamEvents);
+			}
+			finally {
+				lock.writeLock().unlock();
+			}
+
+			return eventId;
+		});
+	}
+
+	private void evictExpired(Deque<StoredEvent> streamEvents) {
+		if (eventTtl == null) {
+			return;
+		}
+
+		long now = currentTimeMillisSupplier.getAsLong();
+		while (!streamEvents.isEmpty()) {
+			StoredEvent event = streamEvents.peekFirst();
+			if (now - event.timestamp() > eventTtl.toMillis()) {
+				streamEvents.removeFirst();
+				eventIndex.remove(event.eventId());
+			}
+			else {
+				break;
+			}
+		}
+	}
+
+	private void evictMaxEvents(Deque<StoredEvent> streamEvents) {
+		if (maxEventsPerStream == null) {
+			return;
+		}
+
+		while (streamEvents.size() > maxEventsPerStream) {
+			StoredEvent event = streamEvents.removeFirst();
+			eventIndex.remove(event.eventId());
+		}
+	}
+
+	@Override
+	public Flux<StoredEvent> replayEventsAfter(String lastEventId) {
+		return Flux.defer(() -> {
+			List<StoredEvent> replayEvents = new ArrayList<>();
+			lock.readLock().lock();
+			try {
+				StoredEvent lastStoredEvent = eventIndex.get(lastEventId);
+				if (lastStoredEvent == null) {
+					return Flux.empty();
+				}
+
+				Deque<StoredEvent> streamEvents = eventStreams.get(lastStoredEvent.streamId());
+				if (streamEvents == null || streamEvents.isEmpty()) {
+					return Flux.empty();
+				}
+
+				boolean foundLastEvent = false;
+				for (StoredEvent event : streamEvents) {
+					if (foundLastEvent) {
+						replayEvents.add(event);
+					}
+					else if (event.eventId().equals(lastEventId)) {
+						foundLastEvent = true;
+					}
+				}
+				return Flux.fromIterable(replayEvents);
+			}
+			finally {
+				lock.readLock().unlock();
+			}
+		});
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/InMemoryMcpEventStore.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/InMemoryMcpEventStore.java
@@ -1,42 +1,49 @@
 package io.modelcontextprotocol.spec;
 
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.LongSupplier;
 
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.util.annotation.NonNull;
+
 public class InMemoryMcpEventStore implements McpEventStore {
+
+	private static final ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
 
 	private final Integer maxEventsPerStream;
 
 	private final Duration eventTtl;
 
+	// transportId -> events
 	private final ConcurrentHashMap<String, Deque<StoredEvent>> eventStreams = new ConcurrentHashMap<>();
 
-	private final ConcurrentHashMap<String, StoredEvent> eventIndex = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<MessageId, StoredEvent> eventIndex = new ConcurrentHashMap<>();
 
 	private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
 	private final LongSupplier currentTimeMillisSupplier;
 
-	public InMemoryMcpEventStore(Integer maxEventsPerStream, Duration eventTtl) {
+	public InMemoryMcpEventStore(Integer maxEventsPerStream, @NonNull Duration eventTtl) {
 		this(maxEventsPerStream, eventTtl, System::currentTimeMillis);
 	}
 
-	InMemoryMcpEventStore(Integer maxEventsPerStream, Duration eventTtl, LongSupplier currentTimeMillisSupplier) {
+	InMemoryMcpEventStore(Integer maxEventsPerStream, @NonNull Duration eventTtl,
+			LongSupplier currentTimeMillisSupplier) {
 		if (maxEventsPerStream != null && maxEventsPerStream <= 0) {
 			throw new IllegalArgumentException("maxEventsPerStream must be positive");
 		}
 
-		if (eventTtl != null && (eventTtl.isNegative() || eventTtl.isZero())) {
+		if (eventTtl.isNegative() || eventTtl.isZero()) {
 			throw new IllegalArgumentException("eventTtl must be non-negative");
 		}
 
@@ -50,18 +57,16 @@ public class InMemoryMcpEventStore implements McpEventStore {
 	}
 
 	@Override
-	public Mono<String> storeEvent(String streamId, McpSchema.JSONRPCMessage message) {
-		return Mono.fromCallable(() -> {
-			String eventId = streamId + "_" + UUID.randomUUID();
-
-			StoredEvent storedEvent = new StoredEvent(eventId, streamId, message,
-					currentTimeMillisSupplier.getAsLong());
+	public Mono<Void> storeEvent(MessageId messageId, McpSchema.JSONRPCMessage message) {
+		return Mono.fromRunnable(() -> {
+			StoredEvent storedEvent = new StoredEvent(messageId, message, currentTimeMillisSupplier.getAsLong());
 
 			lock.writeLock().lock();
 			try {
-				Deque<StoredEvent> streamEvents = eventStreams.computeIfAbsent(streamId, s -> new LinkedList<>());
+				Deque<StoredEvent> streamEvents = eventStreams.computeIfAbsent(messageId.transportId(),
+						s -> new LinkedList<>());
 				streamEvents.addLast(storedEvent);
-				eventIndex.put(eventId, storedEvent);
+				eventIndex.put(messageId, storedEvent);
 
 				evictExpired(streamEvents);
 				evictMaxEvents(streamEvents);
@@ -69,8 +74,6 @@ public class InMemoryMcpEventStore implements McpEventStore {
 			finally {
 				lock.writeLock().unlock();
 			}
-
-			return eventId;
 		});
 	}
 
@@ -84,7 +87,7 @@ public class InMemoryMcpEventStore implements McpEventStore {
 			StoredEvent event = streamEvents.peekFirst();
 			if (now - event.timestamp() > eventTtl.toMillis()) {
 				streamEvents.removeFirst();
-				eventIndex.remove(event.eventId());
+				eventIndex.remove(event.messageId());
 			}
 			else {
 				break;
@@ -99,12 +102,12 @@ public class InMemoryMcpEventStore implements McpEventStore {
 
 		while (streamEvents.size() > maxEventsPerStream) {
 			StoredEvent event = streamEvents.removeFirst();
-			eventIndex.remove(event.eventId());
+			eventIndex.remove(event.messageId());
 		}
 	}
 
 	@Override
-	public Flux<StoredEvent> replayEventsAfter(String lastEventId) {
+	public Flux<StoredEvent> replayEventsAfter(MessageId lastEventId) {
 		return Flux.defer(() -> {
 			List<StoredEvent> replayEvents = new ArrayList<>();
 			lock.readLock().lock();
@@ -114,7 +117,7 @@ public class InMemoryMcpEventStore implements McpEventStore {
 					return Flux.empty();
 				}
 
-				Deque<StoredEvent> streamEvents = eventStreams.get(lastStoredEvent.streamId());
+				Deque<StoredEvent> streamEvents = eventStreams.get(lastStoredEvent.transportId());
 				if (streamEvents == null || streamEvents.isEmpty()) {
 					return Flux.empty();
 				}
@@ -124,7 +127,7 @@ public class InMemoryMcpEventStore implements McpEventStore {
 					if (foundLastEvent) {
 						replayEvents.add(event);
 					}
-					else if (event.eventId().equals(lastEventId)) {
+					else if (event.messageId().equals(lastEventId)) {
 						foundLastEvent = true;
 					}
 				}
@@ -133,6 +136,26 @@ public class InMemoryMcpEventStore implements McpEventStore {
 			finally {
 				lock.readLock().unlock();
 			}
+		});
+	}
+
+	@Override
+	public Mono<Void> clearEventsOfTransportAfterTtl(String transportId) {
+		return Mono.fromRunnable(() -> {
+			scheduledExecutor.schedule(() -> {
+				lock.writeLock().lock();
+				try {
+					Deque<StoredEvent> removedEvents = eventStreams.remove(transportId);
+					if (removedEvents != null) {
+						for (StoredEvent event : removedEvents) {
+							eventIndex.remove(event.messageId());
+						}
+					}
+				}
+				finally {
+					lock.writeLock().unlock();
+				}
+			}, eventTtl.toMillis(), TimeUnit.MILLISECONDS);
 		});
 	}
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpEventStore.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpEventStore.java
@@ -5,8 +5,10 @@ import reactor.core.publisher.Mono;
 
 public interface McpEventStore {
 
-	Mono<String> storeEvent(String streamId, McpSchema.JSONRPCMessage message);
+	Mono<Void> storeEvent(MessageId messageId, McpSchema.JSONRPCMessage message);
 
-	Flux<StoredEvent> replayEventsAfter(String lastEventId);
+	Flux<StoredEvent> replayEventsAfter(MessageId lastEventId);
+
+	Mono<Void> clearEventsOfTransportAfterTtl(String transportId);
 
 }

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpEventStore.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpEventStore.java
@@ -1,0 +1,12 @@
+package io.modelcontextprotocol.spec;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+interface McpEventStore {
+
+	Mono<String> storeEvent(String streamId, McpSchema.JSONRPCMessage message);
+
+	Flux<StoredEvent> replayEventsAfter(String lastEventId);
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpEventStore.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpEventStore.java
@@ -3,7 +3,7 @@ package io.modelcontextprotocol.spec;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-interface McpEventStore {
+public interface McpEventStore {
 
 	Mono<String> storeEvent(String streamId, McpSchema.JSONRPCMessage message);
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/MessageId.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/MessageId.java
@@ -1,0 +1,50 @@
+package io.modelcontextprotocol.spec;
+
+import java.util.Objects;
+
+public class MessageId {
+
+	private static final String DELIMITER = "_";
+
+	private final String value;
+
+	private MessageId(String value) {
+		this.value = value;
+	};
+
+	// This ID design allows for a constant-time extraction of the history by
+	// precisely identifying the SSE stream using the first component
+	public static MessageId of(String transportId, String uniqueValue) {
+		return new MessageId(transportId + DELIMITER + uniqueValue);
+	}
+
+	public static MessageId from(String lastEventId) {
+		return new MessageId(lastEventId);
+	}
+
+	public String value() {
+		return value;
+	}
+
+	public String transportId() {
+		return value.split(DELIMITER, 2)[0];
+	}
+
+	public boolean isValidFormat() {
+		return value.split(DELIMITER).length == 2;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (o == null || getClass() != o.getClass())
+			return false;
+		MessageId messageId = (MessageId) o;
+		return Objects.equals(value(), messageId.value());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(value());
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/StoredEvent.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/StoredEvent.java
@@ -1,0 +1,4 @@
+package io.modelcontextprotocol.spec;
+
+public record StoredEvent(String eventId, String eventType, String eventData, long timestamp) {
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/StoredEvent.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/StoredEvent.java
@@ -1,4 +1,8 @@
 package io.modelcontextprotocol.spec;
 
-public record StoredEvent(String eventId, String streamId, McpSchema.JSONRPCMessage event, long timestamp) {
+public record StoredEvent(MessageId messageId, McpSchema.JSONRPCMessage message, long timestamp) {
+
+	public String transportId() {
+		return messageId.transportId();
+	}
 }

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/StoredEvent.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/StoredEvent.java
@@ -1,4 +1,4 @@
 package io.modelcontextprotocol.spec;
 
-public record StoredEvent(String eventId, String eventType, String eventData, long timestamp) {
+public record StoredEvent(String eventId, String streamId, McpSchema.JSONRPCMessage event, long timestamp) {
 }

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/InMemoryMcpEventStoreTest.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/InMemoryMcpEventStoreTest.java
@@ -1,38 +1,64 @@
 package io.modelcontextprotocol.spec;
 
-import org.junit.jupiter.api.Test;
-import reactor.test.StepVerifier;
-
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class InMemoryMcpEventStoreTest {
 
 	@Test
-	void storeEventStoresEventAndReturnsGeneratedId() {
-		InMemoryMcpEventStore eventStore = new InMemoryMcpEventStore(null, null);
+	void storeEventStoresEventAndReplaysEventsAfterMessageId() {
+		InMemoryMcpEventStore eventStore = new InMemoryMcpEventStore(null, Duration.ofSeconds(30));
 		String streamId = "test-stream";
+		MessageId firstMessageId = MessageId.of(streamId, "req-1");
 		McpSchema.JSONRPCMessage message = new McpSchema.JSONRPCRequest("2.0", "tools/list", "req-1",
 				Map.of("limit", 1));
 
-		String eventId = eventStore.storeEvent(streamId, message).block();
+		eventStore.storeEvent(firstMessageId, message).block();
 
-		assertNotNull(eventId);
-		assertTrue(eventId.startsWith(streamId + "_"));
-
+		MessageId secondMessageId = MessageId.of(streamId, "req-2");
 		McpSchema.JSONRPCRequest nextMessage = new McpSchema.JSONRPCRequest("2.0", "tools/list", "req-2", null);
-		eventStore.storeEvent(streamId, nextMessage).block();
+		eventStore.storeEvent(secondMessageId, nextMessage).block();
 
-		StepVerifier.create(eventStore.replayEventsAfter(eventId)).assertNext(storedEvent -> {
-			assertEquals(streamId, storedEvent.streamId());
-			assertEquals(nextMessage, storedEvent.event());
+		StepVerifier.create(eventStore.replayEventsAfter(firstMessageId)).assertNext(storedEvent -> {
+			assertEquals(streamId, storedEvent.messageId().transportId());
+			assertEquals(secondMessageId, storedEvent.messageId());
+			assertEquals(nextMessage, storedEvent.message());
 			assertTrue(storedEvent.timestamp() > 0);
 		}).verifyComplete();
+	}
+
+	@Test
+	void replayEventsAfterReplaysOnlyEventsFromSameStream() {
+		InMemoryMcpEventStore eventStore = new InMemoryMcpEventStore(null, Duration.ofSeconds(30));
+
+		MessageId streamAFirst = MessageId.of("stream-a", "1");
+		MessageId streamBFirst = MessageId.of("stream-b", "1");
+		MessageId streamASecond = MessageId.of("stream-a", "2");
+
+		eventStore.storeEvent(streamAFirst, new McpSchema.JSONRPCNotification("2.0", "a/first", null)).block();
+		eventStore.storeEvent(streamBFirst, new McpSchema.JSONRPCNotification("2.0", "b/first", null)).block();
+		eventStore.storeEvent(streamASecond, new McpSchema.JSONRPCNotification("2.0", "a/second", null)).block();
+
+		StepVerifier.create(eventStore.replayEventsAfter(streamAFirst))
+			.assertNext(event -> assertEquals(streamASecond, event.messageId()))
+			.verifyComplete();
+	}
+
+	@Test
+	void replayEventsAfterUnknownMessageIdReturnsEmpty() {
+		InMemoryMcpEventStore eventStore = new InMemoryMcpEventStore(null, Duration.ofSeconds(30));
+
+		eventStore.storeEvent(MessageId.of("stream-a", "1"), new McpSchema.JSONRPCNotification("2.0", "a/first", null))
+			.block();
+
+		StepVerifier.create(eventStore.replayEventsAfter(MessageId.of("stream-a", "does-not-exist"))).verifyComplete();
 	}
 
 	@Test
@@ -40,69 +66,66 @@ class InMemoryMcpEventStoreTest {
 		AtomicLong now = new AtomicLong(1_000);
 		InMemoryMcpEventStore eventStore = new InMemoryMcpEventStore(null, Duration.ofMillis(10), now::get);
 		String streamId = "ttl-stream";
+		MessageId firstMessageId = MessageId.of(streamId, "req-1");
+		MessageId secondMessageId = MessageId.of(streamId, "req-2");
+		MessageId thirdMessageId = MessageId.of(streamId, "req-3");
 
-		String firstEventId = eventStore
-			.storeEvent(streamId, new McpSchema.JSONRPCRequest("2.0", "resources/list", "req-1", null))
+		eventStore.storeEvent(firstMessageId, new McpSchema.JSONRPCRequest("2.0", "resources/list", "req-1", null))
 			.block();
 
 		now.addAndGet(30);
 
-		String secondEventId = eventStore
-			.storeEvent(streamId, new McpSchema.JSONRPCRequest("2.0", "resources/list", "req-2", null))
+		eventStore.storeEvent(secondMessageId, new McpSchema.JSONRPCRequest("2.0", "resources/list", "req-2", null))
 			.block();
 
 		now.addAndGet(5);
 
-		String thirdEventId = eventStore
-			.storeEvent(streamId, new McpSchema.JSONRPCRequest("2.0", "resources/list", "req-2", null))
+		eventStore.storeEvent(thirdMessageId, new McpSchema.JSONRPCRequest("2.0", "resources/list", "req-3", null))
 			.block();
 
-		StepVerifier.create(eventStore.replayEventsAfter(firstEventId)).verifyComplete();
-		StepVerifier.create(eventStore.replayEventsAfter(secondEventId)).assertNext(event -> {
-			System.out.println(event);
-			assertEquals(thirdEventId, event.eventId());
-		}).verifyComplete();
-	}
-
-	@Test
-	void storeEventRespectsMaxEventsPerStream() {
-		InMemoryMcpEventStore eventStore = new InMemoryMcpEventStore(2, null);
-		String streamId = "max-stream";
-
-		String firstEventId = eventStore
-			.storeEvent(streamId, new McpSchema.JSONRPCRequest("2.0", "tools/list", "req-1", null))
-			.block();
-		String secondEventId = eventStore
-			.storeEvent(streamId, new McpSchema.JSONRPCRequest("2.0", "tools/list", "req-2", null))
-			.block();
-		String thirdEventId = eventStore
-			.storeEvent(streamId, new McpSchema.JSONRPCRequest("2.0", "tools/list", "req-3", null))
-			.block();
-
-		StepVerifier.create(eventStore.replayEventsAfter(firstEventId)).verifyComplete();
-		StepVerifier.create(eventStore.replayEventsAfter(secondEventId))
-			.assertNext(event -> assertEquals(thirdEventId, event.eventId()))
+		StepVerifier.create(eventStore.replayEventsAfter(firstMessageId)).verifyComplete();
+		StepVerifier.create(eventStore.replayEventsAfter(secondMessageId))
+			.assertNext(event -> assertEquals(thirdMessageId, event.messageId()))
 			.verifyComplete();
 	}
 
 	@Test
-	void storeEventDoesNotEvictByTtlWhenTtlIsNull() {
-		AtomicLong now = new AtomicLong(2_000);
-		InMemoryMcpEventStore eventStore = new InMemoryMcpEventStore(null, null, now::get);
-		String streamId = "ttl-null-stream";
+	void storeEventRespectsMaxEventsPerStream() {
+		InMemoryMcpEventStore eventStore = new InMemoryMcpEventStore(2, Duration.ofSeconds(30));
+		String streamId = "max-stream";
+		MessageId firstMessageId = MessageId.of(streamId, "req-1");
+		MessageId secondMessageId = MessageId.of(streamId, "req-2");
+		MessageId thirdMessageId = MessageId.of(streamId, "req-3");
 
-		String firstEventId = eventStore
-			.storeEvent(streamId, new McpSchema.JSONRPCRequest("2.0", "resources/list", "req-1", null))
+		eventStore.storeEvent(firstMessageId, new McpSchema.JSONRPCRequest("2.0", "tools/list", "req-1", null)).block();
+		eventStore.storeEvent(secondMessageId, new McpSchema.JSONRPCRequest("2.0", "tools/list", "req-2", null))
+			.block();
+		eventStore.storeEvent(thirdMessageId, new McpSchema.JSONRPCRequest("2.0", "tools/list", "req-3", null)).block();
+
+		StepVerifier.create(eventStore.replayEventsAfter(firstMessageId)).verifyComplete();
+		StepVerifier.create(eventStore.replayEventsAfter(secondMessageId))
+			.assertNext(event -> assertEquals(thirdMessageId, event.messageId()))
+			.verifyComplete();
+	}
+
+	@Test
+	void storeEventDoesNotEvictWithinTtlWindow() {
+		AtomicLong now = new AtomicLong(2_000);
+		InMemoryMcpEventStore eventStore = new InMemoryMcpEventStore(null, Duration.ofMillis(50), now::get);
+		String streamId = "ttl-null-stream";
+		MessageId firstMessageId = MessageId.of(streamId, "req-1");
+		MessageId secondMessageId = MessageId.of(streamId, "req-2");
+
+		eventStore.storeEvent(firstMessageId, new McpSchema.JSONRPCRequest("2.0", "resources/list", "req-1", null))
 			.block();
 
 		now.addAndGet(30);
 
-		String secondEventId = eventStore
-			.storeEvent(streamId, new McpSchema.JSONRPCRequest("2.0", "resources/list", "req-2", null))
+		eventStore.storeEvent(secondMessageId, new McpSchema.JSONRPCRequest("2.0", "resources/list", "req-2", null))
 			.block();
 
-		StepVerifier.create(eventStore.replayEventsAfter(firstEventId))
-			.assertNext(event -> assertEquals(secondEventId, event.eventId()))
+		StepVerifier.create(eventStore.replayEventsAfter(firstMessageId))
+			.assertNext(event -> assertEquals(secondMessageId, event.messageId()))
 			.verifyComplete();
 	}
 
@@ -110,20 +133,18 @@ class InMemoryMcpEventStoreTest {
 	void storeEventDoesNotEvictByMaxWhenMaxEventsPerStreamIsNull() {
 		InMemoryMcpEventStore eventStore = new InMemoryMcpEventStore(null, Duration.ofSeconds(10));
 		String streamId = "max-null-stream";
+		MessageId firstMessageId = MessageId.of(streamId, "req-1");
+		MessageId secondMessageId = MessageId.of(streamId, "req-2");
+		MessageId thirdMessageId = MessageId.of(streamId, "req-3");
 
-		String firstEventId = eventStore
-			.storeEvent(streamId, new McpSchema.JSONRPCRequest("2.0", "tools/list", "req-1", null))
+		eventStore.storeEvent(firstMessageId, new McpSchema.JSONRPCRequest("2.0", "tools/list", "req-1", null)).block();
+		eventStore.storeEvent(secondMessageId, new McpSchema.JSONRPCRequest("2.0", "tools/list", "req-2", null))
 			.block();
-		String secondEventId = eventStore
-			.storeEvent(streamId, new McpSchema.JSONRPCRequest("2.0", "tools/list", "req-2", null))
-			.block();
-		String thirdEventId = eventStore
-			.storeEvent(streamId, new McpSchema.JSONRPCRequest("2.0", "tools/list", "req-3", null))
-			.block();
+		eventStore.storeEvent(thirdMessageId, new McpSchema.JSONRPCRequest("2.0", "tools/list", "req-3", null)).block();
 
-		StepVerifier.create(eventStore.replayEventsAfter(firstEventId))
-			.assertNext(event -> assertEquals(secondEventId, event.eventId()))
-			.assertNext(event -> assertEquals(thirdEventId, event.eventId()))
+		StepVerifier.create(eventStore.replayEventsAfter(firstMessageId))
+			.assertNext(event -> assertEquals(secondMessageId, event.messageId()))
+			.assertNext(event -> assertEquals(thirdMessageId, event.messageId()))
 			.verifyComplete();
 	}
 

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/InMemoryMcpEventStoreTest.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/InMemoryMcpEventStoreTest.java
@@ -1,0 +1,130 @@
+package io.modelcontextprotocol.spec;
+
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class InMemoryMcpEventStoreTest {
+
+	@Test
+	void storeEventStoresEventAndReturnsGeneratedId() {
+		InMemoryMcpEventStore eventStore = new InMemoryMcpEventStore(null, null);
+		String streamId = "test-stream";
+		McpSchema.JSONRPCMessage message = new McpSchema.JSONRPCRequest("2.0", "tools/list", "req-1",
+				Map.of("limit", 1));
+
+		String eventId = eventStore.storeEvent(streamId, message).block();
+
+		assertNotNull(eventId);
+		assertTrue(eventId.startsWith(streamId + "_"));
+
+		McpSchema.JSONRPCRequest nextMessage = new McpSchema.JSONRPCRequest("2.0", "tools/list", "req-2", null);
+		eventStore.storeEvent(streamId, nextMessage).block();
+
+		StepVerifier.create(eventStore.replayEventsAfter(eventId)).assertNext(storedEvent -> {
+			assertEquals(streamId, storedEvent.streamId());
+			assertEquals(nextMessage, storedEvent.event());
+			assertTrue(storedEvent.timestamp() > 0);
+		}).verifyComplete();
+	}
+
+	@Test
+	void storeEventEvictsExpiredEventsWhenTtlIsConfigured() {
+		AtomicLong now = new AtomicLong(1_000);
+		InMemoryMcpEventStore eventStore = new InMemoryMcpEventStore(null, Duration.ofMillis(10), now::get);
+		String streamId = "ttl-stream";
+
+		String firstEventId = eventStore
+			.storeEvent(streamId, new McpSchema.JSONRPCRequest("2.0", "resources/list", "req-1", null))
+			.block();
+
+		now.addAndGet(30);
+
+		String secondEventId = eventStore
+			.storeEvent(streamId, new McpSchema.JSONRPCRequest("2.0", "resources/list", "req-2", null))
+			.block();
+
+		now.addAndGet(5);
+
+		String thirdEventId = eventStore
+			.storeEvent(streamId, new McpSchema.JSONRPCRequest("2.0", "resources/list", "req-2", null))
+			.block();
+
+		StepVerifier.create(eventStore.replayEventsAfter(firstEventId)).verifyComplete();
+		StepVerifier.create(eventStore.replayEventsAfter(secondEventId)).assertNext(event -> {
+			System.out.println(event);
+			assertEquals(thirdEventId, event.eventId());
+		}).verifyComplete();
+	}
+
+	@Test
+	void storeEventRespectsMaxEventsPerStream() {
+		InMemoryMcpEventStore eventStore = new InMemoryMcpEventStore(2, null);
+		String streamId = "max-stream";
+
+		String firstEventId = eventStore
+			.storeEvent(streamId, new McpSchema.JSONRPCRequest("2.0", "tools/list", "req-1", null))
+			.block();
+		String secondEventId = eventStore
+			.storeEvent(streamId, new McpSchema.JSONRPCRequest("2.0", "tools/list", "req-2", null))
+			.block();
+		String thirdEventId = eventStore
+			.storeEvent(streamId, new McpSchema.JSONRPCRequest("2.0", "tools/list", "req-3", null))
+			.block();
+
+		StepVerifier.create(eventStore.replayEventsAfter(firstEventId)).verifyComplete();
+		StepVerifier.create(eventStore.replayEventsAfter(secondEventId))
+			.assertNext(event -> assertEquals(thirdEventId, event.eventId()))
+			.verifyComplete();
+	}
+
+	@Test
+	void storeEventDoesNotEvictByTtlWhenTtlIsNull() {
+		AtomicLong now = new AtomicLong(2_000);
+		InMemoryMcpEventStore eventStore = new InMemoryMcpEventStore(null, null, now::get);
+		String streamId = "ttl-null-stream";
+
+		String firstEventId = eventStore
+			.storeEvent(streamId, new McpSchema.JSONRPCRequest("2.0", "resources/list", "req-1", null))
+			.block();
+
+		now.addAndGet(30);
+
+		String secondEventId = eventStore
+			.storeEvent(streamId, new McpSchema.JSONRPCRequest("2.0", "resources/list", "req-2", null))
+			.block();
+
+		StepVerifier.create(eventStore.replayEventsAfter(firstEventId))
+			.assertNext(event -> assertEquals(secondEventId, event.eventId()))
+			.verifyComplete();
+	}
+
+	@Test
+	void storeEventDoesNotEvictByMaxWhenMaxEventsPerStreamIsNull() {
+		InMemoryMcpEventStore eventStore = new InMemoryMcpEventStore(null, Duration.ofSeconds(10));
+		String streamId = "max-null-stream";
+
+		String firstEventId = eventStore
+			.storeEvent(streamId, new McpSchema.JSONRPCRequest("2.0", "tools/list", "req-1", null))
+			.block();
+		String secondEventId = eventStore
+			.storeEvent(streamId, new McpSchema.JSONRPCRequest("2.0", "tools/list", "req-2", null))
+			.block();
+		String thirdEventId = eventStore
+			.storeEvent(streamId, new McpSchema.JSONRPCRequest("2.0", "tools/list", "req-3", null))
+			.block();
+
+		StepVerifier.create(eventStore.replayEventsAfter(firstEventId))
+			.assertNext(event -> assertEquals(secondEventId, event.eventId()))
+			.assertNext(event -> assertEquals(thirdEventId, event.eventId()))
+			.verifyComplete();
+	}
+
+}

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/McpStreamableServerSessionResumabilityTest.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/McpStreamableServerSessionResumabilityTest.java
@@ -1,0 +1,193 @@
+package io.modelcontextprotocol.spec;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.modelcontextprotocol.json.TypeRef;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class McpStreamableServerSessionResumabilityTest {
+
+	@Test
+	void generatedEventIdsAreUniqueAcrossStreamsAndContainStreamInformation() {
+		McpStreamableServerSession session = createSession(null);
+
+		CapturingStreamTransport firstStreamTransport = new CapturingStreamTransport();
+		McpStreamableServerSession.McpStreamableServerSessionStream firstStream = session
+			.listeningStream(firstStreamTransport);
+		firstStream.sendNotification("test/first", Map.of("message", "one")).block();
+
+		CapturingStreamTransport secondStreamTransport = new CapturingStreamTransport();
+		McpStreamableServerSession.McpStreamableServerSessionStream secondStream = session
+			.listeningStream(secondStreamTransport);
+		secondStream.sendNotification("test/second", Map.of("message", "two")).block();
+
+		String firstEventIdValue = firstStreamTransport.messageIds.get(0);
+		String secondEventIdValue = secondStreamTransport.messageIds.get(0);
+
+		MessageId firstEventId = MessageId.from(firstEventIdValue);
+		MessageId secondEventId = MessageId.from(secondEventIdValue);
+
+		assertThat(firstEventId.value()).isNotEqualTo(secondEventId.value());
+		assertThat(firstEventId.transportId()).isNotEqualTo(secondEventId.transportId());
+		assertThat(firstEventId.value()).startsWith(firstEventId.transportId() + "_");
+		assertThat(secondEventId.value()).startsWith(secondEventId.transportId() + "_");
+	}
+
+	@Test
+	void replayUsesLastEventIdAsCursorWithinOriginatingStreamOnly() {
+		InMemoryMcpEventStore eventStore = new InMemoryMcpEventStore(null, Duration.ofMinutes(5));
+		McpStreamableServerSession session = createSession(eventStore);
+
+		MessageId firstStreamFirst = MessageId.of("transport-a", "1");
+		MessageId firstStreamSecond = MessageId.of("transport-a", "2");
+		MessageId secondStreamFirst = MessageId.of("transport-b", "1");
+
+		eventStore
+			.storeEvent(firstStreamFirst, new McpSchema.JSONRPCNotification("2.0", "test/first", Map.of("order", 1)))
+			.block();
+		eventStore
+			.storeEvent(firstStreamSecond, new McpSchema.JSONRPCNotification("2.0", "test/second", Map.of("order", 2)))
+			.block();
+		eventStore
+			.storeEvent(secondStreamFirst, new McpSchema.JSONRPCNotification("2.0", "test/other", Map.of("order", 3)))
+			.block();
+
+		StepVerifier
+			.create(session.replay(firstStreamFirst.value()).map(storedEvent -> storedEvent.messageId().value()))
+			.expectNext(firstStreamSecond.value())
+			.verifyComplete();
+	}
+
+	@Test
+	void replayReturnsEmptyForUnknownOrMissingLastEventId() {
+		InMemoryMcpEventStore eventStore = new InMemoryMcpEventStore(null, Duration.ofMinutes(5));
+		McpStreamableServerSession session = createSession(eventStore);
+
+		eventStore
+			.storeEvent(MessageId.of("transport-a", "1"),
+					new McpSchema.JSONRPCNotification("2.0", "test/one", Map.of("ok", true)))
+			.block();
+
+		StepVerifier.create(session.replay("unknown-stream_unknown-id")).verifyComplete();
+		StepVerifier.create(session.replay(null)).verifyComplete();
+	}
+
+	@Test
+	void closeGracefullyClearsEventStoreBeforeClosingTransport() {
+		McpEventStore eventStore = mock(McpEventStore.class);
+		when(eventStore.clearEventsOfTransportAfterTtl(anyString())).thenReturn(Mono.empty());
+
+		AtomicBoolean transportClosed = new AtomicBoolean();
+		McpStreamableServerTransport transport = mockTransport(transportClosed);
+
+		McpStreamableServerSession session = createSession(eventStore);
+		McpStreamableServerSession.McpStreamableServerSessionStream stream = session.listeningStream(transport);
+
+		StepVerifier.create(stream.closeGracefully()).verifyComplete();
+
+		InOrder inOrder = inOrder(eventStore, transport);
+		inOrder.verify(eventStore).clearEventsOfTransportAfterTtl(anyString());
+		inOrder.verify(transport).closeGracefully();
+		assertThat(transportClosed.get()).isTrue();
+	}
+
+	@Test
+	void closeGracefullyDoesNotCloseTransportWhenEventStoreCleanupFails() {
+		RuntimeException cleanupFailure = new RuntimeException("cleanup failed");
+		McpEventStore eventStore = mock(McpEventStore.class);
+		when(eventStore.clearEventsOfTransportAfterTtl(anyString())).thenReturn(Mono.error(cleanupFailure));
+
+		AtomicBoolean transportClosed = new AtomicBoolean();
+		McpStreamableServerTransport transport = mockTransport(transportClosed);
+
+		McpStreamableServerSession session = createSession(eventStore);
+		McpStreamableServerSession.McpStreamableServerSessionStream stream = session.listeningStream(transport);
+
+		StepVerifier.create(stream.closeGracefully()).expectErrorMatches(error -> error == cleanupFailure).verify();
+
+		assertThat(transportClosed.get()).isFalse();
+	}
+
+	@Test
+	void closeGracefullyUsesStreamSpecificTransportIdForCleanup() {
+		McpEventStore eventStore = mock(McpEventStore.class);
+		AtomicReference<String> capturedTransportId = new AtomicReference<>();
+		when(eventStore.clearEventsOfTransportAfterTtl(anyString())).thenAnswer(invocation -> {
+			capturedTransportId.set(invocation.getArgument(0));
+			return Mono.empty();
+		});
+
+		McpStreamableServerSession session = createSession(eventStore);
+		McpStreamableServerSession.McpStreamableServerSessionStream firstStream = session
+			.listeningStream(new CapturingStreamTransport());
+		StepVerifier.create(firstStream.closeGracefully()).verifyComplete();
+		String firstTransportId = capturedTransportId.get();
+
+		McpStreamableServerSession.McpStreamableServerSessionStream secondStream = session
+			.listeningStream(new CapturingStreamTransport());
+		StepVerifier.create(secondStream.closeGracefully()).verifyComplete();
+		String secondTransportId = capturedTransportId.get();
+
+		assertThat(firstTransportId).isNotBlank();
+		assertThat(secondTransportId).isNotBlank();
+		assertThat(firstTransportId).isNotEqualTo(secondTransportId);
+		verify(eventStore).clearEventsOfTransportAfterTtl(firstTransportId);
+		verify(eventStore).clearEventsOfTransportAfterTtl(secondTransportId);
+	}
+
+	private McpStreamableServerSession createSession(McpEventStore eventStore) {
+		return new McpStreamableServerSession("session-1", McpSchema.ClientCapabilities.builder().roots(true).build(),
+				new McpSchema.Implementation("test-client", "1.0.0"), Duration.ofSeconds(5), Map.of(), Map.of(),
+				eventStore);
+	}
+
+	private McpStreamableServerTransport mockTransport(AtomicBoolean transportClosed) {
+		McpStreamableServerTransport transport = mock(McpStreamableServerTransport.class);
+		when(transport.sendMessage(org.mockito.ArgumentMatchers.any())).thenReturn(Mono.empty());
+		when(transport.sendMessage(org.mockito.ArgumentMatchers.any(), anyString())).thenReturn(Mono.empty());
+		when(transport.closeGracefully()).thenReturn(Mono.fromRunnable(() -> transportClosed.set(true)));
+		return transport;
+	}
+
+	private static final class CapturingStreamTransport implements McpStreamableServerTransport {
+
+		private final List<String> messageIds = new CopyOnWriteArrayList<>();
+
+		@Override
+		public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
+			return sendMessage(message, null);
+		}
+
+		@Override
+		public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message, String messageId) {
+			return Mono.fromRunnable(() -> this.messageIds.add(messageId));
+		}
+
+		@Override
+		public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+			return null;
+		}
+
+		@Override
+		public Mono<Void> closeGracefully() {
+			return Mono.empty();
+		}
+
+	}
+
+}

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/MessageIdTest.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/MessageIdTest.java
@@ -1,0 +1,38 @@
+package io.modelcontextprotocol.spec;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MessageIdTest {
+
+	@Test
+	void ofEncodesTransportIdIntoValue() {
+		MessageId messageId = MessageId.of("stream-123", "event-456");
+
+		assertThat(messageId.value()).isEqualTo("stream-123_event-456");
+		assertThat(messageId.transportId()).isEqualTo("stream-123");
+		assertThat(messageId.isValidFormat()).isTrue();
+	}
+
+	@Test
+	void fromParsesPreviouslyGeneratedIdWithoutChangingValue() {
+		MessageId generated = MessageId.of("stream-a", "cursor-1");
+
+		MessageId reparsed = MessageId.from(generated.value());
+
+		assertThat(reparsed.value()).isEqualTo(generated.value());
+		assertThat(reparsed.transportId()).isEqualTo("stream-a");
+		assertThat(reparsed).isEqualTo(generated);
+	}
+
+	@Test
+	void idsFromDifferentStreamsAreDistinctEvenWithSameEventSuffix() {
+		MessageId first = MessageId.of("stream-a", "same-event");
+		MessageId second = MessageId.of("stream-b", "same-event");
+
+		assertThat(first).isNotEqualTo(second);
+		assertThat(first.value()).isNotEqualTo(second.value());
+	}
+
+}

--- a/mcp-test/src/test/java/io/modelcontextprotocol/server/HttpServletStreamableResumabilityIntegrationTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/server/HttpServletStreamableResumabilityIntegrationTests.java
@@ -1,0 +1,240 @@
+package io.modelcontextprotocol.server;
+
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
+import io.modelcontextprotocol.server.transport.McpTestRequestRecordingServletFilter;
+import io.modelcontextprotocol.server.transport.TomcatTestUtil;
+import io.modelcontextprotocol.spec.InMemoryMcpEventStore;
+import io.modelcontextprotocol.spec.MessageId;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.ProtocolVersions;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.startup.Tomcat;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.test.StepVerifier;
+
+import static io.modelcontextprotocol.spec.HttpHeaders.ACCEPT;
+import static io.modelcontextprotocol.spec.HttpHeaders.CONTENT_TYPE;
+import static io.modelcontextprotocol.spec.HttpHeaders.LAST_EVENT_ID;
+import static io.modelcontextprotocol.spec.HttpHeaders.MCP_SESSION_ID;
+import static io.modelcontextprotocol.util.McpJsonMapperUtils.JSON_MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Timeout(20)
+class HttpServletStreamableResumabilityIntegrationTests {
+
+	private static final int PORT = TomcatTestUtil.findAvailablePort();
+
+	private static final String MESSAGE_ENDPOINT = "/mcp/message";
+
+	private HttpServletStreamableServerTransportProvider mcpServerTransportProvider;
+
+	private McpAsyncServer mcpServer;
+
+	private Tomcat tomcat;
+
+	private McpTestRequestRecordingServletFilter requestFilter;
+
+	private HttpClientStreamableHttpTransport firstTransport;
+
+	private HttpClientStreamableHttpTransport replayTransport;
+
+	@AfterEach
+	void after() {
+		if (firstTransport != null) {
+			firstTransport.closeGracefully().block();
+		}
+		if (replayTransport != null) {
+			replayTransport.closeGracefully().block();
+		}
+		if (mcpServer != null) {
+			mcpServer.closeGracefully().block();
+		}
+		if (mcpServerTransportProvider != null) {
+			mcpServerTransportProvider.closeGracefully().block();
+		}
+		if (tomcat != null) {
+			try {
+				tomcat.stop();
+				tomcat.destroy();
+			}
+			catch (LifecycleException e) {
+				throw new RuntimeException("Failed to stop Tomcat", e);
+			}
+		}
+	}
+
+	@Test
+	void replayUsesNaturallyStoredEventsAndLastEventIdHeader() throws Exception {
+		RecordingEventStore eventStore = new RecordingEventStore();
+		startServer(eventStore);
+		String sessionId = initializeSession();
+
+		openInitialSseStream(sessionId);
+		publishTwoServerNotifications();
+
+		String firstEventId = awaitAndGetFirstStoredEventId(eventStore);
+		ReplayResult replayResult = replayFromFirstEventId(sessionId, firstEventId);
+
+		assertThat(replayResult.message()).isInstanceOf(McpSchema.JSONRPCNotification.class);
+		assertThat(((McpSchema.JSONRPCNotification) replayResult.message()).method()).isEqualTo("test/two");
+		assertThat(replayResult.receivedMessages()).hasSize(1);
+		assertLastEventIdHeader(firstEventId);
+	}
+
+	private void openInitialSseStream(String sessionId) {
+		firstTransport = createTransport(sessionId, null);
+		StepVerifier.create(firstTransport.connect(mono -> mono)).verifyComplete();
+
+		Awaitility.await()
+			.atMost(Duration.ofSeconds(3))
+			.untilAsserted(() -> assertThat(requestFilter.getCalls()).anyMatch(call -> "GET".equals(call.method())
+					&& call.headers().keySet().stream().anyMatch(name -> name.equalsIgnoreCase(MCP_SESSION_ID))));
+	}
+
+	private void publishTwoServerNotifications() {
+		mcpServerTransportProvider.notifyClients("test/one", Map.of("order", 1)).block();
+		mcpServerTransportProvider.notifyClients("test/two", Map.of("order", 2)).block();
+	}
+
+	private String awaitAndGetFirstStoredEventId(RecordingEventStore eventStore) {
+		Awaitility.await()
+			.atMost(Duration.ofSeconds(3))
+			.untilAsserted(() -> assertThat(eventStore.storedIds()).hasSizeGreaterThanOrEqualTo(2));
+
+		String firstEventId = eventStore.storedIds().get(0);
+		String secondEventId = eventStore.storedIds().get(1);
+		assertThat(secondEventId).isNotEqualTo(firstEventId);
+		return firstEventId;
+	}
+
+	private ReplayResult replayFromFirstEventId(String sessionId, String firstEventId) {
+		Sinks.One<McpSchema.JSONRPCMessage> replayedMessage = Sinks.one();
+		CopyOnWriteArrayList<McpSchema.JSONRPCMessage> replayReceived = new CopyOnWriteArrayList<>();
+
+		replayTransport = createTransport(sessionId, firstEventId);
+		StepVerifier.create(replayTransport.connect(mono -> mono.doOnNext(message -> {
+			replayReceived.add(message);
+			replayedMessage.tryEmitValue(message);
+		}))).verifyComplete();
+
+		McpSchema.JSONRPCMessage replayed = replayedMessage.asMono().block(Duration.ofSeconds(3));
+		assertThat(replayed).isNotNull();
+		return new ReplayResult(replayed, replayReceived);
+	}
+
+	private HttpClientStreamableHttpTransport createTransport(String sessionId, String lastEventId) {
+		return HttpClientStreamableHttpTransport.builder("http://localhost:" + PORT)
+			.endpoint(MESSAGE_ENDPOINT)
+			.openConnectionOnStartup(true)
+			.asyncHttpRequestCustomizer((builder, method, uri, body, context) -> {
+				if ("GET".equals(method)) {
+					builder.header(MCP_SESSION_ID, sessionId);
+					if (lastEventId != null) {
+						builder.header(LAST_EVENT_ID, lastEventId);
+					}
+				}
+				return Mono.just(builder);
+			})
+			.build();
+	}
+
+	private void assertLastEventIdHeader(String firstEventId) {
+		McpTestRequestRecordingServletFilter.Call replayCall = requestFilter.getCalls()
+			.stream()
+			.filter(call -> "GET".equals(call.method())
+					&& call.headers().keySet().stream().anyMatch(name -> name.equalsIgnoreCase(LAST_EVENT_ID)))
+			.reduce((first, second) -> second)
+			.orElseThrow();
+
+		String lastEventIdHeaderValue = replayCall.headers()
+			.entrySet()
+			.stream()
+			.filter(entry -> entry.getKey().equalsIgnoreCase(LAST_EVENT_ID))
+			.map(Map.Entry::getValue)
+			.findFirst()
+			.orElseThrow();
+
+		assertThat(lastEventIdHeaderValue).isEqualTo(firstEventId);
+	}
+
+	private void startServer(InMemoryMcpEventStore eventStore) {
+		requestFilter = new McpTestRequestRecordingServletFilter();
+
+		mcpServerTransportProvider = HttpServletStreamableServerTransportProvider.builder()
+			.mcpEndpoint(MESSAGE_ENDPOINT)
+			.build();
+		mcpServer = McpServer.async(mcpServerTransportProvider).eventStore(eventStore).build();
+
+		tomcat = TomcatTestUtil.createTomcatServer("", PORT, mcpServerTransportProvider, requestFilter);
+		try {
+			tomcat.start();
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Failed to start Tomcat", e);
+		}
+	}
+
+	private String initializeSession() throws Exception {
+		McpSchema.InitializeRequest initializeRequest = new McpSchema.InitializeRequest(ProtocolVersions.MCP_2025_11_25,
+				McpSchema.ClientCapabilities.builder().roots(true).build(),
+				new McpSchema.Implementation("E2E Client", "1.0.0"));
+
+		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION,
+				McpSchema.METHOD_INITIALIZE, "init-1", initializeRequest);
+
+		HttpURLConnection connection = (HttpURLConnection) new URL("http://localhost:" + PORT + MESSAGE_ENDPOINT)
+			.openConnection();
+		connection.setRequestMethod("POST");
+		connection.setDoOutput(true);
+		connection.setRequestProperty(CONTENT_TYPE, "application/json");
+		connection.setRequestProperty(ACCEPT, "application/json, text/event-stream");
+		byte[] body = JSON_MAPPER.writeValueAsBytes(request);
+		try (OutputStream outputStream = connection.getOutputStream()) {
+			outputStream.write(body);
+		}
+
+		assertThat(connection.getResponseCode()).isEqualTo(200);
+		String sessionId = connection.getHeaderField(MCP_SESSION_ID);
+		assertThat(sessionId).isNotBlank();
+		connection.disconnect();
+		return sessionId;
+	}
+
+	private record ReplayResult(McpSchema.JSONRPCMessage message,
+			CopyOnWriteArrayList<McpSchema.JSONRPCMessage> receivedMessages) {
+	}
+
+	private static final class RecordingEventStore extends InMemoryMcpEventStore {
+
+		private final CopyOnWriteArrayList<String> storedIds = new CopyOnWriteArrayList<>();
+
+		private RecordingEventStore() {
+			super(null, Duration.ofMinutes(5));
+		}
+
+		@Override
+		public Mono<Void> storeEvent(MessageId messageId, McpSchema.JSONRPCMessage message) {
+			storedIds.add(messageId.value());
+			return super.storeEvent(messageId, message);
+		}
+
+		private CopyOnWriteArrayList<String> storedIds() {
+			return this.storedIds;
+		}
+
+	}
+
+}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
 Implemented SSE resumability/redelivery support for Streamable HTTP by introducing an event-store abstraction, adding in-memory event persistence/replay, wiring Last-Event-ID handling through server session/transport layers, and adding comprehensive unit/integration tests.

I haven't discussed this PR enough, so I haven't created enough Java doc documentation and tests. If there's a chance this PR will be merged, I'll try to improve it.

## Motivation and Context
Implementation of MCP documentation.

## How Has This Been Tested?
I worte some tests, and also i play it on my device.

## Breaking Changes
nop

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
