### PR TITLE
fix: keep connection open after responseStream to enable keep-alive ping

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpStreamableServerSession.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpStreamableServerSession.java
@@ -171,7 +171,8 @@ public class McpStreamableServerSession implements McpLoggableSession {
 				return transport
 					.sendMessage(new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, jsonrpcRequest.id(), null,
 							new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.METHOD_NOT_FOUND,
-									error.message(), error.data())));
+									error.message(), error.data())))
+					.then(promoteToListeningStreamOrClose(stream, transport));
 			}
 			return requestHandler
 				.handle(new McpAsyncServerExchange(this.id, stream, clientCapabilities.get(), clientInfo.get(),
@@ -189,7 +190,30 @@ public class McpStreamableServerSession implements McpLoggableSession {
 					return Mono.just(errorResponse);
 				})
 				.flatMap(transport::sendMessage)
-				.then(transport.closeGracefully());
+				.then(promoteToListeningStreamOrClose(stream, transport));
+		});
+	}
+
+	/**
+	 * Promotes the given response stream to the session's listening stream if no
+	 * listening stream has been established yet. If a listening stream already exists,
+	 * closes the transport gracefully. This allows clients that only use POST (without a
+	 * separate GET SSE stream) to keep the connection alive for keep-alive pings.
+	 * @param stream the response stream to potentially promote
+	 * @param transport the transport to close if promotion is not needed
+	 * @return Mono that completes after either promoting or closing
+	 */
+	private Mono<Void> promoteToListeningStreamOrClose(McpStreamableServerSessionStream stream,
+			McpStreamableServerTransport transport) {
+		return Mono.defer(() -> {
+			McpLoggableSession currentListeningStream = this.listeningStreamRef.get();
+			if (currentListeningStream == this.missingMcpTransportSession) {
+				if (this.listeningStreamRef.compareAndSet(this.missingMcpTransportSession, stream)) {
+					logger.debug("Converted response stream to listening stream for session {}", this.id);
+					return Mono.empty();
+				}
+			}
+			return transport.closeGracefully();
 		});
 	}
 


### PR DESCRIPTION
## Problem

When a Streamable HTTP client (e.g. Cursor) sends a JSON-RPC request such as
`tools/list` without establishing a separate GET SSE listening stream,
`responseStream()` calls `transport.closeGracefully()` immediately after sending
the response. This closes the SSE connection, preventing `KeepAliveScheduler`
from sending ping messages through it.

As a result, clients that rely on keep-alive pings to detect connection health
(e.g. Cursor) mark the MCP server as disconnected (red state) after the idle
timeout period.

Fixes #681

## Root Cause

In `McpStreamableServerSession.responseStream()`, after sending the response:

- The **normal handler path** unconditionally called `.then(transport.closeGracefully())`,
  closing the SSE connection immediately.
- The **method-not-found path** returned after `sendMessage()` without promoting
  the transport to a listening stream.

In both cases, `listeningStreamRef` remains pointing to `MissingMcpTransportSession`,
causing `KeepAliveScheduler` ping attempts to fail with "Stream unavailable".