### PR TITLE
Remove invalid WARN message for missing notification handler in stateless servers

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
@@ -133,8 +133,24 @@ public class McpStatelessAsyncServer {
 
 		this.protocolVersions = new ArrayList<>(mcpTransport.protocolVersions());
 
-		McpStatelessServerHandler handler = new DefaultMcpStatelessServerHandler(requestHandlers, Map.of());
+		Map<String, McpStatelessNotificationHandler> notificationHandlers = prepareNotificationHandlers();
+		McpStatelessServerHandler handler = new DefaultMcpStatelessServerHandler(requestHandlers, notificationHandlers);
 		mcpTransport.setMcpHandler(handler);
+	}
+
+	private Map<String, McpStatelessNotificationHandler> prepareNotificationHandlers() {
+		Map<String, McpStatelessNotificationHandler> notificationHandlers = new HashMap<>();
+
+		notificationHandlers.put(McpSchema.METHOD_NOTIFICATION_INITIALIZED, (exchange, params) -> {
+			logger.debug("Received {}", McpSchema.METHOD_NOTIFICATION_INITIALIZED);
+			return Mono.empty();
+		});
+		notificationHandlers.put(McpSchema.METHOD_NOTIFICATION_ROOTS_LIST_CHANGED, (exchange, params) -> {
+			logger.debug("Received {}", McpSchema.METHOD_NOTIFICATION_ROOTS_LIST_CHANGED);
+			return Mono.empty();
+		});
+
+		return notificationHandlers;
 	}
 
 	// ---------------------------------------

--- a/mcp-test/src/test/java/io/modelcontextprotocol/server/HttpServletStatelessIntegrationTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/server/HttpServletStatelessIntegrationTests.java
@@ -11,6 +11,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
 import io.modelcontextprotocol.common.McpTransportContext;
@@ -42,13 +46,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.client.RestClient;
-import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
-
 import static io.modelcontextprotocol.server.transport.HttpServletStatelessServerTransport.APPLICATION_JSON;
 import static io.modelcontextprotocol.server.transport.HttpServletStatelessServerTransport.TEXT_EVENT_STREAM;
 import static io.modelcontextprotocol.util.McpJsonMapperUtils.JSON_MAPPER;
@@ -808,6 +812,63 @@ class HttpServletStatelessIntegrationTests {
 		finally {
 			mcpServer.closeGracefully();
 		}
+	}
+
+	@Test
+	void testInitializedNotificationDoesNotLogWarn() {
+		Logger handlerLogger = (Logger) LoggerFactory.getLogger(DefaultMcpStatelessServerHandler.class);
+		ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
+		logAppender.start();
+		handlerLogger.addAppender(logAppender);
+
+		try {
+			var mcpServer = McpServer.sync(mcpStatelessServerTransport)
+				.serverInfo("test-server", "1.0.0")
+				.capabilities(ServerCapabilities.builder().build())
+				.build();
+
+			try (var mcpClient = clientBuilder.build()) {
+				mcpClient.initialize(); // automatically sends notifications/initialized
+			}
+			finally {
+				mcpServer.close();
+			}
+		}
+		finally {
+			handlerLogger.detachAppender(logAppender);
+			logAppender.stop();
+		}
+
+		assertThat(logAppender.list).noneMatch(event -> event.getLevel() == Level.WARN);
+	}
+
+	@Test
+	void testRootsListChangedNotificationDoesNotLogWarn() {
+		Logger handlerLogger = (Logger) LoggerFactory.getLogger(DefaultMcpStatelessServerHandler.class);
+		ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
+		logAppender.start();
+		handlerLogger.addAppender(logAppender);
+
+		try {
+			var mcpServer = McpServer.sync(mcpStatelessServerTransport)
+				.serverInfo("test-server", "1.0.0")
+				.capabilities(ServerCapabilities.builder().build())
+				.build();
+
+			try (var mcpClient = clientBuilder.build()) {
+				mcpClient.initialize();
+				mcpClient.rootsListChangedNotification();
+			}
+			finally {
+				mcpServer.close();
+			}
+		}
+		finally {
+			handlerLogger.detachAppender(logAppender);
+			logAppender.stop();
+		}
+
+		assertThat(logAppender.list).noneMatch(event -> event.getLevel() == Level.WARN);
 	}
 
 	private double evaluateExpression(String expression) {


### PR DESCRIPTION
## Motivation and Context
https://github.com/modelcontextprotocol/java-sdk/issues/777

<img width="666" height="106" alt="image" src="https://github.com/user-attachments/assets/6e2a7754-1dab-4773-be04-239797f1ac02" />


According to the MCP specification, notifications from client to server are allowed.

In the case of notification/roots/list_changed, if the client supports listChanged, sending this notification is MUST.
The initialized notification is part of the lifecycle specification.

Since the MCP spec does not define any specific error-handling requirements for notification/roots/list_changed on the server side, it seems more appropriate to accept the notification rather than return a "Missing handler" error.

Because the server is stateless, we have implemented notification/roots/list_changed as a no-op.

## How Has This Been Tested?
I wrote test code.

## Breaking Changes
nop

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
