### PR TITLE
refactor: derive latest MCP protocol version from supported list.

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
@@ -84,7 +84,7 @@ public class StdioServerTransportProvider implements McpServerTransportProvider 
 
 	@Override
 	public List<String> protocolVersions() {
-		return List.of(ProtocolVersions.MCP_2024_11_05);
+		return List.of(ProtocolVersions.LATEST);
 	}
 
 	@Override

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/ProtocolVersions.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/ProtocolVersions.java
@@ -1,5 +1,8 @@
 package io.modelcontextprotocol.spec;
 
+import java.util.Comparator;
+import java.util.List;
+
 public interface ProtocolVersions {
 
 	/**
@@ -25,5 +28,9 @@ public interface ProtocolVersions {
 	 * https://modelcontextprotocol.io/specification/2025-11-25
 	 */
 	String MCP_2025_11_25 = "2025-11-25";
+
+	List<String> ALL = List.of(MCP_2024_11_05, MCP_2025_03_26, MCP_2025_06_18, MCP_2025_11_25);
+
+	String LATEST = ALL.stream().max(Comparator.naturalOrder()).orElseThrow();
 
 }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Fix protocol version resolution to return the latest supported version instead of defaulting to the first declared constant.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The default implementation returned the earliest protocol version, leading to incorrect version negotiation. This ensures the latest supported version is selected dynamically.
## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Build locally

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
Latest version is derived from the centralized supported versions list to avoid hardcoded defaults.
<img width="1286" height="570" alt="Screenshot 2026-02-28 124821" src="https://github.com/user-attachments/assets/84d5e3a3-5717-44fb-98d8-0cfcfb63408f" />
