### PR TITLE
Improve GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   pull_request: {}
 
+env:
+  MAVEN_ARGS: --no-transfer-progress
+
 jobs:
   build:
     name: Build and Test
@@ -19,7 +22,7 @@ jobs:
           cache: 'maven'
 
       - name: Build
-        run: mvn verify
+        run: ./mvnw verify
 
   jackson2-tests:
     name: Jackson 2 Integration Tests
@@ -36,4 +39,4 @@ jobs:
           cache: 'maven'
 
       - name: Jackson 2 Integration Tests
-        run: mvn -pl mcp-test -am -Pjackson2 test
+        run: ./mvnw -pl mcp-test -am -Pjackson2 test

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -6,8 +6,12 @@ on:
     branches: [main]
   workflow_dispatch:
 
+env:
+  MAVEN_ARGS: --no-transfer-progress
+
 jobs:
   server:
+    if: ${{ github.repository_owner == 'modelcontextprotocol' }}
     name: Server Conformance
     runs-on: ubuntu-latest
     steps:
@@ -20,10 +24,11 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Build and start server
+      - name: Build
+        run: ./mvnw clean install -DskipTests
+      - name: Start server
         run: |
-          mvn clean install -DskipTests
-          mvn exec:java -pl conformance-tests/server-servlet -Dexec.mainClass="io.modelcontextprotocol.conformance.server.ConformanceServlet" &
+          ./mvnw exec:java -pl conformance-tests/server-servlet -Dexec.mainClass="io.modelcontextprotocol.conformance.server.ConformanceServlet" &
           timeout 30 bash -c 'until curl -s http://localhost:8080/mcp > /dev/null 2>&1; do sleep 0.5; done'
 
       - name: Run conformance tests
@@ -35,6 +40,7 @@ jobs:
           expected-failures: ./conformance-tests/conformance-baseline.yml
 
   client:
+    if: ${{ github.repository_owner == 'modelcontextprotocol' }}
     name: Client Conformance
     runs-on: ubuntu-latest
     strategy:
@@ -51,7 +57,7 @@ jobs:
           cache: 'maven'
 
       - name: Build client
-        run: mvn clean install -DskipTests
+        run: ./mvnw clean install -DskipTests -T 1C
 
       - name: Run conformance test
         uses: modelcontextprotocol/conformance@v0.1.11
@@ -62,6 +68,7 @@ jobs:
           expected-failures: ./conformance-tests/conformance-baseline.yml
 
   auth:
+    if: ${{ github.repository_owner == 'modelcontextprotocol' }}
     name: Auth Conformance
     runs-on: ubuntu-latest
     strategy:
@@ -92,7 +99,7 @@ jobs:
           cache: 'maven'
 
       - name: Build client
-        run: mvn clean install -DskipTests
+        run: ./mvnw clean install -DskipTests
 
       - name: Run conformance test
         uses: modelcontextprotocol/conformance@v0.1.15

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,8 +15,12 @@ on:
 permissions:
   contents: write
 
+env:
+  MAVEN_ARGS: --no-transfer-progress
+
 jobs:
   deploy:
+    if: ${{ github.repository_owner == 'modelcontextprotocol' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -37,7 +41,7 @@ jobs:
       - name: Deploy docs (push to main)
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         run: |
-          PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version --quiet -DforceStdout)
+          PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version --quiet -DforceStdout)
           if [[ "${PROJECT_VERSION}" == *-SNAPSHOT ]]; then
             ALIAS="latest-snapshot"
           else

--- a/.github/workflows/maven-central-release.yml
+++ b/.github/workflows/maven-central-release.yml
@@ -3,6 +3,9 @@ name: Release to Maven Central
 on:
   workflow_dispatch:
 
+env:
+  MAVEN_ARGS: --no-transfer-progress
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -27,14 +30,14 @@ jobs:
           node-version: '20'
 
       - name: Jackson 2 Integration Tests
-        run: mvn -pl mcp-test -am -Pjackson2 test
+        run: ./mvnw -pl mcp-test -am -Pjackson2 test
 
       - name: Build and Test
-        run: mvn clean verify
+        run: ./mvnw clean verify
 
       - name: Publish to Maven Central
         run: |
-          mvn --batch-mode \
+          ./mvnw --batch-mode \
             -Prelease \
             -Pjavadoc \
             deploy

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches: [ "main" ]
 
+env:
+  MAVEN_ARGS: --no-transfer-progress
+
 jobs:
   build:
+    if: ${{ github.repository_owner == 'modelcontextprotocol' }}
     name: Build branch
     runs-on: ubuntu-latest
     steps:
@@ -30,10 +34,10 @@ jobs:
           node-version: '20'
 
       - name: Generate Java docs
-        run: mvn -Pjavadoc -B javadoc:aggregate
+        run: ./mvnw -Pjavadoc -B javadoc:aggregate
 
       - name: Jackson 2 Integration Tests
-        run: mvn -pl mcp-test -am -Pjackson2 test
+        run: ./mvnw -pl mcp-test -am -Pjackson2 test
 
       - name: Build with Maven and deploy to Sonatype snapshot repository
         env:
@@ -41,7 +45,7 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
         run: |
-          mvn -Pjavadoc -Prelease --batch-mode --update-snapshots deploy
+          ./mvnw -Pjavadoc -Prelease --batch-mode --update-snapshots deploy
 
       - name: Capture project version
-        run: echo PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version --quiet -DforceStdout) >> $GITHUB_ENV
+        run: echo PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version --quiet -DforceStdout) >> $GITHUB_ENV


### PR DESCRIPTION
* Use maven wrapper in actions
* Use --no-transfer-progress, which avoids download progress tracking in logs
* Do not run conformance, docs and publish snapshot worfklows on forks

The `--no-transfer-progress` avoids output like:

```
Downloading from maven-central: https://repo.maven.apache.org/maven2/io/projectreactor/reactor-bom/2024.0.0/reactor-bom-2024.0.0.pom
Progress (1): 911 B
Progress (1): 2.3 kB
Progress (1): 4.8 kB
                    
Downloaded from maven-central: https://repo.maven.apache.org/maven2/io/projectreactor/reactor-bom/2024.0.0/reactor-bom-2024.0.0.pom (4.8 kB at 7.2 kB/s)
Downloading from maven-central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-dependencies/4.0.2/spring-boot-dependencies-4.0.2.pom
Progress (1): 1.0 kB
Progress (1): 2.3 kB
Progress (1): 4.3 kB
Progress (1): 6.5 kB
Progress (1): 8.3 kB
Progress (1): 11 kB 
Progress (1): 15 kB
Progress (1): 20 kB
Progress (1): 30 kB
Progress (1): 38 kB
Progress (1): 42 kB
Progress (1): 51 kB
Progress (1): 61 kB
Progress (1): 71 kB
Progress (1): 92 kB
Progress (1): 111 kB
Progress (1): 116 kB
Progress (1): 123 kB
Progress (1): 131 kB
Progress (1): 136 kB
Progress (1): 137 kB
                    
Downloaded from maven-central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-dependencies/4.0.2/spring-boot-dependencies-4.0.2.pom (137 kB at 2.4 MB/s)
Downloading from maven-central: https://repo.maven.apache.org/maven2/org/apache/activemq/activemq-bom/6.1.8/activemq-bom-6.1.8.pom
Progress (1): 799 B
Progress (1): 1.9 kB
Progress (1): 7.9 kB
```