### PR TITLE
Fix: Replace Mono.zip with Mono.when in StdioServerTransportProvider#sendMessage

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
@@ -160,7 +160,7 @@ public class StdioServerTransportProvider implements McpServerTransportProvider 
 		@Override
 		public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
 
-			return Mono.zip(inboundReady.asMono(), outboundReady.asMono()).then(Mono.defer(() -> {
+			return Mono.when(inboundReady.asMono(), outboundReady.asMono()).then(Mono.defer(() -> {
 				if (outboundSink.tryEmitNext(message).isSuccess()) {
 					return Mono.empty();
 				}


### PR DESCRIPTION
## Summary

Replaces `Mono.zip()` with `Mono.when()` in `StdioMcpSessionTransport#sendMessage` to correctly wait for both inbound and outbound ready signals before sending messages.

## Problem

`Mono.zip()` on `Mono<Void>` sources cancels the slower publisher when the faster one completes empty. As [explained by @chemicL](https://github.com/modelcontextprotocol/java-sdk/issues/303#issuecomment-3921445230), this means the slower of the two ready signals (`inboundReady` or `outboundReady`) gets cancelled instead of being awaited.

## Fix

Changed `Mono.zip(inboundReady.asMono(), outboundReady.asMono())` to `Mono.when(inboundReady.asMono(), outboundReady.asMono())` which properly waits for **all** sources to complete before proceeding.

## Testing

All 9 existing `StdioServerTransportProviderTests` pass.

Fixes #303