### PR TITLE
Fix: Remove unsupported 2024-11-05 protocol version from Streamable HTTP transport

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
@@ -168,8 +168,8 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 
 	@Override
 	public List<String> protocolVersions() {
-		return List.of(ProtocolVersions.MCP_2024_11_05, ProtocolVersions.MCP_2025_03_26,
-				ProtocolVersions.MCP_2025_06_18, ProtocolVersions.MCP_2025_11_25);
+		return List.of(ProtocolVersions.MCP_2025_03_26, ProtocolVersions.MCP_2025_06_18,
+				ProtocolVersions.MCP_2025_11_25);
 	}
 
 	@Override


### PR DESCRIPTION
## Summary

Removes `MCP_2024_11_05` from the `protocolVersions()` list in `HttpServletStreamableServerTransportProvider`.

## Problem

The MCP 2024-11-05 protocol specification predates Streamable HTTP transport — it only defines stdio and SSE transports. As [confirmed by @chemicL](https://github.com/modelcontextprotocol/java-sdk/issues/750#issuecomment-3943886274), listing it in the Streamable HTTP transport provider is incorrect since that transport cannot handle sessions initialized via the 2024-11-05 protocol.

## Fix

Removed `ProtocolVersions.MCP_2024_11_05` from the list, keeping only the versions that support Streamable HTTP:
- `2025-03-26`
- `2025-06-18`
- `2025-11-25`

The SSE transport provider (`HttpServletSseServerTransportProvider`) correctly lists only `MCP_2024_11_05`, so this fix aligns the transports with their respective protocol capabilities.

Fixes #750