### PR TITLE
Add X-Accel-Buffering: no header to SSE responses

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
@@ -287,6 +287,7 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 		response.setHeader("Cache-Control", "no-cache");
 		response.setHeader("Connection", "keep-alive");
 		response.setHeader("Access-Control-Allow-Origin", "*");
+		response.setHeader("X-Accel-Buffering", "no");
 
 		String sessionId = UUID.randomUUID().toString();
 		AsyncContext asyncContext = request.startAsync();

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
@@ -316,6 +316,7 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 			response.setHeader("Cache-Control", "no-cache");
 			response.setHeader("Connection", "keep-alive");
 			response.setHeader("Access-Control-Allow-Origin", "*");
+			response.setHeader("X-Accel-Buffering", "no");
 
 			AsyncContext asyncContext = request.startAsync();
 			asyncContext.setTimeout(0);
@@ -523,6 +524,7 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 				response.setHeader("Cache-Control", "no-cache");
 				response.setHeader("Connection", "keep-alive");
 				response.setHeader("Access-Control-Allow-Origin", "*");
+				response.setHeader("X-Accel-Buffering", "no");
 
 				AsyncContext asyncContext = request.startAsync();
 				asyncContext.setTimeout(0);


### PR DESCRIPTION
## Summary

Adds the `X-Accel-Buffering: no` header to all SSE response endpoints to prevent reverse proxy buffering.

## Problem

Proxy servers like Nginx buffer HTTP responses by default. For SSE (Server-Sent Events) endpoints, this causes events to be held in the buffer and delivered in batches instead of being streamed in real-time. This is particularly problematic for MCP transports that rely on SSE for real-time communication.

## Fix

Added `response.setHeader("X-Accel-Buffering", "no")` to all three SSE response locations:

1. **`HttpServletSseServerTransportProvider`** — SSE endpoint handler
2. **`HttpServletStreamableServerTransportProvider`** — GET handler (SSE stream)
3. **`HttpServletStreamableServerTransportProvider`** — POST handler (streaming requests)

This header is a de facto standard supported by Nginx, AWS ALB, and other common proxies. It has no effect when no proxy is present.

## Testing

All 680 existing tests pass (1 pre-existing Docker container startup failure unrelated to this change).

Fixes #293