### PR TITLE
Add all protocol versions to StdioServerTransportProvider

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
@@ -84,7 +84,8 @@ public class StdioServerTransportProvider implements McpServerTransportProvider 
 
 	@Override
 	public List<String> protocolVersions() {
-		return List.of(ProtocolVersions.MCP_2024_11_05);
+		return List.of(ProtocolVersions.MCP_2024_11_05, ProtocolVersions.MCP_2025_03_26,
+				ProtocolVersions.MCP_2025_06_18, ProtocolVersions.MCP_2025_11_25);
 	}
 
 	@Override


### PR DESCRIPTION
## Summary

Fixes #751

`StdioServerTransportProvider.protocolVersions()` only reported `MCP_2024_11_05`, causing version negotiation to fail with newer clients. Since the stdio transport layer is unchanged across all protocol versions, it should advertise support for all of them — matching the behavior of `HttpServletStreamableServerTransportProvider`.

## Changes

- **`StdioServerTransportProvider.java`**: Updated `protocolVersions()` to return all four protocol versions (`2024-11-05`, `2025-03-26`, `2025-06-18`, `2025-11-25`).

## Before/After

```java
// Before — only the original version
return List.of(ProtocolVersions.MCP_2024_11_05);

// After — all supported versions (matches Streamable HTTP transport)
return List.of(ProtocolVersions.MCP_2024_11_05, ProtocolVersions.MCP_2025_03_26,
        ProtocolVersions.MCP_2025_06_18, ProtocolVersions.MCP_2025_11_25);
```

## Testing

All 9 `StdioServerTransportProviderTests` pass.