### PR TITLE
Fix UTF-8 encoding for non-ASCII tool names in HTTP client transports

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
@@ -445,7 +445,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 		return Mono.deferContextual(ctx -> {
 			var builder = this.requestBuilder.copy()
 				.uri(requestUri)
-				.header(HttpHeaders.CONTENT_TYPE, "application/json")
+				.header(HttpHeaders.CONTENT_TYPE, "application/json; charset=utf-8")
 				.header(MCP_PROTOCOL_VERSION_HEADER_NAME, MCP_PROTOCOL_VERSION)
 				.POST(HttpRequest.BodyPublishers.ofString(body));
 			var transportContext = ctx.getOrDefault(McpTransportContext.KEY, McpTransportContext.EMPTY);

--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
@@ -102,6 +102,8 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 
 	private static final String APPLICATION_JSON = "application/json";
 
+	private static final String APPLICATION_JSON_UTF8 = "application/json; charset=utf-8";
+
 	private static final String TEXT_EVENT_STREAM = "text/event-stream";
 
 	public static int NOT_FOUND = 404;
@@ -477,7 +479,7 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 
 				var builder = requestBuilder.uri(uri)
 					.header(HttpHeaders.ACCEPT, APPLICATION_JSON + ", " + TEXT_EVENT_STREAM)
-					.header(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
+					.header(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON_UTF8)
 					.header(HttpHeaders.CACHE_CONTROL, "no-cache")
 					.header(HttpHeaders.PROTOCOL_VERSION,
 							ctx.getOrDefault(McpAsyncClient.NEGOTIATED_PROTOCOL_VERSION,

--- a/mcp-test/src/main/java/io/modelcontextprotocol/AbstractMcpClientServerIntegrationTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/AbstractMcpClientServerIntegrationTests.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.json.McpJsonDefaults;
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpServerFeatures;
 import io.modelcontextprotocol.server.McpSyncServer;
@@ -47,6 +48,7 @@ import io.modelcontextprotocol.spec.McpSchema.Root;
 import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
+import io.modelcontextprotocol.util.McpJsonMapperUtils;
 import io.modelcontextprotocol.util.Utils;
 import net.javacrumbs.jsonunit.core.Option;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -908,6 +910,62 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			assertThat(transportContextIsEmpty.get()).isFalse();
 			assertThat(responseBodyIsNullOrBlank.get()).isFalse();
 			assertThat(response).isNotNull().isEqualTo(expectedCallResponse);
+		}
+		finally {
+			mcpServer.closeGracefully();
+		}
+	}
+
+	@ParameterizedTest(name = "{0} : {displayName} ")
+	@MethodSource("clientsForTesting")
+	void testToolWithNonAsciiCharacters(String clientType) {
+		var clientBuilder = clientBuilders.get(clientType);
+
+		String inputSchema = """
+					{
+						"type": "object",
+						"properties": {
+							"username": { "type": "string" }
+						},
+						"required": ["username"]
+					}
+				""";
+
+		McpServerFeatures.SyncToolSpecification nonAsciiTool = McpServerFeatures.SyncToolSpecification.builder()
+			.tool(Tool.builder()
+				.name("greeter")
+				.description("打招呼")
+				.inputSchema(McpJsonDefaults.getMapper(), inputSchema)
+				.build())
+			.callHandler((exchange, request) -> {
+				String username = (String) request.arguments().get("username");
+				return McpSchema.CallToolResult.builder()
+					.addContent(new McpSchema.TextContent("Hello " + username))
+					.build();
+			})
+			.build();
+
+		var mcpServer = prepareSyncServerBuilder().capabilities(ServerCapabilities.builder().tools(true).build())
+			.tools(nonAsciiTool)
+			.build();
+
+		try (var mcpClient = clientBuilder.build()) {
+
+			InitializeResult initResult = mcpClient.initialize();
+			assertThat(initResult).isNotNull();
+
+			var tools = mcpClient.listTools().tools();
+			assertThat(tools).hasSize(1);
+			assertThat(tools.get(0).name()).isEqualTo("greeter");
+			assertThat(tools.get(0).description()).isEqualTo("打招呼");
+
+			CallToolResult response = mcpClient
+				.callTool(new McpSchema.CallToolRequest("greeter", Map.of("username", "测试用户")));
+
+			assertThat(response).isNotNull();
+			assertThat(response.isError()).isFalse();
+			assertThat(response.content()).hasSize(1);
+			assertThat(((McpSchema.TextContent) response.content().get(0)).text()).isEqualTo("Hello 测试用户");
 		}
 		finally {
 			mcpServer.closeGracefully();


### PR DESCRIPTION
## Summary

Fixes #260

Tool names containing non-ASCII characters (e.g., Chinese `天气预报`) are corrupted when sent via `HttpClientSseClientTransport` and `HttpClientStreamableHttpTransport` because the `Content-Type` header is set to `application/json` without specifying the charset.

While Java's `BodyPublishers.ofString()` encodes the body as UTF-8 by default, the missing charset declaration in the header can cause the server to interpret the request body using a different encoding (e.g., ISO-8859-1 per HTTP/1.1 defaults), resulting in garbled tool names like `å¤©æ°é¢Dæ¥`.

## Changes

- **`HttpClientSseClientTransport.java`**: Set `Content-Type: application/json; charset=utf-8` in POST requests.
- **`HttpClientStreamableHttpTransport.java`**: Added `APPLICATION_JSON_UTF8` constant for POST request Content-Type; kept `APPLICATION_JSON` for response content-type matching.

## Testing

All 680 tests pass (1 pre-existing Docker failure unrelated to this change).