### PR TITLE
Move markInitialized/reconnect after status code check in Streamable HTTP transport

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
@@ -478,19 +478,20 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 					})).onErrorMap(CompletionException.class, t -> t.getCause()).onErrorComplete().subscribe();
 
 			})).flatMap(responseEvent -> {
-				if (transportSession.markInitialized(
-						responseEvent.responseInfo().headers().firstValue("mcp-session-id").orElseGet(() -> null))) {
-					// Once we have a session, we try to open an async stream for
-					// the server to send notifications and requests out-of-band.
-
-					reconnect(null).contextWrite(deliveredSink.contextView()).subscribe();
-				}
-
 				String sessionRepresentation = sessionIdOrPlaceholder(transportSession);
 
 				int statusCode = responseEvent.responseInfo().statusCode();
 
 				if (statusCode >= 200 && statusCode < 300) {
+					if (transportSession.markInitialized(responseEvent.responseInfo()
+						.headers()
+						.firstValue("mcp-session-id")
+						.orElseGet(() -> null))) {
+						// Once we have a session, we try to open an async stream
+						// for the server to send notifications and requests
+						// out-of-band.
+						reconnect(null).contextWrite(deliveredSink.contextView()).subscribe();
+					}
 
 					String contentType = responseEvent.responseInfo()
 						.headers()


### PR DESCRIPTION
## Summary
Move `markInitialized()` and `reconnect()` inside the 2xx success branch in `HttpClientStreamableHttpTransport#sendMessage` so they are only called when the server actually accepted the connection.

## Problem
When connecting to an MCP server that doesn't support Streamable HTTP transport (returns 405 Method Not Allowed), the transport still calls `markInitialized()` and `reconnect()` before checking the status code. This triggers an unnecessary GET request, causing duplicate SSE sessions when using transport fallback (Streamable HTTP → SSE).

The root cause is in the `flatMap` chain at line ~480: `markInitialized()` and `reconnect()` execute unconditionally before the status code is evaluated on the next line.

## Fix
Move the `markInitialized()`/`reconnect()` block inside the `if (statusCode >= 200 && statusCode < 300)` branch. This ensures:
- **Error responses (4xx, 5xx)** no longer trigger session initialization or reconnection
- **Transport fallback** works cleanly without duplicate sessions on the upstream server
- **Success path** behavior is unchanged — session is initialized and async stream opened only on 2xx

## Testing
All 98 Streamable HTTP transport tests pass. The 1 pre-existing failure (`startContainer`) is a Docker/Testcontainers infrastructure issue unrelated to this change.

Fixes #773