### PR TITLE
Add @JsonIgnoreProperties(ignoreUnknown = true) to capability sub-records

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -404,6 +404,7 @@ public final class McpSchema {
 		 * from MCP servers in their prompts.
 		 */
 		@JsonInclude(JsonInclude.Include.NON_ABSENT)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record Sampling() {
 		}
 
@@ -431,12 +432,14 @@ public final class McpSchema {
 		 * @param url support for out-of-band URL-based elicitation
 		 */
 		@JsonInclude(JsonInclude.Include.NON_ABSENT)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record Elicitation(@JsonProperty("form") Form form, @JsonProperty("url") Url url) {
 
 			/**
 			 * Marker record indicating support for form-based elicitation mode.
 			 */
 			@JsonInclude(JsonInclude.Include.NON_ABSENT)
+			@JsonIgnoreProperties(ignoreUnknown = true)
 			public record Form() {
 			}
 
@@ -444,6 +447,7 @@ public final class McpSchema {
 			 * Marker record indicating support for URL-based elicitation mode.
 			 */
 			@JsonInclude(JsonInclude.Include.NON_ABSENT)
+			@JsonIgnoreProperties(ignoreUnknown = true)
 			public record Url() {
 			}
 
@@ -542,6 +546,7 @@ public final class McpSchema {
 		 * Present if the server supports argument autocompletion suggestions.
 		 */
 		@JsonInclude(JsonInclude.Include.NON_ABSENT)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record CompletionCapabilities() {
 		}
 
@@ -549,6 +554,7 @@ public final class McpSchema {
 		 * Present if the server supports sending log messages to the client.
 		 */
 		@JsonInclude(JsonInclude.Include.NON_ABSENT)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record LoggingCapabilities() {
 		}
 
@@ -559,6 +565,7 @@ public final class McpSchema {
 		 * the prompt list
 		 */
 		@JsonInclude(JsonInclude.Include.NON_ABSENT)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record PromptCapabilities(@JsonProperty("listChanged") Boolean listChanged) {
 		}
 
@@ -570,6 +577,7 @@ public final class McpSchema {
 		 * the resource list
 		 */
 		@JsonInclude(JsonInclude.Include.NON_ABSENT)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record ResourceCapabilities(@JsonProperty("subscribe") Boolean subscribe,
 				@JsonProperty("listChanged") Boolean listChanged) {
 		}
@@ -581,6 +589,7 @@ public final class McpSchema {
 		 * the tool list
 		 */
 		@JsonInclude(JsonInclude.Include.NON_ABSENT)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record ToolCapabilities(@JsonProperty("listChanged") Boolean listChanged) {
 		}
 

--- a/mcp-test/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
@@ -1760,4 +1760,75 @@ public class McpSchemaTests {
 					{"progressToken":"progress-token-789","progress":0.25}"""));
 	}
 
+	// Capability sub-records: unknown fields should be silently ignored (#766)
+
+	@Test
+	void testSamplingIgnoresUnknownFields() throws Exception {
+		McpSchema.ClientCapabilities.Sampling sampling = JSON_MAPPER.readValue("""
+				{"futureField": true}""", McpSchema.ClientCapabilities.Sampling.class);
+		assertThat(sampling).isNotNull();
+	}
+
+	@Test
+	void testElicitationIgnoresUnknownFields() throws Exception {
+		McpSchema.ClientCapabilities.Elicitation elicitation = JSON_MAPPER.readValue("""
+				{"form": {}, "url": {}, "futureField": "value"}""", McpSchema.ClientCapabilities.Elicitation.class);
+		assertThat(elicitation).isNotNull();
+	}
+
+	@Test
+	void testElicitationFormIgnoresUnknownFields() throws Exception {
+		McpSchema.ClientCapabilities.Elicitation.Form form = JSON_MAPPER.readValue("""
+				{"futureField": 42}""", McpSchema.ClientCapabilities.Elicitation.Form.class);
+		assertThat(form).isNotNull();
+	}
+
+	@Test
+	void testElicitationUrlIgnoresUnknownFields() throws Exception {
+		McpSchema.ClientCapabilities.Elicitation.Url url = JSON_MAPPER.readValue("""
+				{"futureField": "value"}""", McpSchema.ClientCapabilities.Elicitation.Url.class);
+		assertThat(url).isNotNull();
+	}
+
+	@Test
+	void testCompletionCapabilitiesIgnoresUnknownFields() throws Exception {
+		McpSchema.ServerCapabilities.CompletionCapabilities completions = JSON_MAPPER.readValue("""
+				{"futureField": true}""", McpSchema.ServerCapabilities.CompletionCapabilities.class);
+		assertThat(completions).isNotNull();
+	}
+
+	@Test
+	void testLoggingCapabilitiesIgnoresUnknownFields() throws Exception {
+		McpSchema.ServerCapabilities.LoggingCapabilities logging = JSON_MAPPER.readValue("""
+				{"futureField": "value"}""", McpSchema.ServerCapabilities.LoggingCapabilities.class);
+		assertThat(logging).isNotNull();
+	}
+
+	@Test
+	void testPromptCapabilitiesIgnoresUnknownFields() throws Exception {
+		McpSchema.ServerCapabilities.PromptCapabilities prompts = JSON_MAPPER.readValue("""
+				{"listChanged": true, "futureField": "value"}""",
+				McpSchema.ServerCapabilities.PromptCapabilities.class);
+		assertThat(prompts).isNotNull();
+		assertThat(prompts.listChanged()).isTrue();
+	}
+
+	@Test
+	void testResourceCapabilitiesIgnoresUnknownFields() throws Exception {
+		McpSchema.ServerCapabilities.ResourceCapabilities resources = JSON_MAPPER.readValue("""
+				{"subscribe": true, "listChanged": false, "futureField": 123}""",
+				McpSchema.ServerCapabilities.ResourceCapabilities.class);
+		assertThat(resources).isNotNull();
+		assertThat(resources.subscribe()).isTrue();
+		assertThat(resources.listChanged()).isFalse();
+	}
+
+	@Test
+	void testToolCapabilitiesIgnoresUnknownFields() throws Exception {
+		McpSchema.ServerCapabilities.ToolCapabilities tools = JSON_MAPPER.readValue("""
+				{"listChanged": true, "futureField": "value"}""", McpSchema.ServerCapabilities.ToolCapabilities.class);
+		assertThat(tools).isNotNull();
+		assertThat(tools.listChanged()).isTrue();
+	}
+
 }


### PR DESCRIPTION
## Summary
Add `@JsonIgnoreProperties(ignoreUnknown = true)` to all capability sub-records that are missing the annotation, ensuring forward compatibility when the MCP spec adds new fields.

## Problem
The top-level `ClientCapabilities` and `ServerCapabilities` records have `@JsonIgnoreProperties(ignoreUnknown = true)`, but their nested sub-records do not. Since the `ObjectMapper` defaults to `FAIL_ON_UNKNOWN_PROPERTIES = true`, any unknown field on a capability sub-object causes a deserialization failure.

This already caused a **real breakage** when the elicitation capability gained `form` and `url` fields (#724, fixed in #731). The systemic issue remains — the next spec addition to any capability sub-object will break older SDK versions.

The [MCP spec schema](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-06-18/schema.json#L302) explicitly does **not** close capability objects (`additionalProperties: false` is never set). Several sub-capabilities (`sampling`, `elicitation`, `completions`, `logging`) explicitly set `additionalProperties: true`.

## Fix
Add `@JsonIgnoreProperties(ignoreUnknown = true)` to:

| Record | Location |
|--------|----------|
| `ClientCapabilities.Sampling` | Line ~407 |
| `ClientCapabilities.Elicitation` | Line ~434 |
| `ClientCapabilities.Elicitation.Form` | Line ~440 |
| `ClientCapabilities.Elicitation.Url` | Line ~447 |
| `ServerCapabilities.CompletionCapabilities` | Line ~549 |
| `ServerCapabilities.LoggingCapabilities` | Line ~556 |
| `ServerCapabilities.PromptCapabilities` | Line ~566 |
| `ServerCapabilities.ResourceCapabilities` | Line ~577 |
| `ServerCapabilities.ToolCapabilities` | Line ~588 |

## Testing
Added 9 targeted tests in `McpSchemaTests` that verify each sub-record correctly ignores unknown fields during deserialization. All existing tests continue to pass.

Fixes #766
Related: #734