### PR TITLE
Fix JsonSchema null collection fields causing serialization failures

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -1312,11 +1312,23 @@ public final class McpSchema {
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record JsonSchema( // @formatter:off
 		@JsonProperty("type") String type,
-		@JsonProperty("properties") Map<String, Object> properties,
-		@JsonProperty("required") List<String> required,
+		@JsonProperty("properties") @JsonInclude(JsonInclude.Include.NON_EMPTY) Map<String, Object> properties,
+		@JsonProperty("required") @JsonInclude(JsonInclude.Include.NON_EMPTY) List<String> required,
 		@JsonProperty("additionalProperties") Boolean additionalProperties,
-		@JsonProperty("$defs") Map<String, Object> defs,
-		@JsonProperty("definitions") Map<String, Object> definitions) { // @formatter:on
+		@JsonProperty("$defs") @JsonInclude(JsonInclude.Include.NON_EMPTY) Map<String, Object> defs,
+		@JsonProperty("definitions") @JsonInclude(JsonInclude.Include.NON_EMPTY) Map<String, Object> definitions) { // @formatter:on
+
+		/**
+		 * Compact constructor that replaces null collection fields with empty defaults so
+		 * that callers never encounter unexpected nulls when the server omits optional
+		 * schema fields during deserialization.
+		 */
+		public JsonSchema {
+			required = required != null ? required : List.of();
+			properties = properties != null ? properties : Map.of();
+			defs = defs != null ? defs : Map.of();
+			definitions = definitions != null ? definitions : Map.of();
+		}
 	}
 
 	/**

--- a/mcp-test/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
@@ -772,6 +772,53 @@ public class McpSchemaTests {
 	}
 
 	@Test
+	void testJsonSchemaWithMissingOptionalFields() throws Exception {
+		// Simulate a minimal schema from a Python MCP server that omits
+		// required, additionalProperties, $defs, and definitions
+		String schemaJson = """
+				{
+					"type": "object",
+					"properties": {
+						"query": {
+							"type": "string"
+						}
+					}
+				}
+				""";
+
+		McpSchema.JsonSchema schema = JSON_MAPPER.readValue(schemaJson, McpSchema.JsonSchema.class);
+
+		// Verify null collection fields are replaced with empty defaults
+		assertThat(schema.required()).isNotNull().isEmpty();
+		assertThat(schema.properties()).isNotNull().containsKey("query");
+		assertThat(schema.additionalProperties()).isNull();
+		assertThat(schema.defs()).isNotNull().isEmpty();
+		assertThat(schema.definitions()).isNotNull().isEmpty();
+
+		// Verify serialization round-trip succeeds without errors
+		String serialized = JSON_MAPPER.writeValueAsString(schema);
+		McpSchema.JsonSchema deserialized = JSON_MAPPER.readValue(serialized, McpSchema.JsonSchema.class);
+
+		assertThat(deserialized.type()).isEqualTo("object");
+		assertThat(deserialized.required()).isNotNull().isEmpty();
+		assertThat(deserialized.defs()).isNotNull().isEmpty();
+		assertThat(deserialized.definitions()).isNotNull().isEmpty();
+	}
+
+	@Test
+	void testJsonSchemaConstructorDefaultsForNullCollections() {
+		// Directly construct with null collection fields
+		McpSchema.JsonSchema schema = new McpSchema.JsonSchema("object", null, null, null, null, null);
+
+		assertThat(schema.type()).isEqualTo("object");
+		assertThat(schema.properties()).isNotNull().isEmpty();
+		assertThat(schema.required()).isNotNull().isEmpty();
+		assertThat(schema.additionalProperties()).isNull();
+		assertThat(schema.defs()).isNotNull().isEmpty();
+		assertThat(schema.definitions()).isNotNull().isEmpty();
+	}
+
+	@Test
 	void testTool() throws Exception {
 		String schemaJson = """
 				{


### PR DESCRIPTION
## Summary

Fixes #664

When an MCP server (e.g. Python/fastmcp) omits optional schema fields like `required`, `$defs`, and `definitions`, Jackson deserializes them as `null`. This causes:
- `IllegalArgumentException` when re-serializing with a standard `ObjectMapper`
- `NullPointerException` when iterating over these collections

## Changes

### `McpSchema.JsonSchema` (`mcp-core`)
- **Compact constructor**: Defaults null collection fields (`required`, `properties`, `defs`, `definitions`) to empty immutable collections (`List.of()`, `Map.of()`)
- **`@JsonInclude(NON_EMPTY)`** on collection fields: Ensures empty defaults are omitted during serialization, preserving wire format compatibility

### Tests (`mcp-test`)
- `testJsonSchemaWithMissingOptionalFields`: Verifies deserialization of a minimal schema (no `required`/`$defs`/`definitions`) produces non-null collections and round-trips correctly
- `testJsonSchemaConstructorDefaultsForNullCollections`: Verifies direct constructor with null args produces empty collections

## Before
```java
JsonSchema schema = mapper.readValue("{\"type\":\"object\"}", JsonSchema.class);
schema.required()  // → null
new ObjectMapper().valueToTree(schema)  // → IllegalArgumentException
```

## After
```java
JsonSchema schema = mapper.readValue("{\"type\":\"object\"}", JsonSchema.class);
schema.required()  // → [] (empty list, never null)
new ObjectMapper().valueToTree(schema)  // → works correctly
```