### PR TITLE
fix: prepare POMs for Maven Central release readiness

### DIFF
--- a/conformance-tests/client-jdk-http-client/pom.xml
+++ b/conformance-tests/client-jdk-http-client/pom.xml
@@ -16,14 +16,14 @@
 
 	<scm>
 		<url>https://github.com/modelcontextprotocol/java-sdk</url>
-		<connection>git://github.com/modelcontextprotocol/java-sdk.git</connection>
-		<developerConnection>git@github.com:modelcontextprotocol/java-sdk.git</developerConnection>
+		<connection>scm:git:git://github.com/modelcontextprotocol/java-sdk.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/modelcontextprotocol/java-sdk.git</developerConnection>
 	</scm>
 
 	<properties>
 		<maven.deploy.skip>true</maven.deploy.skip>
 	</properties>
-	
+
 	<dependencies>
 		<dependency>
 			<groupId>io.modelcontextprotocol.sdk</groupId>
@@ -57,7 +57,8 @@
 							<transformers>
 								<transformer
 									implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-									<mainClass>io.modelcontextprotocol.conformance.client.ConformanceJdkClientMcpClient</mainClass>
+									<mainClass>
+										io.modelcontextprotocol.conformance.client.ConformanceJdkClientMcpClient</mainClass>
 								</transformer>
 								<transformer
 									implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />

--- a/conformance-tests/client-spring-http-client/pom.xml
+++ b/conformance-tests/client-spring-http-client/pom.xml
@@ -16,8 +16,8 @@
 
 	<scm>
 		<url>https://github.com/modelcontextprotocol/java-sdk</url>
-		<connection>git://github.com/modelcontextprotocol/java-sdk.git</connection>
-		<developerConnection>git@github.com:modelcontextprotocol/java-sdk.git</developerConnection>
+		<connection>scm:git:git://github.com/modelcontextprotocol/java-sdk.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/modelcontextprotocol/java-sdk.git</developerConnection>
 	</scm>
 
 	<properties>

--- a/conformance-tests/pom.xml
+++ b/conformance-tests/pom.xml
@@ -16,14 +16,14 @@
 
 	<scm>
 		<url>https://github.com/modelcontextprotocol/java-sdk</url>
-		<connection>git://github.com/modelcontextprotocol/java-sdk.git</connection>
-		<developerConnection>git@github.com:modelcontextprotocol/java-sdk.git</developerConnection>
+		<connection>scm:git:git://github.com/modelcontextprotocol/java-sdk.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/modelcontextprotocol/java-sdk.git</developerConnection>
 	</scm>
 
 	<properties>
 		<maven.deploy.skip>true</maven.deploy.skip>
 	</properties>
-	
+
 	<modules>
 		<module>client-jdk-http-client</module>
 		<module>client-spring-http-client</module>

--- a/conformance-tests/server-servlet/pom.xml
+++ b/conformance-tests/server-servlet/pom.xml
@@ -16,8 +16,8 @@
 
 	<scm>
 		<url>https://github.com/modelcontextprotocol/java-sdk</url>
-		<connection>git://github.com/modelcontextprotocol/java-sdk.git</connection>
-		<developerConnection>git@github.com:modelcontextprotocol/java-sdk.git</developerConnection>
+		<connection>scm:git:git://github.com/modelcontextprotocol/java-sdk.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/modelcontextprotocol/java-sdk.git</developerConnection>
 	</scm>
 
 	<properties>

--- a/mcp-bom/pom.xml
+++ b/mcp-bom/pom.xml
@@ -16,13 +16,13 @@
     <name>Java SDK MCP BOM</name>
     <description>Java SDK MCP Bill of Materials</description>
 
-	<url>https://github.com/modelcontextprotocol/java-sdk</url>
+    <url>https://github.com/modelcontextprotocol/java-sdk</url>
 
-	<scm>
-		<url>https://github.com/modelcontextprotocol/java-sdk</url>
-		<connection>git://github.com/modelcontextprotocol/java-sdk.git</connection>
-		<developerConnection>git@github.com:modelcontextprotocol/java-sdk.git</developerConnection>
-	</scm>
+    <scm>
+        <url>https://github.com/modelcontextprotocol/java-sdk</url>
+        <connection>scm:git:git://github.com/modelcontextprotocol/java-sdk.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/modelcontextprotocol/java-sdk.git</developerConnection>
+    </scm>
 
     <dependencyManagement>
         <dependencies>

--- a/mcp-core/pom.xml
+++ b/mcp-core/pom.xml
@@ -16,8 +16,8 @@
 
 	<scm>
 		<url>https://github.com/modelcontextprotocol/java-sdk</url>
-		<connection>git://github.com/modelcontextprotocol/java-sdk.git</connection>
-		<developerConnection>git@github.com:modelcontextprotocol/java-sdk.git</developerConnection>
+		<connection>scm:git:git://github.com/modelcontextprotocol/java-sdk.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/modelcontextprotocol/java-sdk.git</developerConnection>
 	</scm>
 
 	<build>
@@ -164,13 +164,13 @@
 			<scope>test</scope>
 		</dependency>
 
-        <!-- Test-only JSON library for the Gson-based McpJsonMapper example -->
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.10.1</version>
-            <scope>test</scope>
-        </dependency>
+		<!-- Test-only JSON library for the Gson-based McpJsonMapper example -->
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.10.1</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 

--- a/mcp-json-jackson2/pom.xml
+++ b/mcp-json-jackson2/pom.xml
@@ -13,11 +13,13 @@
 	<name>Java MCP SDK JSON Jackson 2</name>
 	<description>Java MCP SDK JSON implementation based on Jackson 2</description>
 	<url>https://github.com/modelcontextprotocol/java-sdk</url>
+
 	<scm>
 		<url>https://github.com/modelcontextprotocol/java-sdk</url>
-		<connection>git://github.com/modelcontextprotocol/java-sdk.git</connection>
-		<developerConnection>git@github.com:modelcontextprotocol/java-sdk.git</developerConnection>
+		<connection>scm:git:git://github.com/modelcontextprotocol/java-sdk.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/modelcontextprotocol/java-sdk.git</developerConnection>
 	</scm>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -62,21 +64,21 @@
 		</plugins>
 	</build>
 	<dependencies>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson2.version}</version>
-        </dependency>
-        <dependency>
-        	<groupId>io.modelcontextprotocol.sdk</groupId>
-        	<artifactId>mcp-core</artifactId>
-        	<version>1.1.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>com.networknt</groupId>
-            <artifactId>json-schema-validator</artifactId>
-            <version>${json-schema-validator-jackson2.version}</version>
-        </dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>${jackson2.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<artifactId>mcp-core</artifactId>
+			<version>1.1.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>com.networknt</groupId>
+			<artifactId>json-schema-validator</artifactId>
+			<version>${json-schema-validator-jackson2.version}</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/mcp-json-jackson3/pom.xml
+++ b/mcp-json-jackson3/pom.xml
@@ -13,11 +13,13 @@
 	<name>Java MCP SDK JSON Jackson 3</name>
 	<description>Java MCP SDK JSON implementation based on Jackson 3</description>
 	<url>https://github.com/modelcontextprotocol/java-sdk</url>
+
 	<scm>
 		<url>https://github.com/modelcontextprotocol/java-sdk</url>
-		<connection>git://github.com/modelcontextprotocol/java-sdk.git</connection>
-		<developerConnection>git@github.com:modelcontextprotocol/java-sdk.git</developerConnection>
+		<connection>scm:git:git://github.com/modelcontextprotocol/java-sdk.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/modelcontextprotocol/java-sdk.git</developerConnection>
 	</scm>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -61,21 +63,21 @@
 		</plugins>
 	</build>
 	<dependencies>
-        <dependency>
-        	<groupId>io.modelcontextprotocol.sdk</groupId>
-        	<artifactId>mcp-core</artifactId>
-        	<version>1.1.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>tools.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson3.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.networknt</groupId>
-            <artifactId>json-schema-validator</artifactId>
-            <version>${json-schema-validator-jackson3.version}</version>
-        </dependency>
+		<dependency>
+			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<artifactId>mcp-core</artifactId>
+			<version>1.1.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>tools.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>${jackson3.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.networknt</groupId>
+			<artifactId>json-schema-validator</artifactId>
+			<version>${json-schema-validator-jackson3.version}</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/mcp-test/pom.xml
+++ b/mcp-test/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>io.modelcontextprotocol.sdk</groupId>
@@ -16,8 +16,8 @@
 
 	<scm>
 		<url>https://github.com/modelcontextprotocol/java-sdk</url>
-		<connection>git://github.com/modelcontextprotocol/java-sdk.git</connection>
-		<developerConnection>git@github.com:modelcontextprotocol/java-sdk.git</developerConnection>
+		<connection>scm:git:git://github.com/modelcontextprotocol/java-sdk.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/modelcontextprotocol/java-sdk.git</developerConnection>
 	</scm>
 
 	<dependencies>

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -16,8 +16,8 @@
 
 	<scm>
 		<url>https://github.com/modelcontextprotocol/java-sdk</url>
-		<connection>git://github.com/modelcontextprotocol/java-sdk.git</connection>
-		<developerConnection>git@github.com:modelcontextprotocol/java-sdk.git</developerConnection>
+		<connection>scm:git:git://github.com/modelcontextprotocol/java-sdk.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/modelcontextprotocol/java-sdk.git</developerConnection>
 	</scm>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
 
 	<scm>
 		<url>https://github.com/modelcontextprotocol/java-sdk</url>
-		<connection>git://github.com/modelcontextprotocol/java-sdk.git</connection>
-		<developerConnection>git@github.com:modelcontextprotocol/java-sdk.git</developerConnection>
+		<connection>scm:git:git://github.com/modelcontextprotocol/java-sdk.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/modelcontextprotocol/java-sdk.git</developerConnection>
 	</scm>
 
 	<name>Java SDK MCP Parent</name>
@@ -57,7 +57,7 @@
 		<java.version>17</java.version>
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
-		<surefireArgLine/>
+		<surefireArgLine />
 
 		<assert4j.version>3.27.6</assert4j.version>
 		<junit.version>6.0.2</junit.version>
@@ -105,11 +105,11 @@
 	<modules>
 		<module>mcp-bom</module>
 		<module>mcp</module>
-        <module>mcp-core</module>
-        <module>mcp-json-jackson2</module>
-        <module>mcp-json-jackson3</module>
+		<module>mcp-core</module>
+		<module>mcp-json-jackson2</module>
+		<module>mcp-json-jackson3</module>
 		<module>mcp-test</module>
-        <module>conformance-tests</module>
+		<module>conformance-tests</module>
 	</modules>
 
 	<build>
@@ -329,9 +329,9 @@
 						<extensions>true</extensions>
 						<configuration>
 							<publishingServerId>central</publishingServerId>
-                            <excludeArtifacts>
-                                mcp-parent,conformance-tests,client-jdk-http-client,client-spring-http-client,server-servlet
-                            </excludeArtifacts>							
+							<excludeArtifacts>
+								mcp-parent,conformance-tests,client-jdk-http-client,client-spring-http-client,server-servlet
+							</excludeArtifacts>
 							<autoPublish>true</autoPublish>
 						</configuration>
 					</plugin>


### PR DESCRIPTION
- Fix malformed SCM developerConnection URL (slash → colon) across all modules
- Add mcp-json-jackson3 to mcp-bom dependency management
- Update license URL to HTTPS
