### PR TITLE
fix: ensure openConnections.dispose() runs in closeGracefully even if the handshake logic throws an exception or fails.

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/DefaultMcpTransportSession.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/DefaultMcpTransportSession.java
@@ -77,8 +77,9 @@ public class DefaultMcpTransportSession implements McpTransportSession<Disposabl
 
 	@Override
 	public Mono<Void> closeGracefully() {
-		return Mono.from(this.onClose.apply(this.sessionId.get()))
-			.then(Mono.fromRunnable(this.openConnections::dispose));
+		return Mono.defer(() -> Mono.from(this.onClose.apply(this.sessionId.get())))
+			.doFinally(signalType -> this.openConnections.dispose())
+			.then();
 	}
 
 }

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/DefaultMcpTransportSessionTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/DefaultMcpTransportSessionTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ */
+
+package io.modelcontextprotocol.spec;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DefaultMcpTransportSession}.
+ */
+class DefaultMcpTransportSessionTests {
+
+	@Test
+	void shouldDisposeConnectionsEvenIfOnCloseErrors() {
+		// Given
+		AtomicBoolean disposed = new AtomicBoolean(false);
+		Disposable connection = () -> disposed.set(true);
+
+		DefaultMcpTransportSession session = new DefaultMcpTransportSession(
+				sessionId -> Mono.error(new RuntimeException("onClose failure")));
+		session.addConnection(connection);
+
+		// When
+		StepVerifier.create(session.closeGracefully())
+			.expectErrorMatches(t -> t instanceof RuntimeException && "onClose failure".equals(t.getMessage()))
+			.verify();
+
+		// Then
+		assertThat(disposed.get()).as("Connection should be disposed even if onClose fails").isTrue();
+	}
+
+	@Test
+	void shouldDisposeConnectionsOnSuccessfulClose() {
+		// Given
+		AtomicBoolean disposed = new AtomicBoolean(false);
+		Disposable connection = () -> disposed.set(true);
+
+		DefaultMcpTransportSession session = new DefaultMcpTransportSession(sessionId -> Mono.empty());
+		session.addConnection(connection);
+
+		// When
+		StepVerifier.create(session.closeGracefully()).verifyComplete();
+
+		// Then
+		assertThat(disposed.get()).as("Connection should be disposed on successful close").isTrue();
+	}
+
+}


### PR DESCRIPTION
 <!-- Provide a brief summary of your changes -->
  This PR ensures that internal connections in DefaultMcpTransportSession are always disposed of during the graceful shutdown process, even if the handshake logic throws an exception or fails.


  ## Motivation and Context
  <!-- Why is this change needed? What problem does it solve? -->
  The previous implementation of closeGracefully() would skip the connection disposal step if the onClose function emitted an error. This led to resource leaks in scenarios where the server was unresponsive or the handshaking handshake handshaked
  wrong. This fix uses Reactor's doFinally to guarantee cleanup.


  This PR closes https://github.com/modelcontextprotocol/java-sdk/issues/547.


  ## How Has This Been Tested?
  <!-- Have you tested this in a real application? Which scenarios were tested? -->
   - Implemented DefaultMcpTransportSessionTests.
   - Verified that openConnections.dispose() is called when the graceful handshake succeeds.
   - Verified that openConnections.dispose() is called when the graceful handshake fails with an exception.

  ## Breaking Changes
  <!-- Will users need to update their code or configurations? -->
  None.


  ## Types of changes
  <!-- What types of changes does your code introduce? Put an x in all the boxes that apply: -->
   - [x] Bug fix (non-breaking change which fixes an issue)
   - [ ] New feature (non-breaking change which adds functionality)
   - [ ] Breaking change (fix or feature that would cause existing functionality to change)
   - [ ] Documentation update


## Checklist
  <!-- Go over all the following points, and put an x in all the boxes that apply. -->
   - [x] I have read the [MCP Documentation (https://modelcontextprotocol.io)
   - [x] My code follows the repository's style guidelines
   - [x] New and existing tests pass locally
   - [x] I have added appropriate error handling
   - [ ] I have added or updated documentation as needed


  ## Additional context
  <!-- Add any other context, implementation notes, or design decisions -->
  Used Mono.defer and doFinally to ensure reliable execution of the cleanup logic regardless of the reactive signal type.