### PR TITLE
fix: ensure Stdio transport threads are daemons and closed properly (…

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/StdioClientTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/StdioClientTransport.java
@@ -11,7 +11,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -88,9 +87,9 @@ public class StdioClientTransport implements McpClientTransport {
 		this.errorSink = Sinks.many().unicast().onBackpressureBuffer();
 
 		// Start threads
-		this.inboundScheduler = Schedulers.fromExecutorService(Executors.newSingleThreadExecutor(), "inbound");
-		this.outboundScheduler = Schedulers.fromExecutorService(Executors.newSingleThreadExecutor(), "outbound");
-		this.errorScheduler = Schedulers.fromExecutorService(Executors.newSingleThreadExecutor(), "error");
+		this.inboundScheduler = Schedulers.newSingle("inbound", true);
+		this.outboundScheduler = Schedulers.newSingle("outbound", true);
+		this.errorScheduler = Schedulers.newSingle("error", true);
 	}
 
 	/**
@@ -348,6 +347,14 @@ public class StdioClientTransport implements McpClientTransport {
 		})).then(Mono.defer(() -> {
 			logger.debug("Sending TERM to process");
 			if (this.process != null) {
+				try {
+					this.process.getInputStream().close();
+					this.process.getErrorStream().close();
+					this.process.getOutputStream().close();
+				}
+				catch (IOException e) {
+					logger.warn("Failed to close process streams: {}", e.getMessage());
+				}
 				this.process.destroy();
 				return Mono.fromFuture(process.onExit());
 			}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
@@ -11,7 +11,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
@@ -151,10 +150,8 @@ public class StdioServerTransportProvider implements McpServerTransportProvider 
 			this.outboundSink = Sinks.many().unicast().onBackpressureBuffer();
 
 			// Use bounded schedulers for better resource management
-			this.inboundScheduler = Schedulers.fromExecutorService(Executors.newSingleThreadExecutor(),
-					"stdio-inbound");
-			this.outboundScheduler = Schedulers.fromExecutorService(Executors.newSingleThreadExecutor(),
-					"stdio-outbound");
+			this.inboundScheduler = Schedulers.newSingle("stdio-inbound", true);
+			this.outboundScheduler = Schedulers.newSingle("stdio-outbound", true);
 		}
 
 		@Override


### PR DESCRIPTION
## Summary
<!-- Provide a brief summary of your changes -->
 This PR ensures that all threads created by `StdioClientTransport` and `StdioServerTransportProvider` are daemon threads and are properly unblocked during shutdown. It also improves the graceful closure logic for the server process.

 ## Motivation and Context
 <!-- Why is this change needed? What problem does it solve? -->
 Fixes #759.

 In the previous implementation, `StdioClientTransport` used `Executors.newSingleThreadExecutor()` with default thread factories, resulting in non-daemon threads. These threads would linger indefinitely after the transport was closed—especially  Windows where they might be blocked on native I/O—preventing the JVM from exiting naturally.

 The changes solve this by:
 1. Using `Schedulers.newSingle(name, true)` to ensure all transport schedulers use daemon threads.
 2. Explicitly closing the process `InputStream`, `ErrorStream`, and `OutputStream` during shutdown to unblock any threads waiting on `readLine()` or `write()`.

 ## How Has This Been Tested?
 <!-- Have you tested this in a real application? Which scenarios were tested? -->
 Tested on Linux (Ubuntu) using Java 17:
 1. Created a reproduction test that monitors active threads in the JVM after `closeGracefully()`.
 2. Verified that without the fix, threads named `pool-x-thread-y` would linger as non-daemons.
 3. Verified that with the fix, threads are correctly marked as daemons and do not block exit.
 4. Ran the full Stdio test suite (`StdioMcpAsyncClientTests`, `StdioMcpAsyncServerTests`, etc.) to ensure protocol integrity is maintained. (162 tests passed).

 ## Breaking Changes
 <!-- Will users need to update their code or configurations? -->
 None. This is a behavioral fix for internal resource management.

 ## Types of changes
 <!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 - [ ] Documentation update

 ## Checklist
 <!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
 - [x] My code follows the repository's style guidelines
 - [x] New and existing tests pass locally
 - [x] I have added appropriate error handling
 - [ ] I have added or updated documentation as needed

 ## Additional context
 <!-- Add any other context, implementation notes, or design decisions -->
 The use of `Schedulers.newSingle(name, true)` is more idiomatic for Reactor-based applications than manually wrapping executors via `Schedulers.fromExecutorService`, as it handles both naming and daemon status natively while ensuring proper cleanup when `dispose()` is called.