### PR TITLE
docs: add conformance summary to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,16 @@ To run the tests you have to pre-install `Docker` and `npx`.
 ```
 ### Conformance Tests
 
-The SDK is validated against the [MCP conformance test suite](https://github.com/modelcontextprotocol/conformance).
+The SDK is validated against the [MCP conformance test suite](https://github.com/modelcontextprotocol/conformance) at 0.1.15 version.
 Full details and instructions are in [`conformance-tests/VALIDATION_RESULTS.md`](conformance-tests/VALIDATION_RESULTS.md).
 
 **Latest results:**
 
-| Suite         | Result                                         |
-|---------------|------------------------------------------------|
-| Server        | ✅ 40/40 passed (100%)                          |
-| Client        | ⚠️ 3/4 scenarios, 9/10 checks passed      |
-| Auth (Spring) | ⚠️  12/14 scenarios fully passing (98.9% checks) |
+| Suite         | Result                                              |
+|---------------|-----------------------------------------------------|
+| Server        | ✅ 40/40 passed (100%)                              |
+| Client        | 🟡 3/4 scenarios, 9/10 checks passed                |
+| Auth (Spring) | 🟡 12/14 scenarios fully passing (98.9% checks)     |
 
 To run the conformance tests locally you need `npx` installed.
 
@@ -62,9 +62,18 @@ npx @modelcontextprotocol/conformance server --url http://localhost:8080/mcp --s
 
 # Client conformance
 ./mvnw clean package -DskipTests -pl conformance-tests/client-jdk-http-client -am
-npx @modelcontextprotocol/conformance client \
-  --command "java -jar conformance-tests/client-jdk-http-client/target/client-jdk-http-client-1.1.0-SNAPSHOT.jar" \
-  --scenario initialize
+for scenario in initialize tools_call elicitation-sep1034-client-defaults sse-retry; do
+  npx @modelcontextprotocol/conformance client \
+    --command "java -jar conformance-tests/client-jdk-http-client/target/client-jdk-http-client-2.0.0-SNAPSHOT.jar" \
+    --scenario $scenario
+done
+
+# Auth conformance (Spring HTTP Client)
+./mvnw clean package -DskipTests -pl conformance-tests/client-spring-http-client -am
+npx @modelcontextprotocol/conformance@0.1.15 client \
+  --spec-version 2025-11-25 \
+  --command "java -jar conformance-tests/client-spring-http-client/target/client-spring-http-client-2.0.0-SNAPSHOT.jar" \
+  --suite auth
 ```
 
 ## Contributing


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Add a conformance summary section to the root README and link to the detailed validation results.
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
This change addresses issue #798, which requests adding the conformance test results to the README.

The goal is to make the current MCP Java SDK conformance status easier to discover directly from the repository homepage, while keeping the full details in `conformance-tests/VALIDATION_RESULTS.md`.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
This is a documentation-only change.

The values added to the README were taken from the existing `conformance-tests/VALIDATION_RESULTS.md` file and summarized there without changing any code or test behavior.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes.

This update only affects documentation and does not require users to change code or configuration.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
This PR adds a short conformance summary for:
- Server conformance
- Client conformance
- Auth conformance

and links readers to `conformance-tests/VALIDATION_RESULTS.md` for the full validation report.
