### PR TITLE
Client transports: remove deprecated methods from builder

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
@@ -241,24 +241,6 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 		}
 
 		/**
-		 * Applies the given consumer to the shared {@link HttpRequest.Builder} <b>once,
-		 * at build time</b>. Any headers set here are frozen into the template and
-		 * <b>cannot be updated</b> after the transport is built.
-		 * @param requestCustomizer the consumer to customize the HTTP request builder
-		 * @return this builder
-		 * @deprecated Use {@link #requestBuilder(HttpRequest.Builder)} for stable
-		 * headers, or {@link #httpRequestCustomizer(McpSyncHttpClientRequestCustomizer)}
-		 * / {@link #asyncHttpRequestCustomizer(McpAsyncHttpClientRequestCustomizer)} for
-		 * dynamic per-request customization.
-		 */
-		@Deprecated
-		public Builder customizeRequest(final Consumer<HttpRequest.Builder> requestCustomizer) {
-			Assert.notNull(requestCustomizer, "requestCustomizer must not be null");
-			requestCustomizer.accept(requestBuilder);
-			return this;
-		}
-
-		/**
 		 * Sets the JSON mapper implementation to use for serialization/deserialization.
 		 * @param jsonMapper the JSON mapper
 		 * @return this builder

--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
@@ -738,24 +738,6 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 		}
 
 		/**
-		 * Applies the given consumer to the shared {@link HttpRequest.Builder} <b>once,
-		 * at build time</b>. Any headers set here are frozen into the template and
-		 * <b>cannot be updated</b> after the transport is built.
-		 * @param requestCustomizer the consumer to customize the HTTP request builder
-		 * @return this builder
-		 * @deprecated Use {@link #requestBuilder(HttpRequest.Builder)} for stable
-		 * headers, or {@link #httpRequestCustomizer(McpSyncHttpClientRequestCustomizer)}
-		 * / {@link #asyncHttpRequestCustomizer(McpAsyncHttpClientRequestCustomizer)} for
-		 * dynamic per-request customization.
-		 */
-		@Deprecated
-		public Builder customizeRequest(final Consumer<HttpRequest.Builder> requestCustomizer) {
-			Assert.notNull(requestCustomizer, "requestCustomizer must not be null");
-			requestCustomizer.accept(requestBuilder);
-			return this;
-		}
-
-		/**
 		 * Configure a custom {@link McpJsonMapper} implementation to use.
 		 * @param jsonMapper instance to use
 		 * @return the builder instance

--- a/mcp-test/src/test/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransportTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransportTests.java
@@ -334,66 +334,6 @@ class HttpClientSseClientTransportTests {
 	}
 
 	@Test
-	void testCustomizeRequest() {
-		// Create an atomic boolean to verify the customizer was called
-		AtomicBoolean customizerCalled = new AtomicBoolean(false);
-
-		// Create a reference to store the custom header value
-		AtomicReference<String> headerName = new AtomicReference<>();
-		AtomicReference<String> headerValue = new AtomicReference<>();
-
-		// Create a transport with the customizer
-		HttpClientSseClientTransport customizedTransport = HttpClientSseClientTransport.builder(host)
-			// Create a request customizer that adds a custom header
-			.customizeRequest(builder -> {
-				builder.header("X-Custom-Header", "test-value");
-				customizerCalled.set(true);
-
-				// Create a new request to verify the header was set
-				HttpRequest request = builder.uri(URI.create("http://example.com")).build();
-				headerName.set("X-Custom-Header");
-				headerValue.set(request.headers().firstValue("X-Custom-Header").orElse(null));
-			})
-			.build();
-
-		// Verify the customizer was called
-		assertThat(customizerCalled.get()).isTrue();
-
-		// Verify the header was set correctly
-		assertThat(headerName.get()).isEqualTo("X-Custom-Header");
-		assertThat(headerValue.get()).isEqualTo("test-value");
-
-		// Clean up
-		customizedTransport.closeGracefully().block();
-	}
-
-	@Test
-	void testChainedCustomizations() {
-		// Create atomic booleans to verify both customizers were called
-		AtomicBoolean clientCustomizerCalled = new AtomicBoolean(false);
-		AtomicBoolean requestCustomizerCalled = new AtomicBoolean(false);
-
-		// Create a transport with both customizers chained
-		HttpClientSseClientTransport customizedTransport = HttpClientSseClientTransport.builder(host)
-			.customizeClient(builder -> {
-				builder.connectTimeout(Duration.ofSeconds(30));
-				clientCustomizerCalled.set(true);
-			})
-			.customizeRequest(builder -> {
-				builder.header("X-Api-Key", "test-api-key");
-				requestCustomizerCalled.set(true);
-			})
-			.build();
-
-		// Verify both customizers were called
-		assertThat(clientCustomizerCalled.get()).isTrue();
-		assertThat(requestCustomizerCalled.get()).isTrue();
-
-		// Clean up
-		customizedTransport.closeGracefully().block();
-	}
-
-	@Test
 	void testRequestCustomizer() {
 		var mockCustomizer = mock(McpSyncHttpClientRequestCustomizer.class);
 


### PR DESCRIPTION
Follow up from #791, removing deprecated methods in 2.0