### PR TITLE
HttpClientStreamableHttpTransport: handle HTTP 405

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
@@ -298,6 +298,10 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 											"Authorization error connecting to SSE stream",
 											responseEvent.responseInfo()));
 						}
+						else if (statusCode == METHOD_NOT_ALLOWED) {
+							logger.debug("The server does not support SSE streams, using request-response mode.");
+							return Flux.empty();
+						}
 
 						if (!(responseEvent instanceof ResponseSubscribers.SseResponseEvent sseResponseEvent)) {
 							return Flux.<McpSchema.JSONRPCMessage>error(new McpTransportException(
@@ -343,10 +347,6 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 								logger.debug("Received SSE event with type: {}", sseResponseEvent.sseEvent());
 								return Flux.empty();
 							}
-						}
-						else if (statusCode == METHOD_NOT_ALLOWED) { // NotAllowed
-							logger.debug("The server does not support SSE streams, using request-response mode.");
-							return Flux.empty();
 						}
 						else if (statusCode == NOT_FOUND) {
 

--- a/mcp-test/src/test/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransportErrorHandlingTest.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransportErrorHandlingTest.java
@@ -18,7 +18,6 @@ import java.util.function.Predicate;
 import com.sun.net.httpserver.HttpServer;
 import io.modelcontextprotocol.client.transport.customizer.McpHttpClientAuthorizationErrorHandler;
 import io.modelcontextprotocol.common.McpTransportContext;
-import org.reactivestreams.Publisher;
 import io.modelcontextprotocol.server.transport.TomcatTestUtil;
 import io.modelcontextprotocol.spec.HttpHeaders;
 import io.modelcontextprotocol.spec.McpClientTransport;
@@ -34,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -365,6 +365,26 @@ public class HttpClientStreamableHttpTransportErrorHandlingTest {
 
 		// This should trigger reconnect which will fail
 		// The error should be handled internally and passed to exception handler
+
+		StepVerifier.create(transport.closeGracefully()).verifyComplete();
+	}
+
+	@Test
+	void test405OnConnectReturnsEmptyFlux() {
+		serverSseResponseStatus.set(405);
+		AtomicReference<Throwable> capturedException = new AtomicReference<>();
+		var transport = HttpClientStreamableHttpTransport.builder(HOST).openConnectionOnStartup(true).build();
+		transport.setExceptionHandler(capturedException::set);
+
+		var messages = new ArrayList<McpSchema.JSONRPCMessage>();
+		StepVerifier.create(transport.connect(msg -> msg.doOnNext(messages::add))).verifyComplete();
+
+		Awaitility.await()
+			.atMost(Duration.ofSeconds(1))
+			.untilAsserted(() -> assertThat(processedSseConnectCount.get()).isEqualTo(1));
+
+		assertThat(messages).isEmpty();
+		assertThat(capturedException.get()).isNull();
 
 		StepVerifier.create(transport.closeGracefully()).verifyComplete();
 	}


### PR DESCRIPTION
HTTP 405 on reconnect should be a no-op, meaning the upstream server does not support SSE.

In the current state, it displays an error and a warning in the console (see #877). It used to be a complete no-op before changes in #671 , without even logging, because the HTTP 405 does not come with SSE events, but rather with a direct HTTP response.

This fixes the error in the console and triggers debug logging on HTTP 405.


Fixes #877