### PR TITLE
fix: release transport-owned HttpClient references on close

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
@@ -92,7 +92,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 	 * HTTP client for sending messages to the server. Uses HTTP POST over the message
 	 * endpoint
 	 */
-	private final HttpClient httpClient;
+	private final OwnedHttpClient ownedHttpClient;
 
 	/** HTTP request builder for building requests to send messages to the server */
 	private final HttpRequest.Builder requestBuilder;
@@ -140,9 +140,13 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 		this.baseUri = URI.create(baseUri);
 		this.sseEndpoint = sseEndpoint;
 		this.jsonMapper = jsonMapper;
-		this.httpClient = httpClient;
+		this.ownedHttpClient = OwnedHttpClient.create(httpClient);
 		this.requestBuilder = requestBuilder;
 		this.httpRequestCustomizer = httpRequestCustomizer;
+	}
+
+	private HttpClient httpClient() {
+		return this.ownedHttpClient.currentClientOrThrow();
 	}
 
 	@Override
@@ -323,7 +327,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 			var transportContext = ctx.getOrDefault(McpTransportContext.KEY, McpTransportContext.EMPTY);
 			return Mono.from(this.httpRequestCustomizer.customize(builder, "GET", uri, null, transportContext));
 		}).flatMap(requestBuilder -> Mono.create(sink -> {
-			Disposable connection = Flux.<ResponseEvent>create(sseSink -> this.httpClient
+			Disposable connection = Flux.<ResponseEvent>create(sseSink -> this.httpClient()
 				.sendAsync(requestBuilder.build(),
 						responseInfo -> ResponseSubscribers.sseToBodySubscriber(responseInfo, sseSink))
 				.exceptionallyCompose(e -> {
@@ -452,7 +456,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 			return Mono.from(this.httpRequestCustomizer.customize(builder, "POST", requestUri, body, transportContext));
 		}).flatMap(customizedBuilder -> {
 			var request = customizedBuilder.build();
-			return Mono.fromFuture(httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()));
+			return Mono.fromFuture(this.httpClient().sendAsync(request, HttpResponse.BodyHandlers.ofString()));
 		});
 	}
 
@@ -472,7 +476,7 @@ public class HttpClientSseClientTransport implements McpClientTransport {
 			if (subscription != null && !subscription.isDisposed()) {
 				subscription.dispose();
 			}
-		});
+		}).then(this.ownedHttpClient.releaseAfterClose());
 	}
 
 	/**

--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
@@ -89,7 +89,7 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 	 * HTTP client for sending messages to the server. Uses HTTP POST over the message
 	 * endpoint
 	 */
-	private final HttpClient httpClient;
+	private final OwnedHttpClient ownedHttpClient;
 
 	/** HTTP request builder for building requests to send messages to the server */
 	private final HttpRequest.Builder requestBuilder;
@@ -139,7 +139,7 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 			boolean openConnectionOnStartup, McpAsyncHttpClientRequestCustomizer httpRequestCustomizer,
 			McpHttpClientAuthorizationErrorHandler authorizationErrorHandler, List<String> supportedProtocolVersions) {
 		this.jsonMapper = jsonMapper;
-		this.httpClient = httpClient;
+		this.ownedHttpClient = OwnedHttpClient.create(httpClient);
 		this.requestBuilder = requestBuilder;
 		this.baseUri = URI.create(baseUri);
 		this.endpoint = endpoint;
@@ -153,6 +153,10 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 			.sorted(Comparator.reverseOrder())
 			.findFirst()
 			.get();
+	}
+
+	private HttpClient httpClient() {
+		return this.ownedHttpClient.currentClientOrThrow();
 	}
 
 	@Override
@@ -209,7 +213,7 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 			return Mono.from(this.httpRequestCustomizer.customize(builder, "DELETE", uri, null, transportContext));
 		}).flatMap(requestBuilder -> {
 			var request = requestBuilder.build();
-			return Mono.fromFuture(() -> this.httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()));
+			return Mono.fromFuture(() -> this.httpClient().sendAsync(request, HttpResponse.BodyHandlers.ofString()));
 		}).then();
 	}
 
@@ -237,10 +241,10 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 		return Mono.defer(() -> {
 			logger.debug("Graceful close triggered");
 			McpTransportSession<Disposable> currentSession = this.activeSession.getAndUpdate(this::createClosedSession);
-			if (currentSession != null) {
-				return Mono.from(currentSession.closeGracefully());
-			}
-			return Mono.empty();
+			Mono<Void> sessionClose = currentSession != null ? Mono.from(currentSession.closeGracefully())
+					: Mono.empty();
+			return sessionClose.onErrorResume(error -> this.ownedHttpClient.releaseAfterClose().then(Mono.error(error)))
+				.then(this.ownedHttpClient.releaseAfterClose());
 		});
 	}
 
@@ -280,7 +284,7 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 				var transportContext = connectionCtx.getOrDefault(McpTransportContext.KEY, McpTransportContext.EMPTY);
 				return Mono.from(this.httpRequestCustomizer.customize(builder, "GET", uri, null, transportContext));
 			})
-				.flatMapMany(requestBuilder -> Flux.<ResponseEvent>create(sseSink -> this.httpClient
+				.flatMapMany(requestBuilder -> Flux.<ResponseEvent>create(sseSink -> this.httpClient()
 					.sendAsync(requestBuilder.build(), this.toSendMessageBodySubscriber(sseSink))
 					.whenComplete((response, throwable) -> {
 						if (throwable != null) {
@@ -489,7 +493,7 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 			}).flatMapMany(requestBuilder -> Flux.<ResponseEvent>create(responseEventSink -> {
 
 				// Create the async request with proper body subscriber selection
-				Mono.fromFuture(this.httpClient
+				Mono.fromFuture(this.httpClient()
 					.sendAsync(requestBuilder.build(), this.toSendMessageBodySubscriber(responseEventSink))
 					.whenComplete((response, throwable) -> {
 						if (throwable != null) {

--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/OwnedHttpClient.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/OwnedHttpClient.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.client.transport;
+
+import java.net.http.HttpClient;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.modelcontextprotocol.spec.McpTransportException;
+import io.modelcontextprotocol.util.Assert;
+import reactor.core.publisher.Mono;
+
+/**
+ * Tracks a transport-owned {@link HttpClient} so the transport can release its strong
+ * reference on close without changing the public builder API.
+ */
+final class OwnedHttpClient {
+
+	private final AtomicReference<HttpClient> clientRef;
+
+	private OwnedHttpClient(HttpClient httpClient) {
+		Assert.notNull(httpClient, "httpClient must not be null");
+		this.clientRef = new AtomicReference<>(httpClient);
+	}
+
+	static OwnedHttpClient create(HttpClient httpClient) {
+		return new OwnedHttpClient(httpClient);
+	}
+
+	/**
+	 * Return the currently owned client, or fail fast after the transport released it.
+	 */
+	HttpClient currentClientOrThrow() {
+		HttpClient client = this.clientRef.get();
+		if (client == null) {
+			throw new McpTransportException("Transport is closed and no longer owns an HttpClient");
+		}
+		return client;
+	}
+
+	Mono<Void> releaseAfterClose() {
+		return Mono.fromRunnable(() -> this.clientRef.set(null));
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/DefaultMcpTransportSession.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/DefaultMcpTransportSession.java
@@ -78,6 +78,7 @@ public class DefaultMcpTransportSession implements McpTransportSession<Disposabl
 	@Override
 	public Mono<Void> closeGracefully() {
 		return Mono.from(this.onClose.apply(this.sessionId.get()))
+			.onErrorResume(error -> Mono.fromRunnable(this.openConnections::dispose).then(Mono.error(error)))
 			.then(Mono.fromRunnable(this.openConnections::dispose));
 	}
 

--- a/mcp-core/src/test/java/io/modelcontextprotocol/client/transport/HttpClientLeakTestSupport.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/client/transport/HttpClientLeakTestSupport.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.client.transport;
+
+import java.util.List;
+
+final class HttpClientLeakTestSupport {
+
+	private HttpClientLeakTestSupport() {
+	}
+
+	static int selectorManagerThreadCount() {
+		return selectorManagerThreadNames().size();
+	}
+
+	static List<String> selectorManagerThreadNames() {
+		return Thread.getAllStackTraces()
+			.keySet()
+			.stream()
+			.map(Thread::getName)
+			.filter(name -> name.contains("HttpClient") && name.contains("SelectorManager"))
+			.sorted()
+			.toList();
+	}
+
+	static int forceGcUntilStable() throws InterruptedException {
+		int previousCount = Integer.MAX_VALUE;
+		int stableIterations = 0;
+		int currentCount = previousCount;
+
+		for (int i = 0; i < 40; i++) {
+			System.gc();
+			System.runFinalization();
+			Thread.sleep(250);
+
+			currentCount = selectorManagerThreadCount();
+			if (currentCount == previousCount) {
+				stableIterations++;
+				if (stableIterations >= 4) {
+					break;
+				}
+			}
+			else {
+				stableIterations = 0;
+				previousCount = currentCount;
+			}
+		}
+
+		return currentCount;
+	}
+
+	static void pauseForSelectorStartup() throws InterruptedException {
+		Thread.sleep(150);
+	}
+
+}

--- a/mcp-core/src/test/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransportLeakTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransportLeakTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.client.transport;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.json.gson.GsonMcpJsonMapper;
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpClientSseClientTransportLeakTests {
+
+	@Test
+	void closeDoesNotRetainOwnedHttpClientWhenClosedTransportRemainsReachable() throws Exception {
+		try (LoopbackMcpHttpServer server = LoopbackMcpHttpServer.start()) {
+			List<HttpClientSseClientTransport> retainedClosedTransports = new ArrayList<>();
+			int selectorThreadsBefore = HttpClientLeakTestSupport.selectorManagerThreadCount();
+			Function<reactor.core.publisher.Mono<McpSchema.JSONRPCMessage>, reactor.core.publisher.Mono<McpSchema.JSONRPCMessage>> handler = Function
+				.identity();
+
+			for (int i = 0; i < 12; i++) {
+				HttpClientSseClientTransport transport = HttpClientSseClientTransport
+					.builder(server.baseUri().toString())
+					.jsonMapper(new GsonMcpJsonMapper())
+					.build();
+
+				StepVerifier.create(transport.connect(handler)).verifyComplete();
+				HttpClientLeakTestSupport.pauseForSelectorStartup();
+				StepVerifier.create(transport.closeGracefully()).verifyComplete();
+				retainedClosedTransports.add(transport);
+			}
+
+			int selectorThreadsAfter = HttpClientLeakTestSupport.forceGcUntilStable();
+
+			assertThat(selectorThreadsAfter)
+				.describedAs(
+						"closed transports should not keep owned HttpClient instances alive, remaining threads: %s",
+						HttpClientLeakTestSupport.selectorManagerThreadNames())
+				.isLessThanOrEqualTo(selectorThreadsBefore + 1);
+		}
+	}
+
+}

--- a/mcp-core/src/test/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransportLeakTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransportLeakTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.client.transport;
+
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.json.gson.GsonMcpJsonMapper;
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpClientStreamableHttpTransportLeakTests {
+
+	@Test
+	void closeDoesNotRetainOwnedHttpClientWhenClosedTransportRemainsReachable() throws Exception {
+		try (LoopbackMcpHttpServer server = LoopbackMcpHttpServer.start()) {
+			List<HttpClientStreamableHttpTransport> retainedClosedTransports = new ArrayList<>();
+			int selectorThreadsBefore = HttpClientLeakTestSupport.selectorManagerThreadCount();
+			Function<reactor.core.publisher.Mono<McpSchema.JSONRPCMessage>, reactor.core.publisher.Mono<McpSchema.JSONRPCMessage>> handler = Function
+				.identity();
+
+			for (int i = 0; i < 12; i++) {
+				HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
+					.builder(server.baseUri().toString())
+					.jsonMapper(new GsonMcpJsonMapper())
+					.build();
+
+				StepVerifier.create(transport.connect(handler)).verifyComplete();
+				StepVerifier.create(transport.sendMessage(
+						new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION, "ping", Map.of("iteration", i))))
+					.verifyComplete();
+				HttpClientLeakTestSupport.pauseForSelectorStartup();
+				StepVerifier.create(transport.closeGracefully()).verifyComplete();
+				retainedClosedTransports.add(transport);
+			}
+
+			int selectorThreadsAfter = HttpClientLeakTestSupport.forceGcUntilStable();
+
+			assertThat(selectorThreadsAfter)
+				.describedAs(
+						"closed transports should not keep owned HttpClient instances alive, remaining threads: %s",
+						HttpClientLeakTestSupport.selectorManagerThreadNames())
+				.isLessThanOrEqualTo(selectorThreadsBefore + 1);
+		}
+	}
+
+}

--- a/mcp-core/src/test/java/io/modelcontextprotocol/client/transport/LoopbackMcpHttpServer.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/client/transport/LoopbackMcpHttpServer.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.client.transport;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+final class LoopbackMcpHttpServer implements AutoCloseable {
+
+	private static final byte[] EMPTY_BODY = new byte[0];
+
+	private static final byte[] STREAMABLE_PRIMER = """
+			event: message
+			data:
+
+			""".getBytes(StandardCharsets.UTF_8);
+
+	private static final byte[] SSE_ENDPOINT_EVENT = """
+			event: endpoint
+			data: /message
+
+			""".getBytes(StandardCharsets.UTF_8);
+
+	private final HttpServer server;
+
+	private final ExecutorService executor;
+
+	private LoopbackMcpHttpServer(HttpServer server, ExecutorService executor) {
+		this.server = server;
+		this.executor = executor;
+	}
+
+	static LoopbackMcpHttpServer start() throws IOException {
+		HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+		ExecutorService executor = Executors.newCachedThreadPool(new LoopbackThreadFactory());
+		server.setExecutor(executor);
+		server.createContext("/mcp", new StreamableHandler());
+		server.createContext("/sse", new SseHandler());
+		server.createContext("/message", new MessageHandler());
+		server.start();
+		return new LoopbackMcpHttpServer(server, executor);
+	}
+
+	URI baseUri() {
+		return URI.create("http://127.0.0.1:" + this.server.getAddress().getPort());
+	}
+
+	@Override
+	public void close() {
+		this.server.stop(0);
+		this.executor.shutdownNow();
+	}
+
+	private static final class StreamableHandler implements HttpHandler {
+
+		@Override
+		public void handle(HttpExchange exchange) throws IOException {
+			try (exchange) {
+				String method = exchange.getRequestMethod();
+				if ("GET".equals(method)) {
+					Headers headers = exchange.getResponseHeaders();
+					headers.add("Content-Type", "text/event-stream");
+					exchange.sendResponseHeaders(200, STREAMABLE_PRIMER.length);
+					try (OutputStream outputStream = exchange.getResponseBody()) {
+						outputStream.write(STREAMABLE_PRIMER);
+					}
+					return;
+				}
+				if ("POST".equals(method)) {
+					exchange.getResponseHeaders().add("mcp-session-id", "loopback-session");
+					exchange.sendResponseHeaders(202, -1);
+					return;
+				}
+				if ("DELETE".equals(method)) {
+					exchange.sendResponseHeaders(204, -1);
+					return;
+				}
+				exchange.sendResponseHeaders(405, EMPTY_BODY.length);
+			}
+		}
+
+	}
+
+	private static final class SseHandler implements HttpHandler {
+
+		@Override
+		public void handle(HttpExchange exchange) throws IOException {
+			try (exchange) {
+				Headers headers = exchange.getResponseHeaders();
+				headers.add("Content-Type", "text/event-stream");
+				exchange.sendResponseHeaders(200, SSE_ENDPOINT_EVENT.length);
+				try (OutputStream outputStream = exchange.getResponseBody()) {
+					outputStream.write(SSE_ENDPOINT_EVENT);
+				}
+			}
+		}
+
+	}
+
+	private static final class MessageHandler implements HttpHandler {
+
+		@Override
+		public void handle(HttpExchange exchange) throws IOException {
+			try (exchange) {
+				exchange.sendResponseHeaders(202, -1);
+			}
+		}
+
+	}
+
+	private static final class LoopbackThreadFactory implements ThreadFactory {
+
+		@Override
+		public Thread newThread(Runnable runnable) {
+			Thread thread = new Thread(runnable);
+			thread.setDaemon(true);
+			thread.setName("loopback-mcp-http-server-" + thread.getId());
+			return thread;
+		}
+
+	}
+
+}

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/DefaultMcpTransportSessionTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/DefaultMcpTransportSessionTests.java
@@ -1,0 +1,26 @@
+package io.modelcontextprotocol.spec;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultMcpTransportSessionTests {
+
+	@Test
+	void closeGracefullyDisposesOpenConnectionsEvenWhenOnCloseFails() {
+		var disposed = new AtomicBoolean();
+		Disposable disposable = () -> disposed.set(true);
+		var session = new DefaultMcpTransportSession(id -> Mono.error(new RuntimeException("boom")));
+		session.addConnection(disposable);
+
+		StepVerifier.create(session.closeGracefully()).expectErrorMessage("boom").verify();
+
+		assertThat(disposed.get()).isTrue();
+	}
+
+}


### PR DESCRIPTION
## Summary

Fixes the Java 17 `HttpClient-* SelectorManager` thread retention reported in `#547` and `#620` by releasing transport-owned `HttpClient` references on close instead of forcing internal client shutdown.

This change:
- preserves the current public builder API
- keeps Java 17 compatibility
- avoids reflection, `Unsafe`, and JDK-internal shutdown hooks
- keeps `closeGracefully()` non-blocking
- adds deterministic Docker-free leak reproducer tests for both SSE and streamable HTTP transports

This is an alternative to the approaches explored in `#610` and `#868`.

## Motivation and Context

The root problem was that `HttpClientSseClientTransport` and `HttpClientStreamableHttpTransport` retained a strong reference to their internally created `HttpClient` even after transport close.

If user code retained closed transport objects, those internal `HttpClient` instances also remained reachable, which in turn kept `HttpClient-* SelectorManager` threads alive.

Instead of trying to forcibly shut down JDK `HttpClient` internals, this PR treats the issue as an ownership problem:
- transports own the internally created `HttpClient`
- once the transport is closed, that owned reference is released
- after that, the client becomes eligible for normal JVM cleanup

Additionally, `DefaultMcpTransportSession.closeGracefully()` now always disposes tracked connections even if `onClose` fails, which makes close-path cleanup reliable.

## How Has This Been Tested?

Locally verified with targeted `mcp-core` regression tests:

- `DefaultMcpTransportSessionTests`
- `HttpClientSseClientTransportLeakTests`
- `HttpClientStreamableHttpTransportLeakTests`

These tests:
- repeatedly create and close transports
- intentionally keep closed transport objects reachable
- assert that `HttpClient-* SelectorManager` threads return to baseline after GC stabilization

Also verified with existing Docker-backed integration tests:

- `HttpClientSseClientTransportTests`
- `HttpClientStreamableHttpTransportTest`

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation (https://modelcontextprotocol.io/)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

Implementation notes:
- Added an internal `OwnedHttpClient` abstraction to track transport-owned clients.
- `HttpClientSseClientTransport` and `HttpClientStreamableHttpTransport` now release their owned client reference on close.
- `DefaultMcpTransportSession.closeGracefully()` now disposes tracked connections even when `onClose` errors.
- The fix intentionally avoids reflection-based shutdown of JDK `HttpClient` internals.