### PR TITLE
feat: add support for meta parameter in client paginated list queries

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
@@ -736,12 +736,31 @@ public class McpAsyncClient {
 	 * @see #readResource(McpSchema.Resource)
 	 */
 	public Mono<McpSchema.ListResourcesResult> listResources(String cursor) {
+		return this.listResourcesInternal(cursor, null);
+	}
+
+	/**
+	 * Retrieves a paginated list of resources provided by the server. Resources represent
+	 * any kind of UTF-8 encoded data that an MCP server makes available to clients, such
+	 * as database records, API responses, log files, and more.
+	 * @param cursor Optional pagination cursor from a previous list request
+	 * @param meta Optional metadata to include in the request (_meta field)
+	 * @return A Mono that completes with the list of resources result.
+	 * @see McpSchema.ListResourcesResult
+	 * @see #readResource(McpSchema.Resource)
+	 */
+	public Mono<McpSchema.ListResourcesResult> listResources(String cursor, java.util.Map<String, Object> meta) {
+		return this.listResourcesInternal(cursor, meta);
+	}
+
+	private Mono<McpSchema.ListResourcesResult> listResourcesInternal(String cursor,
+			java.util.Map<String, Object> meta) {
 		return this.initializer.withInitialization("listing resources", init -> {
 			if (init.initializeResult().capabilities().resources() == null) {
 				return Mono.error(new IllegalStateException("Server does not provide the resources capability"));
 			}
 			return init.mcpSession()
-				.sendRequest(McpSchema.METHOD_RESOURCES_LIST, new McpSchema.PaginatedRequest(cursor),
+				.sendRequest(McpSchema.METHOD_RESOURCES_LIST, new McpSchema.PaginatedRequest(cursor, meta),
 						LIST_RESOURCES_RESULT_TYPE_REF);
 		});
 	}
@@ -806,12 +825,31 @@ public class McpAsyncClient {
 	 * @see McpSchema.ListResourceTemplatesResult
 	 */
 	public Mono<McpSchema.ListResourceTemplatesResult> listResourceTemplates(String cursor) {
+		return this.listResourceTemplatesInternal(cursor, null);
+	}
+
+	/**
+	 * Retrieves a paginated list of resource templates provided by the server. Resource
+	 * templates allow servers to expose parameterized resources using URI templates,
+	 * enabling dynamic resource access based on variable parameters.
+	 * @param cursor Optional pagination cursor from a previous list request
+	 * @param meta Optional metadata to include in the request (_meta field)
+	 * @return A Mono that completes with the list of resource templates result.
+	 * @see McpSchema.ListResourceTemplatesResult
+	 */
+	public Mono<McpSchema.ListResourceTemplatesResult> listResourceTemplates(String cursor,
+			java.util.Map<String, Object> meta) {
+		return this.listResourceTemplatesInternal(cursor, meta);
+	}
+
+	private Mono<McpSchema.ListResourceTemplatesResult> listResourceTemplatesInternal(String cursor,
+			java.util.Map<String, Object> meta) {
 		return this.initializer.withInitialization("listing resource templates", init -> {
 			if (init.initializeResult().capabilities().resources() == null) {
 				return Mono.error(new IllegalStateException("Server does not provide the resources capability"));
 			}
 			return init.mcpSession()
-				.sendRequest(McpSchema.METHOD_RESOURCES_TEMPLATES_LIST, new McpSchema.PaginatedRequest(cursor),
+				.sendRequest(McpSchema.METHOD_RESOURCES_TEMPLATES_LIST, new McpSchema.PaginatedRequest(cursor, meta),
 						LIST_RESOURCE_TEMPLATES_RESULT_TYPE_REF);
 		});
 	}
@@ -906,8 +944,26 @@ public class McpAsyncClient {
 	 * @see #getPrompt(GetPromptRequest)
 	 */
 	public Mono<ListPromptsResult> listPrompts(String cursor) {
-		return this.initializer.withInitialization("listing prompts", init -> init.mcpSession()
-			.sendRequest(McpSchema.METHOD_PROMPT_LIST, new PaginatedRequest(cursor), LIST_PROMPTS_RESULT_TYPE_REF));
+		return this.listPromptsInternal(cursor, null);
+	}
+
+	/**
+	 * Retrieves a paginated list of prompts with optional metadata.
+	 * @param cursor Optional pagination cursor from a previous list request
+	 * @param meta Optional metadata to include in the request (_meta field)
+	 * @return A Mono that completes with the list of prompts result.
+	 * @see McpSchema.ListPromptsResult
+	 * @see #getPrompt(GetPromptRequest)
+	 */
+	public Mono<ListPromptsResult> listPrompts(String cursor, java.util.Map<String, Object> meta) {
+		return this.listPromptsInternal(cursor, meta);
+	}
+
+	private Mono<ListPromptsResult> listPromptsInternal(String cursor, java.util.Map<String, Object> meta) {
+		return this.initializer.withInitialization("listing prompts",
+				init -> init.mcpSession()
+					.sendRequest(McpSchema.METHOD_PROMPT_LIST, new PaginatedRequest(cursor, meta),
+							LIST_PROMPTS_RESULT_TYPE_REF));
 	}
 
 	/**

--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/McpSyncClient.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/McpSyncClient.java
@@ -260,10 +260,12 @@ public class McpSyncClient implements AutoCloseable {
 	}
 
 	/**
-	 * Retrieves a paginated list of tools with optional metadata.
+	 * Retrieves a paginated list of tools provided by the server.
 	 * @param cursor Optional pagination cursor from a previous list request
 	 * @param meta Optional metadata to include in the request (_meta field)
-	 * @return The list of tools result
+	 * @return The list of tools result containing: - tools: List of available tools, each
+	 * with a name, description, and input schema - nextCursor: Optional cursor for
+	 * pagination if more tools are available
 	 */
 	public McpSchema.ListToolsResult listTools(String cursor, java.util.Map<String, Object> meta) {
 		return withProvidedContext(this.delegate.listTools(cursor, meta)).block();
@@ -289,6 +291,17 @@ public class McpSyncClient implements AutoCloseable {
 	 */
 	public McpSchema.ListResourcesResult listResources(String cursor) {
 		return withProvidedContext(this.delegate.listResources(cursor)).block();
+
+	}
+
+	/**
+	 * Retrieves a paginated list of resources with optional metadata.
+	 * @param cursor Optional pagination cursor from a previous list request
+	 * @param meta Optional metadata to include in the request (_meta field)
+	 * @return The list of resources result
+	 */
+	public McpSchema.ListResourcesResult listResources(String cursor, java.util.Map<String, Object> meta) {
+		return withProvidedContext(this.delegate.listResources(cursor, meta)).block();
 
 	}
 
@@ -335,6 +348,21 @@ public class McpSyncClient implements AutoCloseable {
 	}
 
 	/**
+	 * Resource templates allow servers to expose parameterized resources using URI
+	 * templates. Arguments may be auto-completed through the completion API.
+	 *
+	 * Retrieves a paginated list of resource templates provided by the server.
+	 * @param cursor Optional pagination cursor from a previous list request
+	 * @param meta Optional metadata to include in the request (_meta field)
+	 * @return The list of resource templates result.
+	 */
+	public McpSchema.ListResourceTemplatesResult listResourceTemplates(String cursor,
+			java.util.Map<String, Object> meta) {
+		return withProvidedContext(this.delegate.listResourceTemplates(cursor, meta)).block();
+
+	}
+
+	/**
 	 * Subscriptions. The protocol supports optional subscriptions to resource changes.
 	 * Clients can subscribe to specific resources and receive notifications when they
 	 * change.
@@ -377,6 +405,17 @@ public class McpSyncClient implements AutoCloseable {
 	 */
 	public ListPromptsResult listPrompts(String cursor) {
 		return withProvidedContext(this.delegate.listPrompts(cursor)).block();
+
+	}
+
+	/**
+	 * Retrieves a paginated list of prompts provided by the server.
+	 * @param cursor Optional pagination cursor from a previous list request
+	 * @param meta Optional metadata to include in the request (_meta field)
+	 * @return The list of prompts result.
+	 */
+	public ListPromptsResult listPrompts(String cursor, java.util.Map<String, Object> meta) {
+		return withProvidedContext(this.delegate.listPrompts(cursor, meta)).block();
 
 	}
 

--- a/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
@@ -691,4 +691,43 @@ public abstract class AbstractMcpSyncClientTests {
 		});
 	}
 
+	@Test
+	void testListResourcesWithMeta() {
+		withClient(createMcpTransport(), mcpSyncClient -> {
+			mcpSyncClient.initialize();
+			java.util.Map<String, Object> meta = java.util.Map.of("requestId", "test-123");
+			ListResourcesResult resources = mcpSyncClient.listResources(McpSchema.FIRST_PAGE, meta);
+
+			assertThat(resources).isNotNull().satisfies(result -> {
+				assertThat(result.resources()).isNotNull();
+			});
+		});
+	}
+
+	@Test
+	void testListResourceTemplatesWithMeta() {
+		withClient(createMcpTransport(), mcpSyncClient -> {
+			mcpSyncClient.initialize();
+			java.util.Map<String, Object> meta = java.util.Map.of("requestId", "test-123");
+			ListResourceTemplatesResult result = mcpSyncClient.listResourceTemplates(McpSchema.FIRST_PAGE, meta);
+
+			assertThat(result).isNotNull().satisfies(r -> {
+				assertThat(r.resourceTemplates()).isNotNull();
+			});
+		});
+	}
+
+	@Test
+	void testListPromptsWithMeta() {
+		withClient(createMcpTransport(), mcpSyncClient -> {
+			mcpSyncClient.initialize();
+			java.util.Map<String, Object> meta = java.util.Map.of("requestId", "test-123");
+			McpSchema.ListPromptsResult result = mcpSyncClient.listPrompts(McpSchema.FIRST_PAGE, meta);
+
+			assertThat(result).isNotNull().satisfies(r -> {
+				assertThat(r.prompts()).isNotNull();
+			});
+		});
+	}
+
 }

--- a/mcp-test/src/test/java/io/modelcontextprotocol/client/McpAsyncClientTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/client/McpAsyncClientTests.java
@@ -446,4 +446,422 @@ class McpAsyncClientTests {
 		assertThat(capturedRequest[0].meta()).containsEntry("requestId", "test-123");
 	}
 
+	@Test
+	void testListResourcesWithCursorAndMeta() {
+		McpSchema.Resource mockResource = McpSchema.Resource.builder().uri("file:///test.txt").name("test.txt").build();
+		McpSchema.ListResourcesResult mockResult = new McpSchema.ListResourcesResult(List.of(mockResource), null);
+
+		McpSchema.ServerCapabilities caps = McpSchema.ServerCapabilities.builder().resources(false, false).build();
+		McpSchema.InitializeResult initResult = new McpSchema.InitializeResult(ProtocolVersions.MCP_2024_11_05, caps,
+				MOCK_SERVER_INFO, null);
+
+		McpSchema.PaginatedRequest[] capturedRequest = new McpSchema.PaginatedRequest[1];
+
+		McpClientTransport transport = new McpClientTransport() {
+			Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>> handler;
+
+			@Override
+			public Mono<Void> connect(
+					Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>> handler) {
+				return Mono.deferContextual(ctx -> {
+					this.handler = handler;
+					return Mono.empty();
+				});
+			}
+
+			@Override
+			public Mono<Void> closeGracefully() {
+				return Mono.empty();
+			}
+
+			@Override
+			public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
+				if (!(message instanceof McpSchema.JSONRPCRequest request)) {
+					return Mono.empty();
+				}
+				McpSchema.JSONRPCResponse response;
+				if (McpSchema.METHOD_INITIALIZE.equals(request.method())) {
+					response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), initResult, null);
+				}
+				else if (McpSchema.METHOD_RESOURCES_LIST.equals(request.method())) {
+					capturedRequest[0] = JSON_MAPPER.convertValue(request.params(), McpSchema.PaginatedRequest.class);
+					response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), mockResult, null);
+				}
+				else {
+					return Mono.empty();
+				}
+				return handler.apply(Mono.just(response)).then();
+			}
+
+			@Override
+			public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+				return JSON_MAPPER.convertValue(data, new TypeRef<>() {
+					@Override
+					public java.lang.reflect.Type getType() {
+						return typeRef.getType();
+					}
+				});
+			}
+		};
+
+		McpAsyncClient client = McpClient.async(transport).build();
+
+		Map<String, Object> meta = Map.of("customKey", "customValue");
+		McpSchema.ListResourcesResult result = client.listResources("cursor-1", meta).block();
+		assertThat(result).isNotNull();
+		assertThat(result.resources()).hasSize(1);
+		assertThat(capturedRequest[0]).isNotNull();
+		assertThat(capturedRequest[0].cursor()).isEqualTo("cursor-1");
+		assertThat(capturedRequest[0].meta()).containsEntry("customKey", "customValue");
+	}
+
+	@Test
+	void testSyncListResourcesWithCursorAndMeta() {
+		McpSchema.Resource mockResource = McpSchema.Resource.builder().uri("file:///test.txt").name("test.txt").build();
+		McpSchema.ListResourcesResult mockResult = new McpSchema.ListResourcesResult(List.of(mockResource), null);
+
+		McpSchema.ServerCapabilities caps = McpSchema.ServerCapabilities.builder().resources(false, false).build();
+		McpSchema.InitializeResult initResult = new McpSchema.InitializeResult(ProtocolVersions.MCP_2024_11_05, caps,
+				MOCK_SERVER_INFO, null);
+
+		McpSchema.PaginatedRequest[] capturedRequest = new McpSchema.PaginatedRequest[1];
+
+		McpClientTransport transport = new McpClientTransport() {
+			Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>> handler;
+
+			@Override
+			public Mono<Void> connect(
+					Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>> handler) {
+				return Mono.deferContextual(ctx -> {
+					this.handler = handler;
+					return Mono.empty();
+				});
+			}
+
+			@Override
+			public Mono<Void> closeGracefully() {
+				return Mono.empty();
+			}
+
+			@Override
+			public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
+				if (!(message instanceof McpSchema.JSONRPCRequest request)) {
+					return Mono.empty();
+				}
+				McpSchema.JSONRPCResponse response;
+				if (McpSchema.METHOD_INITIALIZE.equals(request.method())) {
+					response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), initResult, null);
+				}
+				else if (McpSchema.METHOD_RESOURCES_LIST.equals(request.method())) {
+					capturedRequest[0] = JSON_MAPPER.convertValue(request.params(), McpSchema.PaginatedRequest.class);
+					response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), mockResult, null);
+				}
+				else {
+					return Mono.empty();
+				}
+				return handler.apply(Mono.just(response)).then();
+			}
+
+			@Override
+			public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+				return JSON_MAPPER.convertValue(data, new TypeRef<>() {
+					@Override
+					public java.lang.reflect.Type getType() {
+						return typeRef.getType();
+					}
+				});
+			}
+		};
+
+		McpSyncClient client = McpClient.sync(transport).build();
+
+		Map<String, Object> meta = Map.of("customKey", "customValue");
+		McpSchema.ListResourcesResult result = client.listResources("cursor-1", meta);
+		assertThat(result).isNotNull();
+		assertThat(result.resources()).hasSize(1);
+		assertThat(capturedRequest[0]).isNotNull();
+		assertThat(capturedRequest[0].cursor()).isEqualTo("cursor-1");
+		assertThat(capturedRequest[0].meta()).containsEntry("customKey", "customValue");
+	}
+
+	@Test
+	void testListResourceTemplatesWithCursorAndMeta() {
+		McpSchema.ResourceTemplate mockTemplate = new McpSchema.ResourceTemplate("file:///{name}", "template", null,
+				null, null);
+		McpSchema.ListResourceTemplatesResult mockResult = new McpSchema.ListResourceTemplatesResult(
+				List.of(mockTemplate), null);
+
+		McpSchema.ServerCapabilities caps = McpSchema.ServerCapabilities.builder().resources(false, false).build();
+		McpSchema.InitializeResult initResult = new McpSchema.InitializeResult(ProtocolVersions.MCP_2024_11_05, caps,
+				MOCK_SERVER_INFO, null);
+
+		McpSchema.PaginatedRequest[] capturedRequest = new McpSchema.PaginatedRequest[1];
+
+		McpClientTransport transport = new McpClientTransport() {
+			Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>> handler;
+
+			@Override
+			public Mono<Void> connect(
+					Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>> handler) {
+				return Mono.deferContextual(ctx -> {
+					this.handler = handler;
+					return Mono.empty();
+				});
+			}
+
+			@Override
+			public Mono<Void> closeGracefully() {
+				return Mono.empty();
+			}
+
+			@Override
+			public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
+				if (!(message instanceof McpSchema.JSONRPCRequest request)) {
+					return Mono.empty();
+				}
+				McpSchema.JSONRPCResponse response;
+				if (McpSchema.METHOD_INITIALIZE.equals(request.method())) {
+					response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), initResult, null);
+				}
+				else if (McpSchema.METHOD_RESOURCES_TEMPLATES_LIST.equals(request.method())) {
+					capturedRequest[0] = JSON_MAPPER.convertValue(request.params(), McpSchema.PaginatedRequest.class);
+					response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), mockResult, null);
+				}
+				else {
+					return Mono.empty();
+				}
+				return handler.apply(Mono.just(response)).then();
+			}
+
+			@Override
+			public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+				return JSON_MAPPER.convertValue(data, new TypeRef<>() {
+					@Override
+					public java.lang.reflect.Type getType() {
+						return typeRef.getType();
+					}
+				});
+			}
+		};
+
+		McpAsyncClient client = McpClient.async(transport).build();
+
+		Map<String, Object> meta = Map.of("customKey", "customValue");
+		McpSchema.ListResourceTemplatesResult result = client.listResourceTemplates("cursor-1", meta).block();
+		assertThat(result).isNotNull();
+		assertThat(result.resourceTemplates()).hasSize(1);
+		assertThat(capturedRequest[0]).isNotNull();
+		assertThat(capturedRequest[0].cursor()).isEqualTo("cursor-1");
+		assertThat(capturedRequest[0].meta()).containsEntry("customKey", "customValue");
+	}
+
+	@Test
+	void testSyncListResourceTemplatesWithCursorAndMeta() {
+		McpSchema.ResourceTemplate mockTemplate = new McpSchema.ResourceTemplate("file:///{name}", "template", null,
+				null, null);
+		McpSchema.ListResourceTemplatesResult mockResult = new McpSchema.ListResourceTemplatesResult(
+				List.of(mockTemplate), null);
+
+		McpSchema.ServerCapabilities caps = McpSchema.ServerCapabilities.builder().resources(false, false).build();
+		McpSchema.InitializeResult initResult = new McpSchema.InitializeResult(ProtocolVersions.MCP_2024_11_05, caps,
+				MOCK_SERVER_INFO, null);
+
+		McpSchema.PaginatedRequest[] capturedRequest = new McpSchema.PaginatedRequest[1];
+
+		McpClientTransport transport = new McpClientTransport() {
+			Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>> handler;
+
+			@Override
+			public Mono<Void> connect(
+					Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>> handler) {
+				return Mono.deferContextual(ctx -> {
+					this.handler = handler;
+					return Mono.empty();
+				});
+			}
+
+			@Override
+			public Mono<Void> closeGracefully() {
+				return Mono.empty();
+			}
+
+			@Override
+			public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
+				if (!(message instanceof McpSchema.JSONRPCRequest request)) {
+					return Mono.empty();
+				}
+				McpSchema.JSONRPCResponse response;
+				if (McpSchema.METHOD_INITIALIZE.equals(request.method())) {
+					response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), initResult, null);
+				}
+				else if (McpSchema.METHOD_RESOURCES_TEMPLATES_LIST.equals(request.method())) {
+					capturedRequest[0] = JSON_MAPPER.convertValue(request.params(), McpSchema.PaginatedRequest.class);
+					response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), mockResult, null);
+				}
+				else {
+					return Mono.empty();
+				}
+				return handler.apply(Mono.just(response)).then();
+			}
+
+			@Override
+			public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+				return JSON_MAPPER.convertValue(data, new TypeRef<>() {
+					@Override
+					public java.lang.reflect.Type getType() {
+						return typeRef.getType();
+					}
+				});
+			}
+		};
+
+		McpSyncClient client = McpClient.sync(transport).build();
+
+		Map<String, Object> meta = Map.of("customKey", "customValue");
+		McpSchema.ListResourceTemplatesResult result = client.listResourceTemplates("cursor-1", meta);
+		assertThat(result).isNotNull();
+		assertThat(result.resourceTemplates()).hasSize(1);
+		assertThat(capturedRequest[0]).isNotNull();
+		assertThat(capturedRequest[0].cursor()).isEqualTo("cursor-1");
+		assertThat(capturedRequest[0].meta()).containsEntry("customKey", "customValue");
+	}
+
+	@Test
+	void testListPromptsWithCursorAndMeta() {
+		McpSchema.Prompt mockPrompt = new McpSchema.Prompt("test-prompt", "A test prompt", List.of());
+		McpSchema.ListPromptsResult mockResult = new McpSchema.ListPromptsResult(List.of(mockPrompt), null);
+
+		McpSchema.ServerCapabilities caps = McpSchema.ServerCapabilities.builder().prompts(false).build();
+		McpSchema.InitializeResult initResult = new McpSchema.InitializeResult(ProtocolVersions.MCP_2024_11_05, caps,
+				MOCK_SERVER_INFO, null);
+
+		McpSchema.PaginatedRequest[] capturedRequest = new McpSchema.PaginatedRequest[1];
+
+		McpClientTransport transport = new McpClientTransport() {
+			Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>> handler;
+
+			@Override
+			public Mono<Void> connect(
+					Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>> handler) {
+				return Mono.deferContextual(ctx -> {
+					this.handler = handler;
+					return Mono.empty();
+				});
+			}
+
+			@Override
+			public Mono<Void> closeGracefully() {
+				return Mono.empty();
+			}
+
+			@Override
+			public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
+				if (!(message instanceof McpSchema.JSONRPCRequest request)) {
+					return Mono.empty();
+				}
+				McpSchema.JSONRPCResponse response;
+				if (McpSchema.METHOD_INITIALIZE.equals(request.method())) {
+					response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), initResult, null);
+				}
+				else if (McpSchema.METHOD_PROMPT_LIST.equals(request.method())) {
+					capturedRequest[0] = JSON_MAPPER.convertValue(request.params(), McpSchema.PaginatedRequest.class);
+					response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), mockResult, null);
+				}
+				else {
+					return Mono.empty();
+				}
+				return handler.apply(Mono.just(response)).then();
+			}
+
+			@Override
+			public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+				return JSON_MAPPER.convertValue(data, new TypeRef<>() {
+					@Override
+					public java.lang.reflect.Type getType() {
+						return typeRef.getType();
+					}
+				});
+			}
+		};
+
+		McpAsyncClient client = McpClient.async(transport).build();
+
+		Map<String, Object> meta = Map.of("customKey", "customValue");
+		McpSchema.ListPromptsResult result = client.listPrompts("cursor-1", meta).block();
+		assertThat(result).isNotNull();
+		assertThat(result.prompts()).hasSize(1);
+		assertThat(capturedRequest[0]).isNotNull();
+		assertThat(capturedRequest[0].cursor()).isEqualTo("cursor-1");
+		assertThat(capturedRequest[0].meta()).containsEntry("customKey", "customValue");
+	}
+
+	@Test
+	void testSyncListPromptsWithCursorAndMeta() {
+		McpSchema.Prompt mockPrompt = new McpSchema.Prompt("test-prompt", "A test prompt", List.of());
+		McpSchema.ListPromptsResult mockResult = new McpSchema.ListPromptsResult(List.of(mockPrompt), null);
+
+		McpSchema.ServerCapabilities caps = McpSchema.ServerCapabilities.builder().prompts(false).build();
+		McpSchema.InitializeResult initResult = new McpSchema.InitializeResult(ProtocolVersions.MCP_2024_11_05, caps,
+				MOCK_SERVER_INFO, null);
+
+		McpSchema.PaginatedRequest[] capturedRequest = new McpSchema.PaginatedRequest[1];
+
+		McpClientTransport transport = new McpClientTransport() {
+			Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>> handler;
+
+			@Override
+			public Mono<Void> connect(
+					Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>> handler) {
+				return Mono.deferContextual(ctx -> {
+					this.handler = handler;
+					return Mono.empty();
+				});
+			}
+
+			@Override
+			public Mono<Void> closeGracefully() {
+				return Mono.empty();
+			}
+
+			@Override
+			public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
+				if (!(message instanceof McpSchema.JSONRPCRequest request)) {
+					return Mono.empty();
+				}
+				McpSchema.JSONRPCResponse response;
+				if (McpSchema.METHOD_INITIALIZE.equals(request.method())) {
+					response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), initResult, null);
+				}
+				else if (McpSchema.METHOD_PROMPT_LIST.equals(request.method())) {
+					capturedRequest[0] = JSON_MAPPER.convertValue(request.params(), McpSchema.PaginatedRequest.class);
+					response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), mockResult, null);
+				}
+				else {
+					return Mono.empty();
+				}
+				return handler.apply(Mono.just(response)).then();
+			}
+
+			@Override
+			public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+				return JSON_MAPPER.convertValue(data, new TypeRef<>() {
+					@Override
+					public java.lang.reflect.Type getType() {
+						return typeRef.getType();
+					}
+				});
+			}
+		};
+
+		McpSyncClient client = McpClient.sync(transport).build();
+
+		Map<String, Object> meta = Map.of("customKey", "customValue");
+		McpSchema.ListPromptsResult result = client.listPrompts("cursor-1", meta);
+		assertThat(result).isNotNull();
+		assertThat(result.prompts()).hasSize(1);
+		assertThat(capturedRequest[0]).isNotNull();
+		assertThat(capturedRequest[0].cursor()).isEqualTo("cursor-1");
+		assertThat(capturedRequest[0].meta()).containsEntry("customKey", "customValue");
+	}
+
 }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Add support for meta parameter in listTools method.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
McpSchema.PaginatedRequest now has a meta field (added in #344), but the client API methods don't expose it. As a result, servers which can accept the meta parameter in list tools cannot be used with java client. The Python SDK already supports passing `_meta` in tools/list requests:

python
`async def list_tools(self, *, cursor=None, meta=None) -> ListToolsResult`

This change aligns the Java SDK with the Python SDK and the MCP spec which allows `_meta` in PaginatedRequestParams.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

- **Unit tests**: `McpAsyncClientTests.testListToolsWithCursorAndMeta()` and `testSyncListToolsWithCursorAndMeta()` - verify `_meta` is correctly serialized in the JSON-RPC request
- **Integration test**: `AbstractMcpSyncClientTests.testListToolsWithMeta()` - verified against the real server-everything MCP server via HttpClientStreamableHttpSyncClientTests (Docker/Testcontainers). 

Ran per recommendations
```
Unit tests (McpAsyncClientTests):
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.467 s
  testListToolsWithCursorAndMeta    -- Time elapsed: 0.031 s  ✅
  testSyncListToolsWithCursorAndMeta -- Time elapsed: 0.006 s  ✅
  testListToolsWithEmptyCursor      -- Time elapsed: 0.360 s  ✅
  (+ 4 existing tests passing)
BUILD SUCCESS


Integration test (HttpClientStreamableHttpSyncClientTests against real 
server-everything via Docker):
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 13.59 s
  testListToolsWithMeta -- Time elapsed: 0.445 s  ✅
BUILD SUCCESS

```

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None. New overloaded methods added; existing listTools(String cursor) behavior unchanged.
 
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
Closes #907