### PR TITLE
feat: Add SEP-1034 elicitation schema default values

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
@@ -15,6 +15,9 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.modelcontextprotocol.client.LifecycleInitializer.Initialization;
 import io.modelcontextprotocol.json.TypeRef;
 import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
@@ -30,16 +33,14 @@ import io.modelcontextprotocol.spec.McpSchema.ElicitRequest;
 import io.modelcontextprotocol.spec.McpSchema.ElicitResult;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptRequest;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptResult;
-import io.modelcontextprotocol.util.ToolNameValidator;
 import io.modelcontextprotocol.spec.McpSchema.ListPromptsResult;
 import io.modelcontextprotocol.spec.McpSchema.LoggingLevel;
 import io.modelcontextprotocol.spec.McpSchema.LoggingMessageNotification;
 import io.modelcontextprotocol.spec.McpSchema.PaginatedRequest;
 import io.modelcontextprotocol.spec.McpSchema.Root;
 import io.modelcontextprotocol.util.Assert;
+import io.modelcontextprotocol.util.ToolNameValidator;
 import io.modelcontextprotocol.util.Utils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -561,8 +562,63 @@ public class McpAsyncClient {
 			ElicitRequest request = transport.unmarshalFrom(params, new TypeRef<>() {
 			});
 
-			return this.elicitationHandler.apply(request);
+			return this.elicitationHandler.apply(request).map(result -> {
+				// Apply defaults from schema when applyDefaults is enabled
+				if (result.action() == ElicitResult.Action.ACCEPT && result.content() != null
+						&& shouldApplyElicitationDefaults()) {
+					Map<String, Object> merged = new HashMap<>(result.content());
+					applyElicitationDefaults(request.requestedSchema(), merged);
+					return new ElicitResult(result.action(), merged, result.meta());
+				}
+				return result;
+			});
 		};
+	}
+
+	/**
+	 * Checks whether the client is configured to apply elicitation defaults.
+	 * @return true if the client capabilities indicate that defaults should be applied
+	 */
+	private boolean shouldApplyElicitationDefaults() {
+		if (this.clientCapabilities.elicitation() == null) {
+			return false;
+		}
+		McpSchema.ClientCapabilities.Elicitation.Form form = this.clientCapabilities.elicitation().form();
+		return form != null && Boolean.TRUE.equals(form.applyDefaults());
+	}
+
+	/**
+	 * Applies default values from the elicitation schema to the result content. For each
+	 * property in the schema that has a "default" value, if the corresponding key is
+	 * missing from the content map, the default value is inserted.
+	 * @param schema the requestedSchema from the ElicitRequest
+	 * @param content the mutable content map from the ElicitResult
+	 */
+	@SuppressWarnings("unchecked")
+	static void applyElicitationDefaults(Map<String, Object> schema, Map<String, Object> content) {
+		if (schema == null || content == null) {
+			return;
+		}
+
+		Object propertiesObj = schema.get("properties");
+		if (!(propertiesObj instanceof Map)) {
+			return;
+		}
+
+		Map<String, Object> properties = (Map<String, Object>) propertiesObj;
+		for (Map.Entry<String, Object> entry : properties.entrySet()) {
+			String key = entry.getKey();
+			Object propDef = entry.getValue();
+
+			if (!(propDef instanceof Map)) {
+				continue;
+			}
+
+			Map<String, Object> propMap = (Map<String, Object>) propDef;
+			if (!content.containsKey(key) && propMap.containsKey("default")) {
+				content.put(key, propMap.get("default"));
+			}
+		}
 	}
 
 	// --------------------------

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -10,6 +10,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -17,11 +20,10 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.json.TypeRef;
 import io.modelcontextprotocol.util.Assert;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Based on the <a href="http://www.jsonrpc.org/specification">JSON-RPC 2.0
@@ -426,11 +428,23 @@ public final class McpSchema {
 		public record Elicitation(@JsonProperty("form") Form form, @JsonProperty("url") Url url) {
 
 			/**
-			 * Marker record indicating support for form-based elicitation mode.
+			 * Record indicating support for form-based elicitation mode.
+			 *
+			 * @param applyDefaults Whether the client should apply default values from
+			 * the schema to the elicitation result content when fields are missing. When
+			 * true, the SDK will automatically fill in missing fields with their
+			 * schema-defined defaults before returning the result to the server.
 			 */
 			@JsonInclude(JsonInclude.Include.NON_ABSENT)
 			@JsonIgnoreProperties(ignoreUnknown = true)
-			public record Form() {
+			public record Form(@JsonProperty("applyDefaults") Boolean applyDefaults) {
+
+				/**
+				 * Creates a Form with default settings (no applyDefaults).
+				 */
+				public Form() {
+					this(null);
+				}
 			}
 
 			/**
@@ -497,6 +511,31 @@ public final class McpSchema {
 			 */
 			public Builder elicitation(boolean form, boolean url) {
 				this.elicitation = new Elicitation(form ? new Elicitation.Form() : null,
+						url ? new Elicitation.Url() : null);
+				return this;
+			}
+
+			/**
+			 * Enables elicitation capability with form mode and applyDefaults setting.
+			 * <p>
+			 * Note: {@code applyDefaults} is an SDK-level behavior flag that controls
+			 * whether the client automatically fills in missing fields from schema
+			 * defaults. It is serialized as part of the capabilities sent to the server
+			 * during initialization, consistent with the TypeScript SDK behavior. Servers
+			 * should tolerate unknown capability fields per the MCP specification.
+			 * @param form whether to support form-based elicitation
+			 * @param url whether to support URL-based elicitation
+			 * @param applyDefaults whether the client should apply schema defaults to
+			 * elicitation results. Requires {@code form} to be {@code true}.
+			 * @return this builder
+			 * @throws IllegalArgumentException if {@code applyDefaults} is {@code true}
+			 * but {@code form} is {@code false}
+			 */
+			public Builder elicitation(boolean form, boolean url, boolean applyDefaults) {
+				if (!form && applyDefaults) {
+					throw new IllegalArgumentException("applyDefaults requires form to be true");
+				}
+				this.elicitation = new Elicitation(form ? new Elicitation.Form(applyDefaults) : null,
 						url ? new Elicitation.Url() : null);
 				return this;
 			}

--- a/mcp-core/src/test/java/io/modelcontextprotocol/client/McpAsyncClientElicitationDefaultsTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/client/McpAsyncClientElicitationDefaultsTests.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ */
+
+package io.modelcontextprotocol.client;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link McpAsyncClient#applyElicitationDefaults(Map, Map)}.
+ *
+ * Verifies that the client-side default application logic correctly fills in missing
+ * fields from schema defaults, matching the behavior specified in SEP-1034.
+ */
+class McpAsyncClientElicitationDefaultsTests {
+
+	@Test
+	void appliesStringDefault() {
+		Map<String, Object> schema = Map.of("properties", Map.of("name", Map.of("type", "string", "default", "Guest")));
+
+		Map<String, Object> content = new HashMap<>();
+		McpAsyncClient.applyElicitationDefaults(schema, content);
+
+		assertThat(content).containsEntry("name", "Guest");
+	}
+
+	@Test
+	void appliesNumberDefault() {
+		Map<String, Object> schema = Map.of("properties", Map.of("age", Map.of("type", "integer", "default", 18)));
+
+		Map<String, Object> content = new HashMap<>();
+		McpAsyncClient.applyElicitationDefaults(schema, content);
+
+		assertThat(content).containsEntry("age", 18);
+	}
+
+	@Test
+	void appliesBooleanDefault() {
+		Map<String, Object> schema = Map.of("properties",
+				Map.of("subscribe", Map.of("type", "boolean", "default", true)));
+
+		Map<String, Object> content = new HashMap<>();
+		McpAsyncClient.applyElicitationDefaults(schema, content);
+
+		assertThat(content).containsEntry("subscribe", true);
+	}
+
+	@Test
+	void appliesEnumDefault() {
+		Map<String, Object> schema = Map.of("properties",
+				Map.of("color", Map.of("type", "string", "enum", List.of("red", "green"), "default", "green")));
+
+		Map<String, Object> content = new HashMap<>();
+		McpAsyncClient.applyElicitationDefaults(schema, content);
+
+		assertThat(content).containsEntry("color", "green");
+	}
+
+	@Test
+	void doesNotOverrideExistingValues() {
+		Map<String, Object> schema = Map.of("properties", Map.of("name", Map.of("type", "string", "default", "Guest")));
+
+		Map<String, Object> content = new HashMap<>();
+		content.put("name", "Alice");
+		McpAsyncClient.applyElicitationDefaults(schema, content);
+
+		assertThat(content).containsEntry("name", "Alice");
+	}
+
+	@Test
+	void skipsPropertiesWithoutDefault() {
+		Map<String, Object> schema = Map.of("properties", Map.of("email", Map.of("type", "string")));
+
+		Map<String, Object> content = new HashMap<>();
+		McpAsyncClient.applyElicitationDefaults(schema, content);
+
+		assertThat(content).doesNotContainKey("email");
+	}
+
+	@Test
+	void appliesMultipleDefaults() {
+		Map<String, Object> schema = Map.of("properties",
+				Map.of("name", Map.of("type", "string", "default", "Guest"), "age",
+						Map.of("type", "integer", "default", 18), "subscribe",
+						Map.of("type", "boolean", "default", true), "color",
+						Map.of("type", "string", "enum", List.of("red", "green"), "default", "green")));
+
+		Map<String, Object> content = new HashMap<>();
+		McpAsyncClient.applyElicitationDefaults(schema, content);
+
+		assertThat(content).containsEntry("name", "Guest")
+			.containsEntry("age", 18)
+			.containsEntry("subscribe", true)
+			.containsEntry("color", "green");
+	}
+
+	@Test
+	void handlesNullSchema() {
+		Map<String, Object> content = new HashMap<>();
+		McpAsyncClient.applyElicitationDefaults(null, content);
+
+		assertThat(content).isEmpty();
+	}
+
+	@Test
+	void handlesNullContent() {
+		Map<String, Object> schema = Map.of("properties", Map.of("name", Map.of("type", "string", "default", "Guest")));
+
+		// Should not throw
+		McpAsyncClient.applyElicitationDefaults(schema, null);
+	}
+
+	@Test
+	void handlesSchemaWithoutProperties() {
+		Map<String, Object> schema = Map.of("type", "object");
+
+		Map<String, Object> content = new HashMap<>();
+		McpAsyncClient.applyElicitationDefaults(schema, content);
+
+		assertThat(content).isEmpty();
+	}
+
+	@Test
+	void appliesDefaultsOnlyToMissingFields() {
+		Map<String, Object> schema = Map.of("properties", Map.of("name", Map.of("type", "string", "default", "Guest"),
+				"age", Map.of("type", "integer", "default", 18)));
+
+		Map<String, Object> content = new HashMap<>();
+		content.put("name", "John");
+		McpAsyncClient.applyElicitationDefaults(schema, content);
+
+		assertThat(content).containsEntry("name", "John").containsEntry("age", 18);
+	}
+
+	@Test
+	void appliesFloatingPointDefault() {
+		Map<String, Object> schema = Map.of("properties", Map.of("score", Map.of("type", "number", "default", 95.5)));
+
+		Map<String, Object> content = new HashMap<>();
+		McpAsyncClient.applyElicitationDefaults(schema, content);
+
+		assertThat(content).containsEntry("score", 95.5);
+	}
+
+}

--- a/mcp-test/src/main/java/io/modelcontextprotocol/AbstractMcpClientServerIntegrationTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/AbstractMcpClientServerIntegrationTests.java
@@ -451,6 +451,137 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
 	@MethodSource("clientsForTesting")
+	void testCreateElicitationWithApplyDefaults(String clientType) {
+
+		var clientBuilder = clientBuilders.get(clientType);
+
+		// Client handler returns empty content — SDK should apply defaults
+		Function<McpSchema.ElicitRequest, McpSchema.ElicitResult> elicitationHandler = request -> {
+			assertThat(request.message()).isNotEmpty();
+			assertThat(request.requestedSchema()).isNotNull();
+			// Return accept with empty content, simulating a user who didn't fill
+			// anything
+			return new McpSchema.ElicitResult(McpSchema.ElicitResult.Action.ACCEPT, new java.util.HashMap<>());
+		};
+
+		CallToolResult callResponse = McpSchema.CallToolResult.builder()
+			.addContent(new McpSchema.TextContent("CALL RESPONSE"))
+			.build();
+
+		AtomicReference<McpSchema.ElicitResult> elicitResultRef = new AtomicReference<>();
+
+		McpServerFeatures.AsyncToolSpecification tool = McpServerFeatures.AsyncToolSpecification.builder()
+			.tool(Tool.builder().name("tool1").description("tool1 description").inputSchema(EMPTY_JSON_SCHEMA).build())
+			.callHandler((exchange, request) -> {
+
+				var elicitationRequest = McpSchema.ElicitRequest.builder()
+					.message("Provide your preferences")
+					.requestedSchema(Map.of("type", "object", "properties",
+							Map.of("nickname", Map.of("type", "string", "default", "Guest"), "age",
+									Map.of("type", "integer", "default", 18), "subscribe",
+									Map.of("type", "boolean", "default", true), "color",
+									Map.of("type", "string", "enum", java.util.List.of("red", "green"), "default",
+											"green")),
+							"required", java.util.List.of("nickname", "age", "subscribe", "color")))
+					.build();
+
+				return exchange.createElicitation(elicitationRequest)
+					.doOnNext(elicitResultRef::set)
+					.thenReturn(callResponse);
+			})
+			.build();
+
+		var mcpServer = prepareAsyncServerBuilder().serverInfo("test-server", "1.0.0").tools(tool).build();
+
+		// Enable applyDefaults via the capability
+		try (var mcpClient = clientBuilder.clientInfo(new McpSchema.Implementation("Sample client", "0.0.0"))
+			.capabilities(ClientCapabilities.builder().elicitation(true, false, true).build())
+			.elicitation(elicitationHandler)
+			.build()) {
+
+			InitializeResult initResult = mcpClient.initialize();
+			assertThat(initResult).isNotNull();
+
+			CallToolResult response = mcpClient.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
+
+			assertThat(response).isNotNull();
+			assertWith(elicitResultRef.get(), result -> {
+				assertThat(result).isNotNull();
+				assertThat(result.action()).isEqualTo(McpSchema.ElicitResult.Action.ACCEPT);
+				assertThat(result.content()).containsEntry("nickname", "Guest");
+				assertThat(result.content()).containsEntry("age", 18);
+				assertThat(result.content()).containsEntry("subscribe", true);
+				assertThat(result.content()).containsEntry("color", "green");
+			});
+		}
+		finally {
+			mcpServer.closeGracefully().block();
+		}
+	}
+
+	@ParameterizedTest(name = "{0} : {displayName} ")
+	@MethodSource("clientsForTesting")
+	void testCreateElicitationWithApplyDefaultsAndUnmodifiableMap(String clientType) {
+
+		var clientBuilder = clientBuilders.get(clientType);
+
+		// Client handler returns an unmodifiable map (Map.of()) — SDK should handle this
+		// gracefully by copying into a new HashMap before applying defaults
+		Function<McpSchema.ElicitRequest, McpSchema.ElicitResult> elicitationHandler = request -> {
+			return new McpSchema.ElicitResult(McpSchema.ElicitResult.Action.ACCEPT, Map.of());
+		};
+
+		CallToolResult callResponse = McpSchema.CallToolResult.builder()
+			.addContent(new McpSchema.TextContent("CALL RESPONSE"))
+			.build();
+
+		AtomicReference<McpSchema.ElicitResult> elicitResultRef = new AtomicReference<>();
+
+		McpServerFeatures.AsyncToolSpecification tool = McpServerFeatures.AsyncToolSpecification.builder()
+			.tool(Tool.builder().name("tool1").description("tool1 description").inputSchema(EMPTY_JSON_SCHEMA).build())
+			.callHandler((exchange, request) -> {
+
+				var elicitationRequest = McpSchema.ElicitRequest.builder()
+					.message("Provide your preferences")
+					.requestedSchema(Map.of("type", "object", "properties",
+							Map.of("nickname", Map.of("type", "string", "default", "Guest"), "age",
+									Map.of("type", "integer", "default", 18)),
+							"required", java.util.List.of("nickname", "age")))
+					.build();
+
+				return exchange.createElicitation(elicitationRequest)
+					.doOnNext(elicitResultRef::set)
+					.thenReturn(callResponse);
+			})
+			.build();
+
+		var mcpServer = prepareAsyncServerBuilder().serverInfo("test-server", "1.0.0").tools(tool).build();
+
+		try (var mcpClient = clientBuilder.clientInfo(new McpSchema.Implementation("Sample client", "0.0.0"))
+			.capabilities(ClientCapabilities.builder().elicitation(true, false, true).build())
+			.elicitation(elicitationHandler)
+			.build()) {
+
+			InitializeResult initResult = mcpClient.initialize();
+			assertThat(initResult).isNotNull();
+
+			CallToolResult response = mcpClient.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
+
+			assertThat(response).isNotNull();
+			assertWith(elicitResultRef.get(), result -> {
+				assertThat(result).isNotNull();
+				assertThat(result.action()).isEqualTo(McpSchema.ElicitResult.Action.ACCEPT);
+				assertThat(result.content()).containsEntry("nickname", "Guest");
+				assertThat(result.content()).containsEntry("age", 18);
+			});
+		}
+		finally {
+			mcpServer.closeGracefully().block();
+		}
+	}
+
+	@ParameterizedTest(name = "{0} : {displayName} ")
+	@MethodSource("clientsForTesting")
 	void testCreateElicitationWithRequestTimeoutSuccess(String clientType) {
 
 		var clientBuilder = clientBuilders.get(clientType);

--- a/mcp-test/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
@@ -4,12 +4,6 @@
 
 package io.modelcontextprotocol.spec;
 
-import static io.modelcontextprotocol.util.McpJsonMapperUtils.JSON_MAPPER;
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -17,11 +11,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
 import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
+import static io.modelcontextprotocol.util.McpJsonMapperUtils.JSON_MAPPER;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
 import net.javacrumbs.jsonunit.core.Option;
 
 /**
@@ -1723,6 +1722,93 @@ public class McpSchemaTests {
 		String json = JSON_MAPPER.writeValueAsString(capabilities);
 		assertThat(json).contains("\"form\"");
 		assertThat(json).doesNotContain("\"url\"");
+	}
+
+	@Test
+	void testElicitationCapabilityWithApplyDefaults() throws Exception {
+		McpSchema.ClientCapabilities capabilities = McpSchema.ClientCapabilities.builder()
+			.elicitation(true, false, true)
+			.build();
+
+		assertThat(capabilities.elicitation()).isNotNull();
+		assertThat(capabilities.elicitation().form()).isNotNull();
+		assertThat(capabilities.elicitation().form().applyDefaults()).isTrue();
+
+		String json = JSON_MAPPER.writeValueAsString(capabilities);
+		assertThatJson(json).node("elicitation.form.applyDefaults").isEqualTo(true);
+	}
+
+	@Test
+	void testElicitationCapabilityApplyDefaultsSerializationRoundTrip() throws Exception {
+		McpSchema.ClientCapabilities original = McpSchema.ClientCapabilities.builder()
+			.elicitation(true, false, true)
+			.build();
+
+		String json = JSON_MAPPER.writeValueAsString(original);
+		McpSchema.ClientCapabilities deserialized = JSON_MAPPER.readValue(json, McpSchema.ClientCapabilities.class);
+
+		assertThat(deserialized.elicitation()).isNotNull();
+		assertThat(deserialized.elicitation().form()).isNotNull();
+		assertThat(deserialized.elicitation().form().applyDefaults()).isTrue();
+	}
+
+	@Test
+	void testElicitationCapabilityFormWithoutApplyDefaults() throws Exception {
+		// Form without applyDefaults should not include it in JSON
+		McpSchema.ClientCapabilities capabilities = McpSchema.ClientCapabilities.builder()
+			.elicitation(true, false)
+			.build();
+
+		assertThat(capabilities.elicitation().form().applyDefaults()).isNull();
+
+		String json = JSON_MAPPER.writeValueAsString(capabilities);
+		assertThat(json).doesNotContain("\"applyDefaults\"");
+	}
+
+	@Test
+	void testElicitationFormDeserializesWithoutApplyDefaults() throws Exception {
+		String json = """
+				{"elicitation":{"form":{}}}""";
+
+		McpSchema.ClientCapabilities capabilities = JSON_MAPPER.readValue(json, McpSchema.ClientCapabilities.class);
+
+		assertThat(capabilities.elicitation()).isNotNull();
+		assertThat(capabilities.elicitation().form()).isNotNull();
+		assertThat(capabilities.elicitation().form().applyDefaults()).isNull();
+	}
+
+	@Test
+	void testElicitationFormToleratesUnknownFields() throws Exception {
+		String json = """
+				{"elicitation":{"form":{"applyDefaults":true,"futureField":"ignored"}}}""";
+
+		McpSchema.ClientCapabilities capabilities = JSON_MAPPER.readValue(json, McpSchema.ClientCapabilities.class);
+
+		assertThat(capabilities.elicitation().form()).isNotNull();
+		assertThat(capabilities.elicitation().form().applyDefaults()).isTrue();
+	}
+
+	@Test
+	void testElicitRequestWithDefaultValues() throws Exception {
+		// Test that schemas with default values serialize correctly in an ElicitRequest
+		McpSchema.ElicitRequest request = McpSchema.ElicitRequest.builder()
+			.message("Please provide your info")
+			.requestedSchema(Map.of("type", "object", "properties",
+					Map.of("name", Map.of("type", "string", "default", "John Doe"), "age",
+							Map.of("type", "integer", "default", 30), "score",
+							Map.of("type", "number", "default", 95.5), "status",
+							Map.of("type", "string", "enum", List.of("active", "inactive"), "default", "active"),
+							"verified", Map.of("type", "boolean", "default", true)),
+					"required", List.of("name")))
+			.build();
+
+		String value = JSON_MAPPER.writeValueAsString(request);
+
+		assertThatJson(value).node("requestedSchema.properties.name.default").isEqualTo("John Doe");
+		assertThatJson(value).node("requestedSchema.properties.age.default").isEqualTo(30);
+		assertThatJson(value).node("requestedSchema.properties.score.default").isEqualTo(95.5);
+		assertThatJson(value).node("requestedSchema.properties.status.default").isEqualTo("active");
+		assertThatJson(value).node("requestedSchema.properties.verified.default").isEqualTo(true);
 	}
 
 	// Progress Notification Tests


### PR DESCRIPTION
Add client-side default application for elicitation schemas, matching the behavior specified in SEP-1034 and implemented in the TypeScript SDK.

Changes:
- Add applyDefaults field to Elicitation.Form capability record
- Add applyElicitationDefaults() in McpAsyncClient to fill missing fields from schema defaults when the client returns accept with incomplete content
- Add builder method elicitation(form, url, applyDefaults) to ClientCapabilities.Builder
- Add unit tests for applyElicitationDefaults covering all primitive types
- Add schema serialization tests for applyDefaults capability
- Add integration test verifying end-to-end default application flow

Closes modelcontextprotocol/java-sdk#699

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
