### PR TITLE
fix: add missing Export-Package to mcp-json-jackson2 and mcp-json-jackson3

### DIFF
--- a/mcp-json-jackson2/pom.xml
+++ b/mcp-json-jackson2/pom.xml
@@ -42,6 +42,8 @@
 								Import-Package:         io.modelcontextprotocol.json,io.modelcontextprotocol.json.schema, \
 								                        *;
 								Service-Component: 		OSGI-INF/io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapperSupplier.xml,OSGI-INF/io.modelcontextprotocol.json.schema.jackson2.JacksonJsonSchemaValidatorSupplier.xml
+								Export-Package:         io.modelcontextprotocol.json.jackson2;version="${project.version}";-noimport:=true, \
+								                        io.modelcontextprotocol.json.schema.jackson2;version="${project.version}";-noimport:=true
 								-noimportjava:          true;
 								-nouses:                true;
 								-removeheaders:         Private-Package

--- a/mcp-json-jackson3/pom.xml
+++ b/mcp-json-jackson3/pom.xml
@@ -42,6 +42,8 @@
 								Import-Package:         io.modelcontextprotocol.json,io.modelcontextprotocol.json.schema, \
 								                        *;
 								Service-Component: 		OSGI-INF/io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapperSupplier.xml,OSGI-INF/io.modelcontextprotocol.json.schema.jackson3.JacksonJsonSchemaValidatorSupplier.xml
+								Export-Package:         io.modelcontextprotocol.json.jackson3;version="${project.version}";-noimport:=true, \
+								                        io.modelcontextprotocol.json.schema.jackson3;version="${project.version}";-noimport:=true
 								-noimportjava:          true;
 								-nouses:                true;
 								-removeheaders:         Private-Package


### PR DESCRIPTION
Add explicit `Export-Package` directives to the jackson modules so OSGi consumers can access classes directly.

## Motivation and Context

PR #779 added bnd configuration to the jackson modules but omitted `Export-Package` (which `mcp-core` has). Without it, all packages are bundle-private, which prevents direct instantiation of `JacksonMcpJsonMapperSupplier` or `DefaultJsonSchemaValidator` from other bundles — the recommended workaround per #562 since `ServiceLoader.load()` does not work across OSGi bundle boundaries.

This particularly affects Eclipse PDE and Tycho-based projects, which get compile-time "Access restriction" errors and runtime `ClassNotFoundException` when referencing classes from these modules.

## How Has This Been Tested?

Verified the generated `META-INF/MANIFEST.MF` after `mvn process-classes` contains the correct `Export-Package` header with only the module's own packages. Also tested in an Eclipse PDE project — the patched modules compile and resolve without issues.

## Breaking Changes

No.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)