### PR TITLE
Fix SSE event classification to follow spec for missing event field

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
@@ -112,6 +112,29 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 
 	public static int BAD_REQUEST = 400;
 
+	/**
+	 * Determines whether an SSE event should be treated as a "message" event carrying a
+	 * JSON-RPC payload.
+	 *
+	 * <p>
+	 * Per the <a href=
+	 * "https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation">
+	 * SSE specification (WHATWG HTML Living Standard §9.2.6)</a>, an event with no
+	 * explicit {@code event:} field MUST be dispatched as a {@code message} event by
+	 * default. This method applies that rule by treating {@code null} or empty event
+	 * names as equivalent to {@link #MESSAGE_EVENT_TYPE}.
+	 *
+	 * <p>
+	 * This alignment ensures interoperability with MCP servers that emit bare
+	 * {@code data:} frames without an accompanying {@code event:} line, which are valid
+	 * per the SSE spec.
+	 * @param eventName the SSE event name, which may be {@code null} or empty
+	 * @return {@code true} if the event should be parsed as a JSON-RPC message
+	 */
+	static boolean isMessageEvent(String eventName) {
+		return eventName == null || eventName.isEmpty() || MESSAGE_EVENT_TYPE.equals(eventName);
+	}
+
 	private final McpJsonMapper jsonMapper;
 
 	private final URI baseUri;
@@ -311,7 +334,7 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 											+ statusCode));
 						}
 						else if (statusCode >= 200 && statusCode < 300) {
-							if (MESSAGE_EVENT_TYPE.equals(sseResponseEvent.sseEvent().event())) {
+							if (isMessageEvent(sseResponseEvent.sseEvent().event())) {
 								String data = sseResponseEvent.sseEvent().data();
 								// Per 2025-11-25 spec (SEP-1699), servers may
 								// send SSE events

--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
@@ -114,6 +114,29 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 
 	public static int BAD_REQUEST = 400;
 
+	/**
+	 * Determines whether an SSE event should be treated as a "message" event carrying a
+	 * JSON-RPC payload.
+	 *
+	 * <p>
+	 * Per the <a href=
+	 * "https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation">
+	 * SSE specification (WHATWG HTML Living Standard §9.2.6)</a>, an event with no
+	 * explicit {@code event:} field MUST be dispatched as a {@code message} event by
+	 * default. This method applies that rule by treating {@code null} or empty event
+	 * names as equivalent to {@link #MESSAGE_EVENT_TYPE}.
+	 *
+	 * <p>
+	 * This alignment ensures interoperability with MCP servers that emit bare
+	 * {@code data:} frames without an accompanying {@code event:} line, which are valid
+	 * per the SSE spec.
+	 * @param eventName the SSE event name, which may be {@code null} or empty
+	 * @return {@code true} if the event should be parsed as a JSON-RPC message
+	 */
+	static boolean isMessageEvent(String eventName) {
+		return eventName == null || eventName.isEmpty() || MESSAGE_EVENT_TYPE.equals(eventName);
+	}
+
 	private final McpJsonMapper jsonMapper;
 
 	private final URI baseUri;
@@ -323,7 +346,7 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 											+ statusCode));
 						}
 						else if (statusCode >= 200 && statusCode < 300) {
-							if (MESSAGE_EVENT_TYPE.equals(sseResponseEvent.sseEvent().event())) {
+							if (isMessageEvent(sseResponseEvent.sseEvent().event())) {
 								String data = sseResponseEvent.sseEvent().data();
 								// Per 2025-11-25 spec (SEP-1699), servers may
 								// send SSE events

--- a/mcp-core/src/test/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransportSseEventTypeTest.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransportSseEventTypeTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.client.transport;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link HttpClientStreamableHttpTransport#isMessageEvent(String)}.
+ *
+ * <p>
+ * Verifies that SSE event classification follows the <a href=
+ * "https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation">
+ * WHATWG HTML Living Standard §9.2.6</a>: an event without an explicit {@code event:}
+ * field must be dispatched as a {@code message} event.
+ *
+ * @author jiajingda
+ * @see <a href="https://github.com/modelcontextprotocol/java-sdk/issues/885">#885</a>
+ */
+class HttpClientStreamableHttpTransportSseEventTypeTest {
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	void shouldTreatNullOrEmptyEventAsMessage(String eventName) {
+		assertThat(HttpClientStreamableHttpTransport.isMessageEvent(eventName))
+			.as("SSE frame with null/empty event field must be treated as a 'message' event per SSE spec")
+			.isTrue();
+	}
+
+	@Test
+	void shouldTreatExplicitMessageEventAsMessage() {
+		assertThat(HttpClientStreamableHttpTransport.isMessageEvent("message"))
+			.as("Explicit 'message' event must be parsed as a JSON-RPC message")
+			.isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "ping", "error", "notification", "MESSAGE", "Message", "custom-event" })
+	void shouldNotTreatOtherEventsAsMessage(String eventName) {
+		assertThat(HttpClientStreamableHttpTransport.isMessageEvent(eventName))
+			.as("Non-'message' SSE event '%s' must not be parsed as a JSON-RPC message", eventName)
+			.isFalse();
+	}
+
+}


### PR DESCRIPTION
Fix `HttpClientStreamableHttpTransport` silently dropping SSE frames that omit the `event:` field, in violation of the SSE specification.

## Motivation and Context

Per the [SSE specification (WHATWG HTML Living Standard §9.2.6)](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation):

> If the field name is "event": Set the `event type` buffer to `field value`. If the `event:` line is absent, the event type buffer is empty, and the event is dispatched as a `message` event.

The current `reconnect()` / GET SSE stream path in `HttpClientStreamableHttpTransport` uses a strict equality check:

```java
if (MESSAGE_EVENT_TYPE.equals(sseResponseEvent.sseEvent().event())) {
```

When a server emits a bare `data:` frame without an accompanying `event:` line (which is valid per the spec), `event()` is `null` and the frame is silently dropped. This manifests as server-initiated notifications never reaching the handler after initialization completes.

Note the asymmetry: the `sendMessage()` POST path does not check the event type at all and is unaffected, which is why `initialize()` succeeds on HttpClient. The bug only impacts server-pushed messages on the open GET stream.

Originally reported in #885 against the Spring `WebClientStreamableHttpTransport` variant, which was moved to Spring AI 2.0 in #805. This PR fixes the `HttpClient` variant that remains in this repository.

## How Has This Been Tested?

Added `HttpClientStreamableHttpTransportSseEventTypeTest` with parameterized unit tests covering:

- `null` and empty event names → parsed as message (the bug scenario)
- Explicit `"message"` → parsed as message (regression)
- Non-message events (`ping`, `error`, `notification`, `MESSAGE`/`Message` case variants, custom names) → not parsed as message

Verified locally:

```
./mvnw test -pl mcp-core -Dtest=HttpClientStreamableHttpTransportSseEventTypeTest
→ Tests run: 9, Failures: 0, Errors: 0, Skipped: 0

./mvnw validate -pl mcp-core
→ BUILD SUCCESS

./mvnw test -pl mcp-core
→ BUILD SUCCESS (no regressions)
```

## Breaking Changes

None. This is a pure bug fix that relaxes an overly strict check to match the SSE specification. Existing behavior for explicit `"message"` events is preserved, and non-message events are still ignored.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

**Implementation note**: I extracted the classification into a package-private static helper `isMessageEvent(String)` rather than inlining the null/empty check. This keeps the call site readable, documents the spec rule in one place (with a link to WHATWG §9.2.6 in the Javadoc), and enables direct unit testing without setting up an HTTP server.

**Scope**: This PR only addresses the `HttpClient` variant in this repository. The `WebClient` variant mentioned in #885 lives in Spring AI 2.0 after #805 and would need a separate fix there. See my [comment on #885](https://github.com/modelcontextprotocol/java-sdk/issues/885) for details on the asymmetry between the POST and GET paths.

Closes gh-885