### PR TITLE
feat!: enforce required MCP spec fields in McpSchema; lenient wire deserialization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,22 +77,35 @@ git checkout -b feature/your-feature-name
 
 ## Evolving wire-serialized records
 
-Records in `McpSchema` are serialized directly to the MCP JSON wire format. Follow these rules whenever you add a field to an existing record to keep the protocol forward- and backward-compatible.
+Records in `McpSchema` are serialized directly to the MCP JSON wire format. The rules differ depending on whether the field you are adding (or maintaining) is *optional* — Java code may legitimately leave it `null` and the wire may omit it — or *spec-required* by MCP. Follow **Case A** for optional fields and **Case B** for spec-required fields.
 
-### Rules
+### Case A — Optional fields
 
 1. **Add new components only at the end** of the record's component list. Never reorder or rename existing components.
 2. **Annotate every component** with `@JsonProperty("fieldName")` even when the Java name already matches. This survives local renames via refactoring tools.
 3. **Use boxed types** (`Boolean`, `Integer`, `Long`, `Double`) so the field can be absent on the wire without a special sentinel.
-4. **Default to `null`**, not an empty collection or neutral value, so the `@JsonInclude(NON_NULL)` rule omits the field for clients that don't know about it yet.
+4. **Default to `null`**, not an empty collection or neutral value, so the `@JsonInclude(NON_ABSENT)` rule omits the field for clients that don't know about it yet.
 5. **Keep existing constructors as source-compatible overloads** that delegate to the new canonical constructor and pass `null` for the new component. Do not remove them in the same release that adds the field.
-6. **Do not put `@JsonCreator` on the canonical constructor** unless strictly necessary. Jackson auto-detects record canonical constructors; adding `@JsonCreator` pins deserialization to that exact parameter order forever.
-7. **Do not convert `null` to a default value in the canonical constructor.** Null carries "absent" semantics and must be preserved through the serialization round-trip.
+6. **Do not put `@JsonCreator` on the canonical constructor** unless strictly necessary. Jackson auto-detects record canonical constructors; adding `@JsonCreator` pins deserialization to that exact parameter order forever. *(For records that also have spec-required fields, the `@JsonCreator` belongs on a separate static `fromJson` factory — see Case B, Rule 2.)*
+7. **Do not convert `null` to a default value in the canonical constructor.** Null carries "absent" semantics and must be preserved through the serialization round-trip. *(Spec-required fields are the exception — see Case B, Rule 1.)*
 8. **Add three tests per new field** (put them in the relevant test class in `mcp-test`):
    - Deserialize JSON *without* the field → succeeds, field is `null`.
    - Serialize an instance with the field unset (`null`) → the key is absent from output.
    - Deserialize JSON with an extra *unknown* field → succeeds.
-9. **An inner `Builder` subclass can be used.** This improves the developer experience since frequently not all fields are required. 
+9. **An inner `Builder` subclass can be used.** This improves the developer experience since frequently not all fields are required.
+
+### Case B — Spec-required fields
+
+When the MCP specification marks a field as required, callers must not be able to construct a structurally invalid record, but the wire parser must still tolerate peers that fail to send it. Follow these rules in addition to the relevant Case A rules (annotation, naming, append-only).
+
+1. **Reject `null` in the compact constructor.** Use `Assert.notNull` for required objects or `Assert.hasText` for required `String` identifiers (`name`, `uri`, `uriTemplate`, `version`). This throws `IllegalArgumentException` at construction time instead of producing a record that fails later in serialization or protocol handling. Overrides Case A Rule 7 for this field.
+2. **Add a `@JsonCreator` static `fromJson` factory** alongside the canonical constructor. When a required field is absent from the wire, substitute a documented safe default (`""` for strings, `[]` for collections, `{}` for maps, `0` / `0.0` for numerics, `INFO` for `LoggingLevel`, etc.) and log at `WARN` naming the field and the value used. The SDK must not halt the conversation because of a missing field. Place `@JsonCreator` on this `fromJson` factory, never on the canonical constructor (Case A Rule 6 still applies to the canonical constructor itself).
+   - Exception: `JSONRPCResponse.JSONRPCError` fails fast on missing `code` / `message` because a malformed JSON-RPC error envelope is unrecoverable.
+3. **Provide a required-first builder factory** `builder(req1, req2, …)` and remove the corresponding setters from the `Builder`. A no-arg `builder()` factory must not exist on a record that has required fields. If one already exists for source compatibility, mark it `@Deprecated`.
+4. **Add tests per required field**:
+   - Constructing the record with `null` for the field throws `IllegalArgumentException`.
+   - Deserializing JSON *without* the field succeeds and yields the documented default.
+   - Deserializing JSON with an extra *unknown* field still succeeds (Case A Rule 8 also applies).
 
 ### Example
 

--- a/MIGRATION-2.0.md
+++ b/MIGRATION-2.0.md
@@ -77,6 +77,97 @@ The `Tool` record now models `inputSchema` (and `outputSchema`) as arbitrary JSO
 - Java code that used `Tool.inputSchema()` as a `JsonSchema` must switch to `Map<String, Object>` (or copy into your own schema wrapper).
 - `Tool.Builder.inputSchema(JsonSchema)` remains as a **deprecated** helper that maps the old record into a map; prefer `inputSchema(Map)` or `inputSchema(McpJsonMapper, String)`.
 
+### Required MCP spec fields are enforced at construction time
+
+Every wire record in `McpSchema` whose fields are marked required by the MCP spec now asserts non-null (and non-empty for `String` identifiers like `name`, `uri`, `uriTemplate`, `version`) in its compact constructor. Passing `null` throws `IllegalArgumentException` immediately, instead of producing a structurally invalid object that fails later in serialization or protocol handling.
+
+This applies to (non-exhaustive):
+
+- JSON-RPC envelopes: `JSONRPCRequest`, `JSONRPCNotification`, `JSONRPCResponse`, `JSONRPCResponse.JSONRPCError`
+- Lifecycle: `InitializeRequest`, `InitializeResult`, `Implementation`
+- Resources: `Resource`, `ResourceTemplate`, `ListResourcesResult`, `ListResourceTemplatesResult`, `ReadResourceRequest`, `ReadResourceResult`, `SubscribeRequest`, `UnsubscribeRequest`, `ResourcesUpdatedNotification`, `TextResourceContents`, `BlobResourceContents`
+- Prompts: `Prompt`, `PromptArgument`, `PromptMessage`, `ListPromptsResult`, `GetPromptRequest`, `GetPromptResult`
+- Tools: `Tool`, `ListToolsResult`, `CallToolRequest`, `CallToolResult`
+- Sampling / elicitation: `SamplingMessage`, `CreateMessageRequest`, `CreateMessageResult`, `ElicitRequest`, `ElicitResult`
+- Misc: `ProgressNotification`, `SetLevelRequest`, `LoggingMessageNotification`, `CompleteRequest`, `CompleteResult`, `CompleteRequest.CompleteArgument`, content records (`TextContent`, `ImageContent`, `AudioContent`, `EmbeddedResource`), `Root`, `ListRootsResult`, `PromptReference`, `ResourceReference`
+
+**Action:** Audit any code that constructs these records with potentially-null values and provide valid, non-null arguments.
+
+**Wire deserialization is lenient.** Records expose a `@JsonCreator fromJson` factory that substitutes safe defaults (e.g. `[]`, `""`, `0`, `INFO`, `Action.CANCEL`) for any absent required field and logs a `WARN` naming the field and the substituted value. `JSONRPCResponse.JSONRPCError` is excluded — malformed JSON-RPC error envelopes still fail immediately.
+
+**Note:** `LoggingMessageNotification`/`SetLevelRequest` default a *missing* `level` to `INFO`, but an *unrecognized* level string still deserializes to `null` (see the `LoggingLevel` section above) and will then fail the canonical constructor. Ensure clients and servers send only recognized level strings.
+
+### `PromptReference` discriminator pinning and equality
+
+`PromptReference` keeps its `(type, name, title)` record components, so positional construction from 1.x still compiles. Two behavioural changes:
+
+- The compact constructor pins `type` to `ref/prompt`. Any non-null value other than `ref/prompt` is replaced with `ref/prompt` and a `WARN` is logged. The legacy two-arg `PromptReference(String type, String name)` constructor remains `@Deprecated` and routes through the canonical constructor, so it triggers the same WARN.
+- `equals`/`hashCode` now consider `name` only (title and type are ignored). Two refs with the same name but different titles compare equal.
+
+**Action:** Audit any code that used `PromptReference` as a map key or in a `Set` — equality semantics changed. If your code constructed instances with a custom `type` string for testing, switch to `PromptReference.builder(name)` (or `new PromptReference(name)`); the WARN tells you which call sites still pass the discriminator.
+
+`CompleteReference.identifier()` is `@Deprecated` and now returns `null` via a default method on the interface.
+
+### `ResourceReference` record component reduced
+
+Components changed from `(type, uri)` to `(uri)`. Positional construction with two arguments breaks. The legacy `ResourceReference(String type, String uri)` constructor stays `@Deprecated`; it ignores `type` and logs a `WARN`. Use `new ResourceReference(uri)` or `ResourceReference.builder(uri)`. The `type()` accessor still returns `ref/resource` and Jackson serializes it via `@JsonProperty("type")` on the accessor.
+
+### Builder API: required-first factories; old setters/no-arg builders deprecated
+
+Most records that have a builder have gained a required-first factory method (`builder(req1, req2, …)`) and the corresponding setters for required fields are removed from the builder. The old no-arg `builder()` factory and public no-arg `Builder()` constructor are kept but `@Deprecated` where they would allow constructing a builder without required state.
+
+Examples:
+
+| Type | Old (deprecated) | New |
+|------|-----------------|-----|
+| `Resource` | `Resource.builder().uri(u).name(n)…` | `Resource.builder(uri, name)…` |
+| `ResourceTemplate` | `ResourceTemplate.builder().uriTemplate(u).name(n)…` | `ResourceTemplate.builder(uriTemplate, name)…` |
+| `Implementation` | `new Implementation(name, version)` | `Implementation.builder(name, version)…` |
+| `InitializeRequest` / `InitializeResult` | `… .builder()…` | `… .builder(protocolVersion, capabilities, clientInfo/serverInfo)` |
+| `Tool` | `Tool.builder().name(n)…` | `Tool.builder(name)…` |
+| `Prompt` / `PromptArgument` / `GetPromptRequest` | `… .builder().name(n)…` | `… .builder(name)…` |
+| `PromptMessage` / `SamplingMessage` | `… .builder().role(r).content(c)…` | `… .builder(role, content)…` |
+| `CreateMessageRequest` | `… .builder().messages(m).maxTokens(n)…` | `… .builder(messages, maxTokens)…` |
+| `ElicitRequest` | `… .builder().message(m).requestedSchema(s)…` | `… .builder(message, requestedSchema)…` |
+| `LoggingMessageNotification` | `… .builder().level(l).data(d)…` | `… .builder(level, data)…` |
+| `ListResourcesResult` / `ListResourceTemplatesResult` / `ListPromptsResult` / `ListToolsResult` / `ListRootsResult` | `… .builder()…` | `… .builder(items)…` |
+| `ReadResourceRequest` / `SubscribeRequest` / `UnsubscribeRequest` / `ResourcesUpdatedNotification` / `Root` | n/a | `… .builder(uri)…` |
+| `ReadResourceResult` | n/a | `ReadResourceResult.builder(contents)…` |
+| `TextResourceContents` / `BlobResourceContents` | n/a | `… .builder(uri, text|blob)…` |
+| `TextContent` / `ImageContent` / `AudioContent` / `EmbeddedResource` | n/a | `… .builder(text \| data, mimeType \| resource)…` |
+| `CallToolResult` | unchanged | also: required-first content set via builder constructor remains optional |
+| `ProgressNotification` | n/a | `ProgressNotification.builder(progressToken, progress)` |
+| `JSONRPCResponse.JSONRPCError` | n/a | `JSONRPCError.builder(code, message)` |
+| `CompleteRequest` | n/a | `CompleteRequest.builder(ref, argument)` |
+| `Annotations` | n/a | `Annotations.builder()` |
+| Capabilities (`Sampling`, `Elicitation`, `Roots`, `LoggingCapabilities`, `CompletionCapabilities`, prompt/resource/tool capabilities) | n/a | `… .builder()…` |
+
+### JSON-RPC envelope ergonomics
+
+In 1.x, every envelope was constructed via the canonical record constructor and the literal `"2.0"` `jsonrpc` string had to be threaded through every call site:
+
+```java
+new JSONRPCRequest("2.0", "tools/call", id, params);
+new JSONRPCNotification("2.0", "notifications/initialized", null);
+new JSONRPCResponse("2.0", id, result, null);
+new JSONRPCResponse("2.0", id, null, new JSONRPCError(code, message, null));
+```
+
+2.0 adds defaulting constructors and static factories so the `"2.0"` constant and the unused `result`/`error` slot disappear from caller code:
+
+```java
+new JSONRPCRequest("tools/call", id);                       // params optional
+new JSONRPCRequest("tools/call", id, params);
+new JSONRPCNotification("notifications/initialized");        // params optional
+new JSONRPCNotification("notifications/initialized", params);
+JSONRPCResponse.result(id, result);
+JSONRPCResponse.error(id, new JSONRPCError(code, message));  // 2-arg error
+```
+
+`JSONRPCResponse`'s compact constructor additionally enforces the JSON-RPC invariant that exactly one of `result` / `error` is set — previously the SDK could build envelopes that violated the protocol.
+
+The 1.x canonical 4-arg constructors continue to compile.
+
 ### Optional JSON Schema validation on `tools/call` (server)
 
 When a `JsonSchemaValidator` is available (including the default from `McpJsonDefaults.getSchemaValidator()` when you do not configure one explicitly) and `validateToolInputs` is left at its default of `true`, the server validates incoming tool arguments against `tool.inputSchema()` before invoking the tool. Failed validation produces a `CallToolResult` with `isError` set and a textual error in the content.

--- a/conformance-tests/client-jdk-http-client/src/main/java/io/modelcontextprotocol/conformance/client/ConformanceJdkClientMcpClient.java
+++ b/conformance-tests/client-jdk-http-client/src/main/java/io/modelcontextprotocol/conformance/client/ConformanceJdkClientMcpClient.java
@@ -80,7 +80,7 @@ public class ConformanceJdkClientMcpClient {
 		HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport.builder(serverUrl).build();
 
 		return McpClient.sync(transport)
-			.clientInfo(new McpSchema.Implementation("test-client", "1.0.0"))
+			.clientInfo(McpSchema.Implementation.builder("test-client", "1.0.0").build())
 			.requestTimeout(Duration.ofSeconds(30))
 			.build();
 	}
@@ -97,7 +97,7 @@ public class ConformanceJdkClientMcpClient {
 		var capabilities = McpSchema.ClientCapabilities.builder().elicitation().build();
 
 		return McpClient.sync(transport)
-			.clientInfo(new McpSchema.Implementation("test-client", "1.0.0"))
+			.clientInfo(McpSchema.Implementation.builder("test-client", "1.0.0").build())
 			.requestTimeout(Duration.ofSeconds(30))
 			.capabilities(capabilities)
 			.elicitation(request -> {
@@ -120,7 +120,7 @@ public class ConformanceJdkClientMcpClient {
 				}
 
 				// Return accept action with the defaults applied
-				return new McpSchema.ElicitResult(McpSchema.ElicitResult.Action.ACCEPT, content, null);
+				return McpSchema.ElicitResult.builder(McpSchema.ElicitResult.Action.ACCEPT).content(content).build();
 			})
 			.build();
 	}
@@ -174,7 +174,7 @@ public class ConformanceJdkClientMcpClient {
 						arguments.put("b", 3);
 
 						McpSchema.CallToolResult result = client
-							.callTool(new McpSchema.CallToolRequest("add_numbers", arguments));
+							.callTool(McpSchema.CallToolRequest.builder("add_numbers").arguments(arguments).build());
 
 						System.out.println("Successfully called add_numbers tool");
 						if (result != null && result.content() != null) {
@@ -219,7 +219,9 @@ public class ConformanceJdkClientMcpClient {
 						var arguments = new java.util.HashMap<String, Object>();
 
 						McpSchema.CallToolResult result = client
-							.callTool(new McpSchema.CallToolRequest("test_client_elicitation_defaults", arguments));
+							.callTool(McpSchema.CallToolRequest.builder("test_client_elicitation_defaults")
+								.arguments(arguments)
+								.build());
 
 						System.out.println("Successfully called test_client_elicitation_defaults tool");
 						if (result != null && result.content() != null) {
@@ -264,8 +266,8 @@ public class ConformanceJdkClientMcpClient {
 						// reconnection
 						var arguments = new java.util.HashMap<String, Object>();
 
-						McpSchema.CallToolResult result = client
-							.callTool(new McpSchema.CallToolRequest("test_reconnection", arguments));
+						McpSchema.CallToolResult result = client.callTool(
+								McpSchema.CallToolRequest.builder("test_reconnection").arguments(arguments).build());
 
 						System.out.println("Successfully called test_reconnection tool");
 						if (result != null && result.content() != null) {

--- a/conformance-tests/client-spring-http-client/src/main/java/io/modelcontextprotocol/conformance/client/scenario/DefaultScenario.java
+++ b/conformance-tests/client-spring-http-client/src/main/java/io/modelcontextprotocol/conformance/client/scenario/DefaultScenario.java
@@ -69,7 +69,7 @@ public class DefaultScenario implements Scenario {
 
 		this.client = McpClient.sync(transport)
 			.transportContextProvider(new AuthenticationMcpTransportContextProvider())
-			.clientInfo(new McpSchema.Implementation("test-client", "1.0.0"))
+			.clientInfo(McpSchema.Implementation.builder("test-client", "1.0.0").build())
 			.requestTimeout(Duration.ofSeconds(30))
 			.build();
 

--- a/conformance-tests/client-spring-http-client/src/main/java/io/modelcontextprotocol/conformance/client/scenario/PreRegistrationScenario.java
+++ b/conformance-tests/client-spring-http-client/src/main/java/io/modelcontextprotocol/conformance/client/scenario/PreRegistrationScenario.java
@@ -60,7 +60,7 @@ public class PreRegistrationScenario implements Scenario {
 
 		var client = McpClient.sync(transport)
 			.transportContextProvider(new AuthenticationMcpTransportContextProvider())
-			.clientInfo(new McpSchema.Implementation("test-client", "1.0.0"))
+			.clientInfo(McpSchema.Implementation.builder("test-client", "1.0.0").build())
 			.requestTimeout(Duration.ofSeconds(30))
 			.build();
 

--- a/conformance-tests/server-servlet/src/main/java/io/modelcontextprotocol/conformance/server/ConformanceServlet.java
+++ b/conformance-tests/server-servlet/src/main/java/io/modelcontextprotocol/conformance/server/ConformanceServlet.java
@@ -144,15 +144,14 @@ public class ConformanceServlet {
 		return List.of(
 				// test_simple_text - Returns simple text content
 				McpServerFeatures.SyncToolSpecification.builder()
-					.tool(Tool.builder()
-						.name("test_simple_text")
+					.tool(Tool.builder("test_simple_text", EMPTY_JSON_SCHEMA)
 						.description("Returns simple text content for testing")
-						.inputSchema(EMPTY_JSON_SCHEMA)
 						.build())
 					.callHandler((exchange, request) -> {
 						logger.info("Tool 'test_simple_text' called");
 						return CallToolResult.builder()
-							.content(List.of(new TextContent("This is a simple text response for testing.")))
+							.content(
+									List.of(TextContent.builder("This is a simple text response for testing.").build()))
 							.isError(false)
 							.build();
 					})
@@ -160,15 +159,13 @@ public class ConformanceServlet {
 
 				// test_image_content - Returns image content
 				McpServerFeatures.SyncToolSpecification.builder()
-					.tool(Tool.builder()
-						.name("test_image_content")
+					.tool(Tool.builder("test_image_content", EMPTY_JSON_SCHEMA)
 						.description("Returns image content for testing")
-						.inputSchema(EMPTY_JSON_SCHEMA)
 						.build())
 					.callHandler((exchange, request) -> {
 						logger.info("Tool 'test_image_content' called");
 						return CallToolResult.builder()
-							.content(List.of(new ImageContent(null, RED_PIXEL_PNG, "image/png")))
+							.content(List.of(ImageContent.builder(RED_PIXEL_PNG, "image/png").build()))
 							.isError(false)
 							.build();
 					})
@@ -176,15 +173,13 @@ public class ConformanceServlet {
 
 				// test_audio_content - Returns audio content
 				McpServerFeatures.SyncToolSpecification.builder()
-					.tool(Tool.builder()
-						.name("test_audio_content")
+					.tool(Tool.builder("test_audio_content", EMPTY_JSON_SCHEMA)
 						.description("Returns audio content for testing")
-						.inputSchema(EMPTY_JSON_SCHEMA)
 						.build())
 					.callHandler((exchange, request) -> {
 						logger.info("Tool 'test_audio_content' called");
 						return CallToolResult.builder()
-							.content(List.of(new AudioContent(null, MINIMAL_WAV, "audio/wav")))
+							.content(List.of(AudioContent.builder(MINIMAL_WAV, "audio/wav").build()))
 							.isError(false)
 							.build();
 					})
@@ -192,36 +187,35 @@ public class ConformanceServlet {
 
 				// test_embedded_resource - Returns embedded resource content
 				McpServerFeatures.SyncToolSpecification.builder()
-					.tool(Tool.builder()
-						.name("test_embedded_resource")
+					.tool(Tool.builder("test_embedded_resource", EMPTY_JSON_SCHEMA)
 						.description("Returns embedded resource content for testing")
-						.inputSchema(EMPTY_JSON_SCHEMA)
 						.build())
 					.callHandler((exchange, request) -> {
 						logger.info("Tool 'test_embedded_resource' called");
-						TextResourceContents resourceContents = new TextResourceContents("test://embedded-resource",
-								"text/plain", "This is an embedded resource content.");
-						EmbeddedResource embeddedResource = new EmbeddedResource(null, resourceContents);
+						TextResourceContents resourceContents = TextResourceContents
+							.builder("test://embedded-resource", "This is an embedded resource content.")
+							.mimeType("text/plain")
+							.build();
+						EmbeddedResource embeddedResource = EmbeddedResource.builder(resourceContents).build();
 						return CallToolResult.builder().content(List.of(embeddedResource)).isError(false).build();
 					})
 					.build(),
 
 				// test_multiple_content_types - Returns multiple content types
 				McpServerFeatures.SyncToolSpecification.builder()
-					.tool(Tool.builder()
-						.name("test_multiple_content_types")
+					.tool(Tool.builder("test_multiple_content_types", EMPTY_JSON_SCHEMA)
 						.description("Returns multiple content types for testing")
-						.inputSchema(EMPTY_JSON_SCHEMA)
 						.build())
 					.callHandler((exchange, request) -> {
 						logger.info("Tool 'test_multiple_content_types' called");
-						TextResourceContents resourceContents = new TextResourceContents(
-								"test://mixed-content-resource", "application/json",
-								"{\"test\":\"data\",\"value\":123}");
-						EmbeddedResource embeddedResource = new EmbeddedResource(null, resourceContents);
+						TextResourceContents resourceContents = TextResourceContents
+							.builder("test://mixed-content-resource", "{\"test\":\"data\",\"value\":123}")
+							.mimeType("application/json")
+							.build();
+						EmbeddedResource embeddedResource = EmbeddedResource.builder(resourceContents).build();
 						return CallToolResult.builder()
-							.content(List.of(new TextContent("Multiple content types test:"),
-									new ImageContent(null, RED_PIXEL_PNG, "image/png"), embeddedResource))
+							.content(List.of(TextContent.builder("Multiple content types test:").build(),
+									ImageContent.builder(RED_PIXEL_PNG, "image/png").build(), embeddedResource))
 							.isError(false)
 							.build();
 					})
@@ -229,28 +223,22 @@ public class ConformanceServlet {
 
 				// test_tool_with_logging - Tool that sends log messages during execution
 				McpServerFeatures.SyncToolSpecification.builder()
-					.tool(Tool.builder()
-						.name("test_tool_with_logging")
+					.tool(Tool.builder("test_tool_with_logging", EMPTY_JSON_SCHEMA)
 						.description("Tool that sends log messages during execution")
-						.inputSchema(EMPTY_JSON_SCHEMA)
 						.build())
 					.callHandler((exchange, request) -> {
 						logger.info("Tool 'test_tool_with_logging' called");
 						// Send log notifications
-						exchange.loggingNotification(LoggingMessageNotification.builder()
-							.level(LoggingLevel.INFO)
-							.data("Tool execution started")
-							.build());
-						exchange.loggingNotification(LoggingMessageNotification.builder()
-							.level(LoggingLevel.INFO)
-							.data("Tool processing data")
-							.build());
-						exchange.loggingNotification(LoggingMessageNotification.builder()
-							.level(LoggingLevel.INFO)
-							.data("Tool execution completed")
-							.build());
+						exchange.loggingNotification(
+								LoggingMessageNotification.builder(LoggingLevel.INFO, "Tool execution started")
+									.build());
+						exchange.loggingNotification(
+								LoggingMessageNotification.builder(LoggingLevel.INFO, "Tool processing data").build());
+						exchange.loggingNotification(
+								LoggingMessageNotification.builder(LoggingLevel.INFO, "Tool execution completed")
+									.build());
 						return CallToolResult.builder()
-							.content(List.of(new TextContent("Tool execution completed with logging")))
+							.content(List.of(TextContent.builder("Tool execution completed with logging").build()))
 							.isError(false)
 							.build();
 					})
@@ -258,15 +246,14 @@ public class ConformanceServlet {
 
 				// test_error_handling - Tool that always returns an error
 				McpServerFeatures.SyncToolSpecification.builder()
-					.tool(Tool.builder()
-						.name("test_error_handling")
+					.tool(Tool.builder("test_error_handling", EMPTY_JSON_SCHEMA)
 						.description("Tool that returns an error for testing error handling")
-						.inputSchema(EMPTY_JSON_SCHEMA)
 						.build())
 					.callHandler((exchange, request) -> {
 						logger.info("Tool 'test_error_handling' called");
 						return CallToolResult.builder()
-							.content(List.of(new TextContent("This tool intentionally returns an error for testing")))
+							.content(List.of(TextContent.builder("This tool intentionally returns an error for testing")
+								.build()))
 							.isError(true)
 							.build();
 					})
@@ -274,33 +261,34 @@ public class ConformanceServlet {
 
 				// test_tool_with_progress - Tool that reports progress
 				McpServerFeatures.SyncToolSpecification.builder()
-					.tool(Tool.builder()
-						.name("test_tool_with_progress")
+					.tool(Tool.builder("test_tool_with_progress", EMPTY_JSON_SCHEMA)
 						.description("Tool that reports progress notifications")
-						.inputSchema(EMPTY_JSON_SCHEMA)
 						.build())
 					.callHandler((exchange, request) -> {
 						logger.info("Tool 'test_tool_with_progress' called");
 						Object progressToken = request.meta().get("progressToken");
 						if (progressToken != null) {
 							// Send progress notifications sequentially
-							exchange.progressNotification(new ProgressNotification(progressToken, 0.0, 100.0, null));
+							exchange.progressNotification(
+									ProgressNotification.builder(progressToken, 0.0).total(100.0).build());
 							// try {
 							// Thread.sleep(50);
 							// }
 							// catch (InterruptedException e) {
 							// Thread.currentThread().interrupt();
 							// }
-							exchange.progressNotification(new ProgressNotification(progressToken, 50.0, 100.0, null));
+							exchange.progressNotification(
+									ProgressNotification.builder(progressToken, 50.0).total(100.0).build());
 							// try {
 							// Thread.sleep(50);
 							// }
 							// catch (InterruptedException e) {
 							// Thread.currentThread().interrupt();
 							// }
-							exchange.progressNotification(new ProgressNotification(progressToken, 100.0, 100.0, null));
+							exchange.progressNotification(
+									ProgressNotification.builder(progressToken, 100.0).total(100.0).build());
 							return CallToolResult.builder()
-								.content(List.of(new TextContent("Tool execution completed with progress")))
+								.content(List.of(TextContent.builder("Tool execution completed with progress").build()))
 								.isError(false)
 								.build();
 						}
@@ -313,7 +301,8 @@ public class ConformanceServlet {
 							// Thread.currentThread().interrupt();
 							// }
 							return CallToolResult.builder()
-								.content(List.of(new TextContent("Tool execution completed without progress")))
+								.content(List
+									.of(TextContent.builder("Tool execution completed without progress").build()))
 								.isError(false)
 								.build();
 						}
@@ -322,28 +311,28 @@ public class ConformanceServlet {
 
 				// test_sampling - Tool that requests LLM sampling from client
 				McpServerFeatures.SyncToolSpecification.builder()
-					.tool(Tool.builder()
-						.name("test_sampling")
-						.description("Tool that requests LLM sampling from client")
-						.inputSchema(Map.of("type", "object", "properties",
+					.tool(Tool
+						.builder("test_sampling", Map.of("type", "object", "properties",
 								Map.of("prompt",
 										Map.of("type", "string", "description", "The prompt to send to the LLM")),
 								"required", List.of("prompt")))
+						.description("Tool that requests LLM sampling from client")
 						.build())
 					.callHandler((exchange, request) -> {
 						logger.info("Tool 'test_sampling' called");
 						String prompt = (String) request.arguments().get("prompt");
 
 						// Request sampling from client
-						CreateMessageRequest samplingRequest = CreateMessageRequest.builder()
-							.messages(List.of(new SamplingMessage(Role.USER, new TextContent(prompt))))
-							.maxTokens(100)
+						CreateMessageRequest samplingRequest = CreateMessageRequest
+							.builder(List
+								.of(SamplingMessage.builder(Role.USER, TextContent.builder(prompt).build()).build()),
+									100)
 							.build();
 
 						CreateMessageResult response = exchange.createMessage(samplingRequest);
 						String responseText = "LLM response: " + ((TextContent) response.content()).text();
 						return CallToolResult.builder()
-							.content(List.of(new TextContent(responseText)))
+							.content(List.of(TextContent.builder(responseText).build()))
 							.isError(false)
 							.build();
 					})
@@ -351,13 +340,12 @@ public class ConformanceServlet {
 
 				// test_elicitation - Tool that requests user input from client
 				McpServerFeatures.SyncToolSpecification.builder()
-					.tool(Tool.builder()
-						.name("test_elicitation")
-						.description("Tool that requests user input from client")
-						.inputSchema(Map.of("type", "object", "properties",
+					.tool(Tool
+						.builder("test_elicitation", Map.of("type", "object", "properties",
 								Map.of("message",
 										Map.of("type", "string", "description", "The message to show the user")),
 								"required", List.of("message")))
+						.description("Tool that requests user input from client")
 						.build())
 					.callHandler((exchange, request) -> {
 						logger.info("Tool 'test_elicitation' called");
@@ -369,13 +357,13 @@ public class ConformanceServlet {
 										Map.of("type", "string", "description", "User's email address")),
 								"required", List.of("username", "email"));
 
-						ElicitRequest elicitRequest = new ElicitRequest(message, requestedSchema);
+						ElicitRequest elicitRequest = ElicitRequest.builder(message, requestedSchema).build();
 
 						ElicitResult response = exchange.createElicitation(elicitRequest);
 						String responseText = "User response: action=" + response.action() + ", content="
 								+ response.content();
 						return CallToolResult.builder()
-							.content(List.of(new TextContent(responseText)))
+							.content(List.of(TextContent.builder(responseText).build()))
 							.isError(false)
 							.build();
 					})
@@ -384,10 +372,8 @@ public class ConformanceServlet {
 				// test_elicitation_sep1034_defaults - Tool with default values for all
 				// primitive types
 				McpServerFeatures.SyncToolSpecification.builder()
-					.tool(Tool.builder()
-						.name("test_elicitation_sep1034_defaults")
+					.tool(Tool.builder("test_elicitation_sep1034_defaults", EMPTY_JSON_SCHEMA)
 						.description("Tool that requests elicitation with default values for all primitive types")
-						.inputSchema(EMPTY_JSON_SCHEMA)
 						.build())
 					.callHandler((exchange, request) -> {
 						logger.info("Tool 'test_elicitation_sep1034_defaults' called");
@@ -402,14 +388,15 @@ public class ConformanceServlet {
 										"verified", Map.of("type", "boolean", "default", true)),
 								"required", List.of("name", "age", "score", "status", "verified"));
 
-						ElicitRequest elicitRequest = new ElicitRequest("Please provide your information with defaults",
-								requestedSchema);
+						ElicitRequest elicitRequest = ElicitRequest
+							.builder("Please provide your information with defaults", requestedSchema)
+							.build();
 
 						ElicitResult response = exchange.createElicitation(elicitRequest);
 						String responseText = "Elicitation completed: action=" + response.action() + ", content="
 								+ response.content();
 						return CallToolResult.builder()
-							.content(List.of(new TextContent(responseText)))
+							.content(List.of(TextContent.builder(responseText).build()))
 							.isError(false)
 							.build();
 					})
@@ -417,10 +404,8 @@ public class ConformanceServlet {
 
 				// test_elicitation_sep1330_enums - Tool with enum schema improvements
 				McpServerFeatures.SyncToolSpecification.builder()
-					.tool(Tool.builder()
-						.name("test_elicitation_sep1330_enums")
+					.tool(Tool.builder("test_elicitation_sep1330_enums", EMPTY_JSON_SCHEMA)
 						.description("Tool that requests elicitation with enum schema improvements")
-						.inputSchema(EMPTY_JSON_SCHEMA)
 						.build())
 					.callHandler((exchange, request) -> {
 						logger.info("Tool 'test_elicitation_sep1330_enums' called");
@@ -455,13 +440,14 @@ public class ConformanceServlet {
 								"required", List.of("untitledSingle", "titledSingle", "legacyEnum", "untitledMulti",
 										"titledMulti"));
 
-						ElicitRequest elicitRequest = new ElicitRequest("Select your preferences", requestedSchema);
+						ElicitRequest elicitRequest = ElicitRequest.builder("Select your preferences", requestedSchema)
+							.build();
 
 						ElicitResult response = exchange.createElicitation(elicitRequest);
 						String responseText = "Elicitation completed: action=" + response.action() + ", content="
 								+ response.content();
 						return CallToolResult.builder()
-							.content(List.of(new TextContent(responseText)))
+							.content(List.of(TextContent.builder(responseText).build()))
 							.isError(false)
 							.build();
 					})
@@ -471,113 +457,142 @@ public class ConformanceServlet {
 	private static List<McpServerFeatures.SyncPromptSpecification> createPromptSpecs() {
 		return List.of(
 				// test_simple_prompt - Simple prompt without arguments
-				new McpServerFeatures.SyncPromptSpecification(
-						new Prompt("test_simple_prompt", null, "A simple prompt for testing", List.of()),
-						(exchange, request) -> {
-							logger.info("Prompt 'test_simple_prompt' requested");
-							return new GetPromptResult(null, List.of(new PromptMessage(Role.USER,
-									new TextContent("This is a simple prompt for testing."))));
-						}),
+				new McpServerFeatures.SyncPromptSpecification(Prompt.builder("test_simple_prompt")
+					.description("A simple prompt for testing")
+					.arguments(List.of())
+					.build(), (exchange, request) -> {
+						logger.info("Prompt 'test_simple_prompt' requested");
+						return GetPromptResult.builder(List.of(PromptMessage
+							.builder(Role.USER, TextContent.builder("This is a simple prompt for testing.").build())
+							.build())).build();
+					}),
 
 				// test_prompt_with_arguments - Prompt with arguments
-				new McpServerFeatures.SyncPromptSpecification(
-						new Prompt("test_prompt_with_arguments", null, "A prompt with arguments for testing",
-								List.of(new PromptArgument("arg1", "First test argument", true),
-										new PromptArgument("arg2", "Second test argument", true))),
-						(exchange, request) -> {
-							logger.info("Prompt 'test_prompt_with_arguments' requested");
-							String arg1 = (String) request.arguments().get("arg1");
-							String arg2 = (String) request.arguments().get("arg2");
-							String text = String.format("Prompt with arguments: arg1='%s', arg2='%s'", arg1, arg2);
-							return new GetPromptResult(null,
-									List.of(new PromptMessage(Role.USER, new TextContent(text))));
-						}),
+				new McpServerFeatures.SyncPromptSpecification(Prompt.builder("test_prompt_with_arguments")
+					.description("A prompt with arguments for testing")
+					.arguments(List.of(
+							PromptArgument.builder("arg1").description("First test argument").required(true).build(),
+							PromptArgument.builder("arg2").description("Second test argument").required(true).build()))
+					.build(), (exchange, request) -> {
+						logger.info("Prompt 'test_prompt_with_arguments' requested");
+						String arg1 = (String) request.arguments().get("arg1");
+						String arg2 = (String) request.arguments().get("arg2");
+						String text = String.format("Prompt with arguments: arg1='%s', arg2='%s'", arg1, arg2);
+						return GetPromptResult
+							.builder(List
+								.of(PromptMessage.builder(Role.USER, TextContent.builder(text).build()).build()))
+							.build();
+					}),
 
 				// test_prompt_with_embedded_resource - Prompt with embedded resource
-				new McpServerFeatures.SyncPromptSpecification(
-						new Prompt("test_prompt_with_embedded_resource", null,
-								"A prompt with embedded resource for testing",
-								List.of(new PromptArgument("resourceUri", "URI of the resource to embed", true))),
-						(exchange, request) -> {
-							logger.info("Prompt 'test_prompt_with_embedded_resource' requested");
-							String resourceUri = (String) request.arguments().get("resourceUri");
-							TextResourceContents resourceContents = new TextResourceContents(resourceUri, "text/plain",
-									"Embedded resource content for testing.");
-							EmbeddedResource embeddedResource = new EmbeddedResource(null, resourceContents);
-							return new GetPromptResult(null,
-									List.of(new PromptMessage(Role.USER, embeddedResource), new PromptMessage(Role.USER,
-											new TextContent("Please process the embedded resource above."))));
-						}),
+				new McpServerFeatures.SyncPromptSpecification(Prompt.builder("test_prompt_with_embedded_resource")
+					.description("A prompt with embedded resource for testing")
+					.arguments(List.of(PromptArgument.builder("resourceUri")
+						.description("URI of the resource to embed")
+						.required(true)
+						.build()))
+					.build(), (exchange, request) -> {
+						logger.info("Prompt 'test_prompt_with_embedded_resource' requested");
+						String resourceUri = (String) request.arguments().get("resourceUri");
+						TextResourceContents resourceContents = TextResourceContents
+							.builder(resourceUri, "Embedded resource content for testing.")
+							.mimeType("text/plain")
+							.build();
+						EmbeddedResource embeddedResource = EmbeddedResource.builder(resourceContents).build();
+						return GetPromptResult
+							.builder(List.of(PromptMessage.builder(Role.USER, embeddedResource).build(),
+									PromptMessage
+										.builder(Role.USER,
+												TextContent.builder("Please process the embedded resource above.")
+													.build())
+										.build()))
+							.build();
+					}),
 
 				// test_prompt_with_image - Prompt with image content
-				new McpServerFeatures.SyncPromptSpecification(new Prompt("test_prompt_with_image", null,
-						"A prompt with image content for testing", List.of()), (exchange, request) -> {
-							logger.info("Prompt 'test_prompt_with_image' requested");
-							return new GetPromptResult(null, List.of(
-									new PromptMessage(Role.USER, new ImageContent(null, RED_PIXEL_PNG, "image/png")),
-									new PromptMessage(Role.USER, new TextContent("Please analyze the image above."))));
-						}));
+				new McpServerFeatures.SyncPromptSpecification(Prompt.builder("test_prompt_with_image")
+					.description("A prompt with image content for testing")
+					.arguments(List.of())
+					.build(), (exchange, request) -> {
+						logger.info("Prompt 'test_prompt_with_image' requested");
+						return GetPromptResult.builder(List.of(
+								PromptMessage
+									.builder(Role.USER, ImageContent.builder(RED_PIXEL_PNG, "image/png").build())
+									.build(),
+								PromptMessage
+									.builder(Role.USER, TextContent.builder("Please analyze the image above.").build())
+									.build()))
+							.build();
+					}));
 	}
 
 	private static List<McpServerFeatures.SyncResourceSpecification> createResourceSpecs() {
 		return List.of(
 				// test://static-text - Static text resource
-				new McpServerFeatures.SyncResourceSpecification(Resource.builder()
-					.uri("test://static-text")
-					.name("Static Text Resource")
-					.description("A static text resource for testing")
-					.mimeType("text/plain")
-					.build(), (exchange, request) -> {
-						logger.info("Resource 'test://static-text' requested");
-						return new ReadResourceResult(List.of(new TextResourceContents("test://static-text",
-								"text/plain", "This is the content of the static text resource.")));
-					}),
+				new McpServerFeatures.SyncResourceSpecification(
+						Resource.builder("test://static-text", "Static Text Resource")
+							.description("A static text resource for testing")
+							.mimeType("text/plain")
+							.build(),
+						(exchange, request) -> {
+							logger.info("Resource 'test://static-text' requested");
+							return ReadResourceResult.builder(List.of(TextResourceContents
+								.builder("test://static-text", "This is the content of the static text resource.")
+								.mimeType("text/plain")
+								.build())).build();
+						}),
 
 				// test://static-binary - Static binary resource (image)
-				new McpServerFeatures.SyncResourceSpecification(Resource.builder()
-					.uri("test://static-binary")
-					.name("Static Binary Resource")
-					.description("A static binary resource for testing")
-					.mimeType("image/png")
-					.build(), (exchange, request) -> {
-						logger.info("Resource 'test://static-binary' requested");
-						return new ReadResourceResult(
-								List.of(new BlobResourceContents("test://static-binary", "image/png", RED_PIXEL_PNG)));
-					}),
+				new McpServerFeatures.SyncResourceSpecification(
+						Resource.builder("test://static-binary", "Static Binary Resource")
+							.description("A static binary resource for testing")
+							.mimeType("image/png")
+							.build(),
+						(exchange, request) -> {
+							logger.info("Resource 'test://static-binary' requested");
+							return ReadResourceResult
+								.builder(List.of(BlobResourceContents.builder("test://static-binary", RED_PIXEL_PNG)
+									.mimeType("image/png")
+									.build()))
+								.build();
+						}),
 
 				// test://watched-resource - Resource that can be subscribed to
-				new McpServerFeatures.SyncResourceSpecification(Resource.builder()
-					.uri("test://watched-resource")
-					.name("Watched Resource")
-					.description("A resource that can be subscribed to for updates")
-					.mimeType("text/plain")
-					.build(), (exchange, request) -> {
-						logger.info("Resource 'test://watched-resource' requested");
-						return new ReadResourceResult(List.of(new TextResourceContents("test://watched-resource",
-								"text/plain", "This is a watched resource content.")));
-					}));
+				new McpServerFeatures.SyncResourceSpecification(
+						Resource.builder("test://watched-resource", "Watched Resource")
+							.description("A resource that can be subscribed to for updates")
+							.mimeType("text/plain")
+							.build(),
+						(exchange, request) -> {
+							logger.info("Resource 'test://watched-resource' requested");
+							return ReadResourceResult.builder(List.of(TextResourceContents
+								.builder("test://watched-resource", "This is a watched resource content.")
+								.mimeType("text/plain")
+								.build())).build();
+						}));
 	}
 
 	private static List<McpServerFeatures.SyncResourceTemplateSpecification> createResourceTemplateSpecs() {
 		return List.of(
 				// test://template/{id}/data - Resource template with parameter
 				// substitution
-				new McpServerFeatures.SyncResourceTemplateSpecification(ResourceTemplate.builder()
-					.uriTemplate("test://template/{id}/data")
-					.name("Template Resource")
-					.description("A resource template for testing parameter substitution")
-					.mimeType("application/json")
-					.build(), (exchange, request) -> {
-						logger.info("Resource template 'test://template/{{id}}/data' requested for URI: {}",
-								request.uri());
-						// Extract id from URI
-						String uri = request.uri();
-						String id = uri.replaceAll("test://template/(.+)/data", "$1");
-						String jsonContent = String
-							.format("{\"id\":\"%s\",\"templateTest\":true,\"data\":\"Data for ID: %s\"}", id, id);
-						return new ReadResourceResult(
-								List.of(new TextResourceContents(uri, "application/json", jsonContent)));
-					}));
+				new McpServerFeatures.SyncResourceTemplateSpecification(
+						ResourceTemplate.builder("test://template/{id}/data", "Template Resource")
+							.description("A resource template for testing parameter substitution")
+							.mimeType("application/json")
+							.build(),
+						(exchange, request) -> {
+							logger.info("Resource template 'test://template/{{id}}/data' requested for URI: {}",
+									request.uri());
+							// Extract id from URI
+							String uri = request.uri();
+							String id = uri.replaceAll("test://template/(.+)/data", "$1");
+							String jsonContent = String
+								.format("{\"id\":\"%s\",\"templateTest\":true,\"data\":\"Data for ID: %s\"}", id, id);
+							return ReadResourceResult.builder(List.of(TextResourceContents.builder(uri, jsonContent)
+								.mimeType("application/json")
+								.build())).build();
+						}));
 	}
 
 	private static List<McpServerFeatures.SyncCompletionSpecification> createCompletionSpecs() {

--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/LifecycleInitializer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/LifecycleInitializer.java
@@ -302,8 +302,9 @@ class LifecycleInitializer {
 
 		String latestVersion = this.protocolVersions.get(this.protocolVersions.size() - 1);
 
-		McpSchema.InitializeRequest initializeRequest = new McpSchema.InitializeRequest(latestVersion,
-				this.clientCapabilities, this.clientInfo);
+		McpSchema.InitializeRequest initializeRequest = McpSchema.InitializeRequest
+			.builder(latestVersion, this.clientCapabilities, this.clientInfo)
+			.build();
 
 		Mono<McpSchema.InitializeResult> result = mcpClientSession.sendRequest(McpSchema.METHOD_INITIALIZE,
 				initializeRequest, McpAsyncClient.INITIALIZE_RESULT_TYPE_REF);

--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
@@ -538,7 +538,7 @@ public class McpAsyncClient {
 
 			List<Root> roots = this.roots.values().stream().toList();
 
-			return Mono.just(new McpSchema.ListRootsResult(roots));
+			return Mono.just(McpSchema.ListRootsResult.builder(roots).build());
 		};
 	}
 
@@ -633,10 +633,10 @@ public class McpAsyncClient {
 		return this.listTools(McpSchema.FIRST_PAGE).expand(result -> {
 			String next = result.nextCursor();
 			return (next != null && !next.isEmpty()) ? this.listTools(next) : Mono.empty();
-		}).reduce(new McpSchema.ListToolsResult(new ArrayList<>(), null), (allToolsResult, result) -> {
-			allToolsResult.tools().addAll(result.tools());
-			return allToolsResult;
-		}).map(result -> new McpSchema.ListToolsResult(Collections.unmodifiableList(result.tools()), null));
+		}).reduce(new ArrayList<McpSchema.Tool>(), (accumulated, result) -> {
+			accumulated.addAll(result.tools());
+			return accumulated;
+		}).map(all -> McpSchema.ListToolsResult.builder(Collections.unmodifiableList(all)).build());
 	}
 
 	/**
@@ -719,11 +719,11 @@ public class McpAsyncClient {
 	public Mono<McpSchema.ListResourcesResult> listResources() {
 		return this.listResources(McpSchema.FIRST_PAGE)
 			.expand(result -> (result.nextCursor() != null) ? this.listResources(result.nextCursor()) : Mono.empty())
-			.reduce(new McpSchema.ListResourcesResult(new ArrayList<>(), null), (allResourcesResult, result) -> {
-				allResourcesResult.resources().addAll(result.resources());
-				return allResourcesResult;
+			.reduce(new ArrayList<McpSchema.Resource>(), (accumulated, result) -> {
+				accumulated.addAll(result.resources());
+				return accumulated;
 			})
-			.map(result -> new McpSchema.ListResourcesResult(Collections.unmodifiableList(result.resources()), null));
+			.map(all -> McpSchema.ListResourcesResult.builder(Collections.unmodifiableList(all)).build());
 	}
 
 	/**
@@ -774,7 +774,7 @@ public class McpAsyncClient {
 	 * @see McpSchema.ReadResourceResult
 	 */
 	public Mono<McpSchema.ReadResourceResult> readResource(McpSchema.Resource resource) {
-		return this.readResource(new McpSchema.ReadResourceRequest(resource.uri()));
+		return this.readResource(McpSchema.ReadResourceRequest.builder(resource.uri()).build());
 	}
 
 	/**
@@ -806,13 +806,11 @@ public class McpAsyncClient {
 		return this.listResourceTemplates(McpSchema.FIRST_PAGE)
 			.expand(result -> (result.nextCursor() != null) ? this.listResourceTemplates(result.nextCursor())
 					: Mono.empty())
-			.reduce(new McpSchema.ListResourceTemplatesResult(new ArrayList<>(), null),
-					(allResourceTemplatesResult, result) -> {
-						allResourceTemplatesResult.resourceTemplates().addAll(result.resourceTemplates());
-						return allResourceTemplatesResult;
-					})
-			.map(result -> new McpSchema.ListResourceTemplatesResult(
-					Collections.unmodifiableList(result.resourceTemplates()), null));
+			.reduce(new ArrayList<McpSchema.ResourceTemplate>(), (accumulated, result) -> {
+				accumulated.addAll(result.resourceTemplates());
+				return accumulated;
+			})
+			.map(all -> McpSchema.ListResourceTemplatesResult.builder(Collections.unmodifiableList(all)).build());
 	}
 
 	/**
@@ -898,7 +896,7 @@ public class McpAsyncClient {
 					new TypeRef<>() {
 					});
 
-			return readResource(new McpSchema.ReadResourceRequest(resourcesUpdatedNotification.uri()))
+			return readResource(McpSchema.ReadResourceRequest.builder(resourcesUpdatedNotification.uri()).build())
 				.flatMap(readResourceResult -> Flux.fromIterable(resourcesUpdateConsumers)
 					.flatMap(consumer -> consumer.apply(readResourceResult.contents()))
 					.onErrorResume(error -> {
@@ -927,11 +925,11 @@ public class McpAsyncClient {
 	public Mono<ListPromptsResult> listPrompts() {
 		return this.listPrompts(McpSchema.FIRST_PAGE)
 			.expand(result -> (result.nextCursor() != null) ? this.listPrompts(result.nextCursor()) : Mono.empty())
-			.reduce(new ListPromptsResult(new ArrayList<>(), null), (allPromptsResult, result) -> {
-				allPromptsResult.prompts().addAll(result.prompts());
-				return allPromptsResult;
+			.reduce(new ArrayList<McpSchema.Prompt>(), (accumulated, result) -> {
+				accumulated.addAll(result.prompts());
+				return accumulated;
 			})
-			.map(result -> new McpSchema.ListPromptsResult(Collections.unmodifiableList(result.prompts()), null));
+			.map(all -> McpSchema.ListPromptsResult.builder(Collections.unmodifiableList(all)).build());
 	}
 
 	/**

--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/McpClient.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/McpClient.java
@@ -169,7 +169,7 @@ public interface McpClient {
 
 		private ClientCapabilities capabilities;
 
-		private Implementation clientInfo = new Implementation("Java SDK MCP Client", "0.15.0");
+		private Implementation clientInfo = Implementation.builder("Java SDK MCP Client", "0.15.0").build();
 
 		private final Map<String, Root> roots = new HashMap<>();
 
@@ -525,7 +525,7 @@ public interface McpClient {
 
 		private ClientCapabilities capabilities;
 
-		private Implementation clientInfo = new Implementation("Java SDK MCP Client", "0.15.0");
+		private Implementation clientInfo = Implementation.builder("Java SDK MCP Client", "0.15.0").build();
 
 		private final Map<String, Root> roots = new HashMap<>();
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/McpClientFeatures.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/McpClientFeatures.java
@@ -106,7 +106,8 @@ class McpClientFeatures {
 					: new McpSchema.ClientCapabilities(null,
 							!Utils.isEmpty(roots) ? new McpSchema.ClientCapabilities.RootCapabilities(false) : null,
 							samplingHandler != null ? new McpSchema.ClientCapabilities.Sampling() : null,
-							elicitationHandler != null ? new McpSchema.ClientCapabilities.Elicitation() : null);
+							elicitationHandler != null ? McpSchema.ClientCapabilities.Elicitation.builder().build()
+									: null);
 			this.roots = roots != null ? new ConcurrentHashMap<>(roots) : new ConcurrentHashMap<>();
 
 			this.toolsChangeConsumers = toolsChangeConsumers != null ? toolsChangeConsumers : List.of();
@@ -256,7 +257,8 @@ class McpClientFeatures {
 					: new McpSchema.ClientCapabilities(null,
 							!Utils.isEmpty(roots) ? new McpSchema.ClientCapabilities.RootCapabilities(false) : null,
 							samplingHandler != null ? new McpSchema.ClientCapabilities.Sampling() : null,
-							elicitationHandler != null ? new McpSchema.ClientCapabilities.Elicitation() : null);
+							elicitationHandler != null ? McpSchema.ClientCapabilities.Elicitation.builder().build()
+									: null);
 			this.roots = roots != null ? new HashMap<>(roots) : new HashMap<>();
 
 			this.toolsChangeConsumers = toolsChangeConsumers != null ? toolsChangeConsumers : List.of();

--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/ServerParameters.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/ServerParameters.java
@@ -11,17 +11,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.modelcontextprotocol.util.Assert;
 
 /**
- * Server parameters for stdio client.
+ * Server parameters for stdio client. This is not a wire type; Jackson annotations are
+ * intentionally omitted.
  *
  * @author Christian Tzolov
  * @author Dariusz Jędrzejczyk
  */
-@JsonInclude(JsonInclude.Include.NON_ABSENT)
 public class ServerParameters {
 
 	// Environment variables to inherit by default
@@ -32,13 +30,10 @@ public class ServerParameters {
 						"SYSTEMDRIVE", "SYSTEMROOT", "TEMP", "USERNAME", "USERPROFILE")
 				: Arrays.asList("HOME", "LOGNAME", "PATH", "SHELL", "TERM", "USER");
 
-	@JsonProperty("command")
 	private String command;
 
-	@JsonProperty("args")
 	private List<String> args = new ArrayList<>();
 
-	@JsonProperty("env")
 	private Map<String, String> env;
 
 	private ServerParameters(String command, List<String> args, Map<String, String> env) {

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/DefaultMcpStatelessServerHandler.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/DefaultMcpStatelessServerHandler.java
@@ -37,7 +37,7 @@ class DefaultMcpStatelessServerHandler implements McpStatelessServerHandler {
 				.build());
 		}
 		return requestHandler.handle(transportContext, request.params())
-			.map(result -> new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), result, null))
+			.map(result -> McpSchema.JSONRPCResponse.result(request.id(), result))
 			.onErrorResume(t -> {
 				McpSchema.JSONRPCResponse.JSONRPCError error;
 				if (t instanceof McpError mcpError && mcpError.getJsonRpcError() != null) {
@@ -45,9 +45,9 @@ class DefaultMcpStatelessServerHandler implements McpStatelessServerHandler {
 				}
 				else {
 					error = new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INTERNAL_ERROR,
-							t.getMessage(), null);
+							t.getMessage());
 				}
-				return Mono.just(new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), null, error));
+				return Mono.just(McpSchema.JSONRPCResponse.error(request.id(), error));
 			});
 	}
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -414,7 +414,7 @@ public class McpAsyncServer {
 					String content = "Response missing structured content which is expected when calling tool with non-empty outputSchema";
 					logger.warn(content);
 					return CallToolResult.builder()
-						.content(List.of(new McpSchema.TextContent(content)))
+						.content(List.of(McpSchema.TextContent.builder(content).build()))
 						.isError(true)
 						.build();
 				}
@@ -425,7 +425,7 @@ public class McpAsyncServer {
 				if (!validation.valid()) {
 					logger.warn("Tool call result validation failed: {}", validation.errorMessage());
 					return CallToolResult.builder()
-						.content(List.of(new McpSchema.TextContent(validation.errorMessage())))
+						.content(List.of(McpSchema.TextContent.builder(validation.errorMessage()).build()))
 						.isError(true)
 						.build();
 				}
@@ -438,7 +438,7 @@ public class McpAsyncServer {
 					// https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content
 
 					return CallToolResult.builder()
-						.content(List.of(new McpSchema.TextContent(validation.jsonStructuredOutput())))
+						.content(List.of(McpSchema.TextContent.builder(validation.jsonStructuredOutput()).build()))
 						.isError(result.isError())
 						.structuredContent(result.structuredContent())
 						.build();
@@ -529,7 +529,7 @@ public class McpAsyncServer {
 		return (exchange, params) -> {
 			List<Tool> tools = this.tools.stream().map(McpServerFeatures.AsyncToolSpecification::tool).toList();
 
-			return Mono.just(new McpSchema.ListToolsResult(tools, null));
+			return Mono.just(McpSchema.ListToolsResult.builder(tools).build());
 		};
 	}
 
@@ -781,7 +781,7 @@ public class McpAsyncServer {
 				.stream()
 				.map(McpServerFeatures.AsyncResourceSpecification::resource)
 				.toList();
-			return Mono.just(new McpSchema.ListResourcesResult(resourceList, null));
+			return Mono.just(McpSchema.ListResourcesResult.builder(resourceList).build());
 		};
 	}
 
@@ -791,7 +791,7 @@ public class McpAsyncServer {
 				.stream()
 				.map(McpServerFeatures.AsyncResourceTemplateSpecification::resourceTemplate)
 				.toList();
-			return Mono.just(new McpSchema.ListResourceTemplatesResult(resourceList, null));
+			return Mono.just(McpSchema.ListResourceTemplatesResult.builder(resourceList).build());
 		};
 	}
 
@@ -923,7 +923,7 @@ public class McpAsyncServer {
 				.map(McpServerFeatures.AsyncPromptSpecification::prompt)
 				.toList();
 
-			return Mono.just(new McpSchema.ListPromptsResult(promptList, null));
+			return Mono.just(McpSchema.ListPromptsResult.builder(promptList).build());
 		};
 	}
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
@@ -166,13 +166,13 @@ public class McpAsyncServerExchange {
 		return this.listRoots(McpSchema.FIRST_PAGE)
 			.expand(result -> (result.nextCursor() != null) ?
 					this.listRoots(result.nextCursor()) : Mono.empty())
-			.reduce(new McpSchema.ListRootsResult(new ArrayList<>(), null),
+			.reduce(McpSchema.ListRootsResult.builder(new ArrayList<>()).build(),
 				(allRootsResult, result) -> {
 					allRootsResult.roots().addAll(result.roots());
 					return allRootsResult;
 				})
-			.map(result -> new McpSchema.ListRootsResult(Collections.unmodifiableList(result.roots()),
-					result.nextCursor()));
+			.map(result -> McpSchema.ListRootsResult.builder(Collections.unmodifiableList(result.roots()))
+					.nextCursor(result.nextCursor()).build());
 		// @formatter:on
 	}
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServer.java
@@ -66,9 +66,9 @@ import reactor.core.publisher.Mono;
  * Example of creating a basic synchronous server: <pre>{@code
  * McpServer.sync(transportProvider)
  *     .serverInfo("my-server", "1.0.0")
- *     .toolCall(Tool.builder().name("calculator").title("Performs calculations").inputSchema(schema).build(),
+ *     .toolCall(Tool.builder("calculator", schema).title("Performs calculations").build(),
  *           (exchange, request) -> CallToolResult.builder()
- *                   .content(List.of(new McpSchema.TextContent("Result: " + calculate(request.arguments()))))
+ *                   .content(List.of(McpSchema.TextContent.builder("Result: " + calculate(request.arguments())).build()))
  *                   .isError(false)
  *                   .build())
  *     .build();
@@ -77,10 +77,10 @@ import reactor.core.publisher.Mono;
  * Example of creating a basic asynchronous server: <pre>{@code
  * McpServer.async(transportProvider)
  *     .serverInfo("my-server", "1.0.0")
- *     .toolCall(Tool.builder().name("calculator").title("Performs calculations").inputSchema(schema).build(),
+ *     .toolCall(Tool.builder("calculator", schema).title("Performs calculations").build(),
  *           (exchange, request) -> Mono.fromSupplier(() -> calculate(request.arguments()))
  *               .map(result -> CallToolResult.builder()
- *                   .content(List.of(new McpSchema.TextContent("Result: " + result)))
+ *                   .content(List.of(McpSchema.TextContent.builder("Result: " + result).build()))
  *                   .isError(false)
  *                   .build()))
  *     .build();
@@ -97,7 +97,7 @@ import reactor.core.publisher.Mono;
  * 			.tool(calculatorTool)
  *   	    .callTool((exchange, args) -> Mono.fromSupplier(() -> calculate(args.arguments()))
  *                 .map(result -> CallToolResult.builder()
- *                   .content(List.of(new McpSchema.TextContent("Result: " + result)))
+ *                   .content(List.of(McpSchema.TextContent.builder("Result: " + result).build()))
  *                   .isError(false)
  *                   .build()))
  *.         .build(),
@@ -105,7 +105,7 @@ import reactor.core.publisher.Mono;
  * 	        .tool((weatherTool)
  *          .callTool((exchange, args) -> Mono.fromSupplier(() -> getWeather(args.arguments()))
  *                 .map(result -> CallToolResult.builder()
- *                   .content(List.of(new McpSchema.TextContent("Weather: " + result)))
+ *                   .content(List.of(McpSchema.TextContent.builder("Weather: " + result).build()))
  *                   .isError(false)
  *                   .build()))
  *          .build()
@@ -145,7 +145,8 @@ import reactor.core.publisher.Mono;
  */
 public interface McpServer {
 
-	McpSchema.Implementation DEFAULT_SERVER_INFO = new McpSchema.Implementation("Java SDK MCP Server", "0.15.0");
+	McpSchema.Implementation DEFAULT_SERVER_INFO = McpSchema.Implementation.builder("Java SDK MCP Server", "0.15.0")
+		.build();
 
 	/**
 	 * Starts building a synchronous MCP server that provides blocking operations.
@@ -395,7 +396,7 @@ public interface McpServer {
 		public AsyncSpecification<S> serverInfo(String name, String version) {
 			Assert.hasText(name, "Name must not be null or empty");
 			Assert.hasText(version, "Version must not be null or empty");
-			this.serverInfo = new McpSchema.Implementation(name, version);
+			this.serverInfo = McpSchema.Implementation.builder(name, version).build();
 			return this;
 		}
 
@@ -992,7 +993,7 @@ public interface McpServer {
 		public SyncSpecification<S> serverInfo(String name, String version) {
 			Assert.hasText(name, "Name must not be null or empty");
 			Assert.hasText(version, "Version must not be null or empty");
-			this.serverInfo = new McpSchema.Implementation(name, version);
+			this.serverInfo = McpSchema.Implementation.builder(name, version).build();
 			return this;
 		}
 
@@ -1531,7 +1532,7 @@ public interface McpServer {
 		public StatelessAsyncSpecification serverInfo(String name, String version) {
 			Assert.hasText(name, "Name must not be null or empty");
 			Assert.hasText(version, "Version must not be null or empty");
-			this.serverInfo = new McpSchema.Implementation(name, version);
+			this.serverInfo = McpSchema.Implementation.builder(name, version).build();
 			return this;
 		}
 
@@ -2028,7 +2029,7 @@ public interface McpServer {
 		public StatelessSyncSpecification serverInfo(String name, String version) {
 			Assert.hasText(name, "Name must not be null or empty");
 			Assert.hasText(version, "Version must not be null or empty");
-			this.serverInfo = new McpSchema.Implementation(name, version);
+			this.serverInfo = McpSchema.Implementation.builder(name, version).build();
 			return this;
 		}
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServerFeatures.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServerFeatures.java
@@ -77,10 +77,12 @@ public class McpServerFeatures {
 																					// logging
 																					// by
 																					// default
-							!Utils.isEmpty(prompts) ? new McpSchema.ServerCapabilities.PromptCapabilities(false) : null,
+							!Utils.isEmpty(prompts) ? McpSchema.ServerCapabilities.PromptCapabilities.builder().build()
+									: null,
 							!Utils.isEmpty(resources)
-									? new McpSchema.ServerCapabilities.ResourceCapabilities(false, false) : null,
-							!Utils.isEmpty(tools) ? new McpSchema.ServerCapabilities.ToolCapabilities(false) : null);
+									? McpSchema.ServerCapabilities.ResourceCapabilities.builder().build() : null,
+							!Utils.isEmpty(tools) ? McpSchema.ServerCapabilities.ToolCapabilities.builder().build()
+									: null);
 
 			this.tools = (tools != null) ? tools : List.of();
 			this.resources = (resources != null) ? resources : Map.of();
@@ -192,10 +194,12 @@ public class McpServerFeatures {
 																					// logging
 																					// by
 																					// default
-							!Utils.isEmpty(prompts) ? new McpSchema.ServerCapabilities.PromptCapabilities(false) : null,
+							!Utils.isEmpty(prompts) ? McpSchema.ServerCapabilities.PromptCapabilities.builder().build()
+									: null,
 							!Utils.isEmpty(resources)
-									? new McpSchema.ServerCapabilities.ResourceCapabilities(false, false) : null,
-							!Utils.isEmpty(tools) ? new McpSchema.ServerCapabilities.ToolCapabilities(false) : null);
+									? McpSchema.ServerCapabilities.ResourceCapabilities.builder().build() : null,
+							!Utils.isEmpty(tools) ? McpSchema.ServerCapabilities.ToolCapabilities.builder().build()
+									: null);
 
 			this.tools = (tools != null) ? tools : new ArrayList<>();
 			this.resources = (resources != null) ? resources : new HashMap<>();
@@ -487,20 +491,19 @@ public class McpServerFeatures {
 	 *
 	 * <pre>{@code
 	 * McpServerFeatures.SyncToolSpecification.builder()
-	 * 		.tool(Tool.builder()
-	 * 				.name("calculator")
+	 * 		.tool(Tool.builder("calculator",
+	 * 					Map.of("type", "object", "properties",
+	 * 							Map.of("expression", Map.of("type", "string")),
+	 * 							"required", List.of("expression")))
 	 * 				.title("Performs mathematical calculations")
-	 * 				.inputSchema(new JsonSchemaObject()
-	 * 						.required("expression")
-	 * 						.property("expression", JsonSchemaType.STRING))
-	 * 				.build()
+	 * 				.build())
 	 * 		.toolHandler((exchange, req) -> {
 	 * 			String expr = (String) req.arguments().get("expression");
 	 * 			return CallToolResult.builder()
-	 *                   .content(List.of(new McpSchema.TextContent("Result: " + evaluate(expr))))
+	 *                   .content(List.of(McpSchema.TextContent.builder("Result: " + evaluate(expr)).build()))
 	 *                   .isError(false)
 	 *                   .build();
-	 * 		}))
+	 * 		})
 	 *      .build();
 	 * }</pre>
 	 *

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
@@ -284,7 +284,7 @@ public class McpStatelessAsyncServer {
 					String content = "Response missing structured content which is expected when calling tool with non-empty outputSchema";
 					logger.warn(content);
 					return CallToolResult.builder()
-						.content(List.of(new McpSchema.TextContent(content)))
+						.content(List.of(McpSchema.TextContent.builder(content).build()))
 						.isError(true)
 						.build();
 				}
@@ -295,7 +295,7 @@ public class McpStatelessAsyncServer {
 				if (!validation.valid()) {
 					logger.warn("Tool call result validation failed: {}", validation.errorMessage());
 					return CallToolResult.builder()
-						.content(List.of(new McpSchema.TextContent(validation.errorMessage())))
+						.content(List.of(McpSchema.TextContent.builder(validation.errorMessage()).build()))
 						.isError(true)
 						.build();
 				}
@@ -308,7 +308,7 @@ public class McpStatelessAsyncServer {
 					// https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content
 
 					return CallToolResult.builder()
-						.content(List.of(new McpSchema.TextContent(validation.jsonStructuredOutput())))
+						.content(List.of(McpSchema.TextContent.builder(validation.jsonStructuredOutput()).build()))
 						.isError(result.isError())
 						.structuredContent(result.structuredContent())
 						.build();
@@ -393,7 +393,7 @@ public class McpStatelessAsyncServer {
 			List<Tool> tools = this.tools.stream()
 				.map(McpStatelessServerFeatures.AsyncToolSpecification::tool)
 				.toList();
-			return Mono.just(new McpSchema.ListToolsResult(tools, null));
+			return Mono.just(McpSchema.ListToolsResult.builder(tools).build());
 		};
 	}
 
@@ -557,7 +557,7 @@ public class McpStatelessAsyncServer {
 				.stream()
 				.map(McpStatelessServerFeatures.AsyncResourceSpecification::resource)
 				.toList();
-			return Mono.just(new McpSchema.ListResourcesResult(resourceList, null));
+			return Mono.just(McpSchema.ListResourcesResult.builder(resourceList).build());
 		};
 	}
 
@@ -567,7 +567,7 @@ public class McpStatelessAsyncServer {
 				.stream()
 				.map(AsyncResourceTemplateSpecification::resourceTemplate)
 				.toList();
-			return Mono.just(new McpSchema.ListResourceTemplatesResult(resourceList, null));
+			return Mono.just(McpSchema.ListResourceTemplatesResult.builder(resourceList).build());
 		};
 	}
 
@@ -687,7 +687,7 @@ public class McpStatelessAsyncServer {
 				.map(McpStatelessServerFeatures.AsyncPromptSpecification::prompt)
 				.toList();
 
-			return Mono.just(new McpSchema.ListPromptsResult(promptList, null));
+			return Mono.just(McpSchema.ListPromptsResult.builder(promptList).build());
 		};
 	}
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessServerFeatures.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessServerFeatures.java
@@ -71,10 +71,12 @@ public class McpStatelessServerFeatures {
 					: new McpSchema.ServerCapabilities(null, // completions
 							null, // experimental
 							null, // currently statless server doesn't support set logging
-							!Utils.isEmpty(prompts) ? new McpSchema.ServerCapabilities.PromptCapabilities(false) : null,
+							!Utils.isEmpty(prompts) ? McpSchema.ServerCapabilities.PromptCapabilities.builder().build()
+									: null,
 							!Utils.isEmpty(resources)
-									? new McpSchema.ServerCapabilities.ResourceCapabilities(false, false) : null,
-							!Utils.isEmpty(tools) ? new McpSchema.ServerCapabilities.ToolCapabilities(false) : null);
+									? McpSchema.ServerCapabilities.ResourceCapabilities.builder().build() : null,
+							!Utils.isEmpty(tools) ? McpSchema.ServerCapabilities.ToolCapabilities.builder().build()
+									: null);
 
 			this.tools = (tools != null) ? tools : List.of();
 			this.resources = (resources != null) ? resources : Map.of();
@@ -172,10 +174,12 @@ public class McpStatelessServerFeatures {
 																					// logging
 																					// by
 																					// default
-							!Utils.isEmpty(prompts) ? new McpSchema.ServerCapabilities.PromptCapabilities(false) : null,
+							!Utils.isEmpty(prompts) ? McpSchema.ServerCapabilities.PromptCapabilities.builder().build()
+									: null,
 							!Utils.isEmpty(resources)
-									? new McpSchema.ServerCapabilities.ResourceCapabilities(false, false) : null,
-							!Utils.isEmpty(tools) ? new McpSchema.ServerCapabilities.ToolCapabilities(false) : null);
+									? McpSchema.ServerCapabilities.ResourceCapabilities.builder().build() : null,
+							!Utils.isEmpty(tools) ? McpSchema.ServerCapabilities.ToolCapabilities.builder().build()
+									: null);
 
 			this.tools = (tools != null) ? tools : new ArrayList<>();
 			this.resources = (resources != null) ? resources : new HashMap<>();

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
@@ -462,8 +462,8 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 					response.setHeader(HttpHeaders.MCP_SESSION_ID, init.session().getId());
 					response.setStatus(HttpServletResponse.SC_OK);
 
-					String jsonResponse = jsonMapper.writeValueAsString(new McpSchema.JSONRPCResponse(
-							McpSchema.JSONRPC_VERSION, jsonrpcRequest.id(), initResult, null));
+					String jsonResponse = jsonMapper
+						.writeValueAsString(McpSchema.JSONRPCResponse.result(jsonrpcRequest.id(), initResult));
 
 					PrintWriter writer = response.getWriter();
 					writer.write(jsonResponse);

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpClientSession.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpClientSession.java
@@ -154,12 +154,10 @@ public class McpClientSession implements McpSession {
 
 				McpSchema.JSONRPCResponse.JSONRPCError jsonRpcError = (error instanceof McpError mcpError
 						&& mcpError.getJsonRpcError() != null) ? mcpError.getJsonRpcError()
-								// TODO: add error message through the data field
 								: new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INTERNAL_ERROR,
 										error.getMessage(), McpError.aggregateExceptionMessages(error));
 
-				var errorResponse = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), null,
-						jsonRpcError);
+				var errorResponse = McpSchema.JSONRPCResponse.error(request.id(), jsonRpcError);
 				return Mono.just(errorResponse);
 			}).flatMap(this.transport::sendMessage).onErrorComplete(t -> {
 				logger.warn("Issue sending response to the client, ", t);
@@ -188,13 +186,13 @@ public class McpClientSession implements McpSession {
 			var handler = this.requestHandlers.get(request.method());
 			if (handler == null) {
 				MethodNotFoundError error = getMethodNotFoundError(request.method());
-				return Mono.just(new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), null,
-						new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.METHOD_NOT_FOUND,
-								error.message(), error.data())));
+				return Mono
+					.just(McpSchema.JSONRPCResponse.error(request.id(), new McpSchema.JSONRPCResponse.JSONRPCError(
+							McpSchema.ErrorCodes.METHOD_NOT_FOUND, error.message(), error.data())));
 			}
 
 			return handler.handle(request.params())
-				.map(result -> new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), result, null));
+				.map(result -> McpSchema.JSONRPCResponse.result(request.id(), result));
 		});
 	}
 
@@ -251,8 +249,7 @@ public class McpClientSession implements McpSession {
 		return Mono.deferContextual(ctx -> Mono.<McpSchema.JSONRPCResponse>create(pendingResponseSink -> {
 			logger.debug("Sending message for method {}", method);
 			this.pendingResponses.put(requestId, pendingResponseSink);
-			McpSchema.JSONRPCRequest jsonrpcRequest = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, method,
-					requestId, requestParams);
+			McpSchema.JSONRPCRequest jsonrpcRequest = new McpSchema.JSONRPCRequest(method, requestId, requestParams);
 			this.transport.sendMessage(jsonrpcRequest).contextWrite(ctx).subscribe(v -> {
 			}, error -> {
 				this.pendingResponses.remove(requestId);
@@ -282,8 +279,7 @@ public class McpClientSession implements McpSession {
 	 */
 	@Override
 	public Mono<Void> sendNotification(String method, Object params) {
-		McpSchema.JSONRPCNotification jsonrpcNotification = new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION,
-				method, params);
+		McpSchema.JSONRPCNotification jsonrpcNotification = new McpSchema.JSONRPCNotification(method, params);
 		return this.transport.sendMessage(jsonrpcNotification);
 	}
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -244,9 +244,19 @@ public final class McpSchema {
 		 * MUST NOT be null
 		 */
 		public JSONRPCRequest {
+			Assert.hasText(jsonrpc, "jsonrpc must not be empty");
 			Assert.notNull(id, "MCP requests MUST include an ID - null IDs are not allowed");
 			Assert.isTrue(id instanceof String || id instanceof Integer || id instanceof Long,
 					"MCP requests MUST have an ID that is either a string or integer");
+			Assert.notNull(method, "MCP request method must not be null");
+		}
+
+		public JSONRPCRequest(String method, Object id, Object params) {
+			this(JSONRPC_VERSION, method, id, params);
+		}
+
+		public JSONRPCRequest(String method, Object id) {
+			this(JSONRPC_VERSION, method, id, null);
 		}
 	}
 
@@ -263,6 +273,19 @@ public final class McpSchema {
 		@JsonProperty("jsonrpc") String jsonrpc,
 		@JsonProperty("method") String method,
 		@JsonProperty("params") Object params) implements JSONRPCMessage { // @formatter:on
+
+		public JSONRPCNotification {
+			Assert.hasText(jsonrpc, "jsonrpc must not be empty");
+			Assert.notNull(method, "MCP notification method must not be null");
+		}
+
+		public JSONRPCNotification(String method, Object params) {
+			this(JSONRPC_VERSION, method, params);
+		}
+
+		public JSONRPCNotification(String method) {
+			this(JSONRPC_VERSION, method, null);
+		}
 	}
 
 	/**
@@ -281,6 +304,22 @@ public final class McpSchema {
 		@JsonProperty("result") Object result,
 		@JsonProperty("error") JSONRPCError error) implements JSONRPCMessage { // @formatter:on
 
+		public JSONRPCResponse {
+			Assert.hasText(jsonrpc, "jsonrpc must not be empty");
+			Assert.notNull(id, "MCP responses MUST include an ID - null IDs are not allowed");
+			Assert.isTrue(id instanceof String || id instanceof Integer || id instanceof Long,
+					"MCP responses MUST have an ID that is either a string or integer");
+			Assert.isTrue((result != null) ^ (error != null), "MCP responses MUST either have a result or error");
+		}
+
+		public static JSONRPCResponse result(Object id, Object result) {
+			return new JSONRPCResponse(JSONRPC_VERSION, id, result, null);
+		}
+
+		public static JSONRPCResponse error(Object id, JSONRPCError error) {
+			return new JSONRPCResponse(JSONRPC_VERSION, id, null, error);
+		}
+
 		/**
 		 * A response to a request that indicates an error occurred.
 		 *
@@ -296,6 +335,16 @@ public final class McpSchema {
 			@JsonProperty("code") Integer code,
 			@JsonProperty("message") String message,
 			@JsonProperty("data") Object data) { // @formatter:on
+
+			public JSONRPCError {
+				Assert.notNull(code, "code must not be null");
+				Assert.notNull(message, "message must not be null");
+			}
+
+			public JSONRPCError(Integer code, String message) {
+				this(code, message, null);
+			}
+
 		}
 	}
 
@@ -320,8 +369,79 @@ public final class McpSchema {
 		@JsonProperty("clientInfo") Implementation clientInfo,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Request { // @formatter:on
 
+		public InitializeRequest {
+			Assert.notNull(protocolVersion, "protocolVersion must not be null");
+			Assert.notNull(capabilities, "capabilities must not be null");
+			Assert.notNull(clientInfo, "clientInfo must not be null");
+		}
+
+		@JsonCreator
+		static InitializeRequest fromJson(@JsonProperty("protocolVersion") String protocolVersion,
+				@JsonProperty("capabilities") ClientCapabilities capabilities,
+				@JsonProperty("clientInfo") Implementation clientInfo,
+				@JsonProperty("_meta") Map<String, Object> meta) {
+			if (protocolVersion == null || capabilities == null || clientInfo == null) {
+				List<String> missing = new ArrayList<>();
+				if (protocolVersion == null) {
+					missing.add("protocolVersion -> ''");
+					protocolVersion = "";
+				}
+				if (capabilities == null) {
+					missing.add("capabilities -> {}");
+					capabilities = new ClientCapabilities(null, null, null, null);
+				}
+				if (clientInfo == null) {
+					missing.add("clientInfo -> {name='', version=''}");
+					clientInfo = new Implementation("", "");
+				}
+				logger.warn("InitializeRequest: missing required fields during deserialization: {}",
+						String.join(", ", missing));
+			}
+			return new InitializeRequest(protocolVersion, capabilities, clientInfo, meta);
+		}
+
+		/**
+		 * @deprecated Use {@link #builder(String, ClientCapabilities, Implementation)}
+		 * instead.
+		 */
+		@Deprecated
 		public InitializeRequest(String protocolVersion, ClientCapabilities capabilities, Implementation clientInfo) {
 			this(protocolVersion, capabilities, clientInfo, null);
+		}
+
+		public static Builder builder(String protocolVersion, ClientCapabilities capabilities,
+				Implementation clientInfo) {
+			return new Builder(protocolVersion, capabilities, clientInfo);
+		}
+
+		public static class Builder {
+
+			private final String protocolVersion;
+
+			private final ClientCapabilities capabilities;
+
+			private final Implementation clientInfo;
+
+			private Map<String, Object> meta;
+
+			private Builder(String protocolVersion, ClientCapabilities capabilities, Implementation clientInfo) {
+				Assert.hasText(protocolVersion, "protocolVersion must not be empty");
+				Assert.notNull(capabilities, "capabilities must not be null");
+				Assert.notNull(clientInfo, "clientInfo must not be null");
+				this.protocolVersion = protocolVersion;
+				this.capabilities = capabilities;
+				this.clientInfo = clientInfo;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public InitializeRequest build() {
+				return new InitializeRequest(protocolVersion, capabilities, clientInfo, meta);
+			}
+
 		}
 	}
 
@@ -349,9 +469,87 @@ public final class McpSchema {
 		@JsonProperty("instructions") String instructions,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Result { // @formatter:on
 
+		public InitializeResult {
+			Assert.notNull(protocolVersion, "protocolVersion must not be null");
+			Assert.notNull(capabilities, "capabilities must not be null");
+			Assert.notNull(serverInfo, "serverInfo must not be null");
+		}
+
+		@JsonCreator
+		static InitializeResult fromJson(@JsonProperty("protocolVersion") String protocolVersion,
+				@JsonProperty("capabilities") ServerCapabilities capabilities,
+				@JsonProperty("serverInfo") Implementation serverInfo,
+				@JsonProperty("instructions") String instructions, @JsonProperty("_meta") Map<String, Object> meta) {
+			if (protocolVersion == null || capabilities == null || serverInfo == null) {
+				List<String> missing = new ArrayList<>();
+				if (protocolVersion == null) {
+					missing.add("protocolVersion -> ''");
+					protocolVersion = "";
+				}
+				if (capabilities == null) {
+					missing.add("capabilities -> {}");
+					capabilities = new ServerCapabilities(null, null, null, null, null, null);
+				}
+				if (serverInfo == null) {
+					missing.add("serverInfo -> {name='', version=''}");
+					serverInfo = new Implementation("", "");
+				}
+				logger.warn("InitializeResult: missing required fields during deserialization: {}",
+						String.join(", ", missing));
+			}
+			return new InitializeResult(protocolVersion, capabilities, serverInfo, instructions, meta);
+		}
+
+		/**
+		 * @deprecated Use {@link #builder(String, ServerCapabilities, Implementation)}
+		 * instead.
+		 */
+		@Deprecated
 		public InitializeResult(String protocolVersion, ServerCapabilities capabilities, Implementation serverInfo,
 				String instructions) {
 			this(protocolVersion, capabilities, serverInfo, instructions, null);
+		}
+
+		public static Builder builder(String protocolVersion, ServerCapabilities capabilities,
+				Implementation serverInfo) {
+			return new Builder(protocolVersion, capabilities, serverInfo);
+		}
+
+		public static class Builder {
+
+			private final String protocolVersion;
+
+			private final ServerCapabilities capabilities;
+
+			private final Implementation serverInfo;
+
+			private String instructions;
+
+			private Map<String, Object> meta;
+
+			private Builder(String protocolVersion, ServerCapabilities capabilities, Implementation serverInfo) {
+				Assert.hasText(protocolVersion, "protocolVersion must not be empty");
+				Assert.notNull(capabilities, "capabilities must not be null");
+				Assert.notNull(serverInfo, "serverInfo must not be null");
+				this.protocolVersion = protocolVersion;
+				this.capabilities = capabilities;
+				this.serverInfo = serverInfo;
+			}
+
+			public Builder instructions(String instructions) {
+				this.instructions = instructions;
+				return this;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public InitializeResult build() {
+				return new InitializeResult(protocolVersion, capabilities, serverInfo, instructions, meta);
+			}
+
 		}
 	}
 
@@ -383,6 +581,25 @@ public final class McpSchema {
 		@JsonInclude(JsonInclude.Include.NON_ABSENT)
 		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record RootCapabilities(@JsonProperty("listChanged") Boolean listChanged) {
+
+			public static Builder builder() {
+				return new Builder();
+			}
+
+			public static class Builder {
+
+				private Boolean listChanged;
+
+				public Builder listChanged(Boolean listChanged) {
+					this.listChanged = listChanged;
+					return this;
+				}
+
+				public RootCapabilities build() {
+					return new RootCapabilities(listChanged);
+				}
+
+			}
 		}
 
 		/**
@@ -444,9 +661,37 @@ public final class McpSchema {
 			/**
 			 * Creates an Elicitation with default settings (backward compatible, produces
 			 * empty JSON object).
+			 * @deprecated Use {@link #builder()} instead.
 			 */
+			@Deprecated
 			public Elicitation() {
 				this(null, null);
+			}
+
+			public static Builder builder() {
+				return new Builder();
+			}
+
+			public static class Builder {
+
+				private Form form;
+
+				private Url url;
+
+				public Builder form(Form form) {
+					this.form = form;
+					return this;
+				}
+
+				public Builder url(Url url) {
+					this.url = url;
+					return this;
+				}
+
+				public Elicitation build() {
+					return new Elicitation(form, url);
+				}
+
 			}
 		}
 
@@ -485,7 +730,7 @@ public final class McpSchema {
 			 * @return this builder
 			 */
 			public Builder elicitation() {
-				this.elicitation = new Elicitation();
+				this.elicitation = Elicitation.builder().build();
 				return this;
 			}
 
@@ -498,6 +743,11 @@ public final class McpSchema {
 			public Builder elicitation(boolean form, boolean url) {
 				this.elicitation = new Elicitation(form ? new Elicitation.Form() : null,
 						url ? new Elicitation.Url() : null);
+				return this;
+			}
+
+			public Builder elicitation(Elicitation elicitation) {
+				this.elicitation = elicitation;
 				return this;
 			}
 
@@ -557,6 +807,25 @@ public final class McpSchema {
 		@JsonInclude(JsonInclude.Include.NON_ABSENT)
 		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record PromptCapabilities(@JsonProperty("listChanged") Boolean listChanged) {
+
+			public static Builder builder() {
+				return new Builder();
+			}
+
+			public static class Builder {
+
+				private Boolean listChanged;
+
+				public Builder listChanged(Boolean listChanged) {
+					this.listChanged = listChanged;
+					return this;
+				}
+
+				public PromptCapabilities build() {
+					return new PromptCapabilities(listChanged);
+				}
+
+			}
 		}
 
 		/**
@@ -570,6 +839,32 @@ public final class McpSchema {
 		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record ResourceCapabilities(@JsonProperty("subscribe") Boolean subscribe,
 				@JsonProperty("listChanged") Boolean listChanged) {
+
+			public static Builder builder() {
+				return new Builder();
+			}
+
+			public static class Builder {
+
+				private Boolean subscribe;
+
+				private Boolean listChanged;
+
+				public Builder subscribe(Boolean subscribe) {
+					this.subscribe = subscribe;
+					return this;
+				}
+
+				public Builder listChanged(Boolean listChanged) {
+					this.listChanged = listChanged;
+					return this;
+				}
+
+				public ResourceCapabilities build() {
+					return new ResourceCapabilities(subscribe, listChanged);
+				}
+
+			}
 		}
 
 		/**
@@ -581,6 +876,25 @@ public final class McpSchema {
 		@JsonInclude(JsonInclude.Include.NON_ABSENT)
 		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record ToolCapabilities(@JsonProperty("listChanged") Boolean listChanged) {
+
+			public static Builder builder() {
+				return new Builder();
+			}
+
+			public static class Builder {
+
+				private Boolean listChanged;
+
+				public Builder listChanged(Boolean listChanged) {
+					this.listChanged = listChanged;
+					return this;
+				}
+
+				public ToolCapabilities build() {
+					return new ToolCapabilities(listChanged);
+				}
+
+			}
 		}
 
 		/**
@@ -667,10 +981,68 @@ public final class McpSchema {
 	public record Implementation( // @formatter:off
 		@JsonProperty("name") String name,
 		@JsonProperty("title") String title,
-		@JsonProperty("version") String version) implements Identifier { // @formatter:on			
+		@JsonProperty("version") String version) implements Identifier { // @formatter:on
 
+		public Implementation {
+			Assert.notNull(name, "name must not be null");
+			Assert.notNull(version, "version must not be null");
+		}
+
+		@JsonCreator
+		static Implementation fromJson(@JsonProperty("name") String name, @JsonProperty("title") String title,
+				@JsonProperty("version") String version) {
+			if (name == null || version == null) {
+				List<String> missing = new ArrayList<>();
+				if (name == null) {
+					missing.add("name -> ''");
+					name = "";
+				}
+				if (version == null) {
+					missing.add("version -> ''");
+					version = "";
+				}
+				logger.warn("Implementation: missing required fields during deserialization: {}",
+						String.join(", ", missing));
+			}
+			return new Implementation(name, title, version);
+		}
+
+		/**
+		 * @deprecated Use {@link #builder(String, String)}
+		 */
+		@Deprecated
 		public Implementation(String name, String version) {
 			this(name, null, version);
+		}
+
+		public static Builder builder(String name, String version) {
+			return new Builder(name, version);
+		}
+
+		public static class Builder {
+
+			private final String name;
+
+			private String title;
+
+			private final String version;
+
+			private Builder(String name, String version) {
+				Assert.hasText(name, "name must not be empty");
+				Assert.hasText(version, "version must not be empty");
+				this.name = name;
+				this.version = version;
+			}
+
+			public Builder title(String title) {
+				this.title = title;
+				return this;
+			}
+
+			public Implementation build() {
+				return new Implementation(name, title, version);
+			}
+
 		}
 	}
 
@@ -715,8 +1087,45 @@ public final class McpSchema {
 		@JsonProperty("lastModified") String lastModified
 		) { // @formatter:on
 
+		/**
+		 * @deprecated Use {@link #builder()} instead.
+		 */
+		@Deprecated
 		public Annotations(List<Role> audience, Double priority) {
 			this(audience, priority, null);
+		}
+
+		public static Builder builder() {
+			return new Builder();
+		}
+
+		public static class Builder {
+
+			private List<Role> audience;
+
+			private Double priority;
+
+			private String lastModified;
+
+			public Builder audience(List<Role> audience) {
+				this.audience = audience;
+				return this;
+			}
+
+			public Builder priority(Double priority) {
+				this.priority = priority;
+				return this;
+			}
+
+			public Builder lastModified(String lastModified) {
+				this.lastModified = lastModified;
+				return this;
+			}
+
+			public Annotations build() {
+				return new Annotations(audience, priority, lastModified);
+			}
+
 		}
 	}
 
@@ -794,15 +1203,20 @@ public final class McpSchema {
 		@JsonProperty("annotations") Annotations annotations,
 		@JsonProperty("_meta") Map<String, Object> meta) implements ResourceContent { // @formatter:on
 
-		public static Builder builder() {
-			return new Builder();
+		public Resource {
+			Assert.hasText(uri, "uri must not be empty");
+			Assert.hasText(name, "name must not be empty");
+		}
+
+		public static Builder builder(String uri, String name) {
+			return new Builder(uri, name);
 		}
 
 		public static class Builder {
 
-			private String uri;
+			private final String uri;
 
-			private String name;
+			private final String name;
 
 			private String title;
 
@@ -816,14 +1230,11 @@ public final class McpSchema {
 
 			private Map<String, Object> meta;
 
-			public Builder uri(String uri) {
+			private Builder(String uri, String name) {
+				Assert.hasText(uri, "uri must not be empty");
+				Assert.hasText(name, "name must not be empty");
 				this.uri = uri;
-				return this;
-			}
-
-			public Builder name(String name) {
 				this.name = name;
-				return this;
 			}
 
 			public Builder title(String title) {
@@ -857,9 +1268,6 @@ public final class McpSchema {
 			}
 
 			public Resource build() {
-				Assert.hasText(uri, "uri must not be empty");
-				Assert.hasText(name, "name must not be empty");
-
 				return new Resource(uri, name, title, description, mimeType, size, annotations, meta);
 			}
 
@@ -895,25 +1303,38 @@ public final class McpSchema {
 		@JsonProperty("annotations") Annotations annotations,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Annotated, Identifier, Meta { // @formatter:on
 
+		public ResourceTemplate {
+			Assert.hasText(uriTemplate, "uriTemplate must not be empty");
+			Assert.hasText(name, "name must not be empty");
+		}
+
+		/**
+		 * @deprecated Use {@link #builder(String, String)}.
+		 */
+		@Deprecated
 		public ResourceTemplate(String uriTemplate, String name, String title, String description, String mimeType,
 				Annotations annotations) {
 			this(uriTemplate, name, title, description, mimeType, annotations, null);
 		}
 
+		/**
+		 * @deprecated Use {@link #builder(String, String)}.
+		 */
+		@Deprecated
 		public ResourceTemplate(String uriTemplate, String name, String description, String mimeType,
 				Annotations annotations) {
 			this(uriTemplate, name, null, description, mimeType, annotations);
 		}
 
-		public static Builder builder() {
-			return new Builder();
+		public static Builder builder(String uriTemplate, String name) {
+			return new Builder(uriTemplate, name);
 		}
 
 		public static class Builder {
 
-			private String uriTemplate;
+			private final String uriTemplate;
 
-			private String name;
+			private final String name;
 
 			private String title;
 
@@ -925,14 +1346,11 @@ public final class McpSchema {
 
 			private Map<String, Object> meta;
 
-			public Builder uriTemplate(String uri) {
-				this.uriTemplate = uri;
-				return this;
-			}
-
-			public Builder name(String name) {
+			private Builder(String uriTemplate, String name) {
+				Assert.hasText(uriTemplate, "uriTemplate must not be empty");
+				Assert.hasText(name, "name must not be empty");
+				this.uriTemplate = uriTemplate;
 				this.name = name;
-				return this;
 			}
 
 			public Builder title(String title) {
@@ -961,9 +1379,6 @@ public final class McpSchema {
 			}
 
 			public ResourceTemplate build() {
-				Assert.hasText(uriTemplate, "uri must not be empty");
-				Assert.hasText(name, "name must not be empty");
-
 				return new ResourceTemplate(uriTemplate, name, title, description, mimeType, annotations, meta);
 			}
 
@@ -985,8 +1400,57 @@ public final class McpSchema {
 		@JsonProperty("nextCursor") String nextCursor,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Result { // @formatter:on
 
+		public ListResourcesResult {
+			Assert.notNull(resources, "resources must not be null");
+		}
+
+		@JsonCreator
+		static ListResourcesResult fromJson(@JsonProperty("resources") List<Resource> resources,
+				@JsonProperty("nextCursor") String nextCursor, @JsonProperty("_meta") Map<String, Object> meta) {
+			if (resources == null) {
+				logger.warn(
+						"ListResourcesResult: missing required field 'resources' during deserialization, using default []");
+				resources = List.of();
+			}
+			return new ListResourcesResult(resources, nextCursor, meta);
+		}
+
+		@Deprecated
 		public ListResourcesResult(List<Resource> resources, String nextCursor) {
 			this(resources, nextCursor, null);
+		}
+
+		public static Builder builder(List<Resource> resources) {
+			return new Builder(resources);
+		}
+
+		public static class Builder {
+
+			private final List<Resource> resources;
+
+			private String nextCursor;
+
+			private Map<String, Object> meta;
+
+			private Builder(List<Resource> resources) {
+				Assert.notNull(resources, "resources must not be null");
+				this.resources = resources;
+			}
+
+			public Builder nextCursor(String nextCursor) {
+				this.nextCursor = nextCursor;
+				return this;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public ListResourcesResult build() {
+				return new ListResourcesResult(resources, nextCursor, meta);
+			}
+
 		}
 	}
 
@@ -1005,8 +1469,58 @@ public final class McpSchema {
 		@JsonProperty("nextCursor") String nextCursor,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Result { // @formatter:on
 
+		public ListResourceTemplatesResult {
+			Assert.notNull(resourceTemplates, "resourceTemplates must not be null");
+		}
+
+		@JsonCreator
+		static ListResourceTemplatesResult fromJson(
+				@JsonProperty("resourceTemplates") List<ResourceTemplate> resourceTemplates,
+				@JsonProperty("nextCursor") String nextCursor, @JsonProperty("_meta") Map<String, Object> meta) {
+			if (resourceTemplates == null) {
+				logger.warn(
+						"ListResourceTemplatesResult: missing required field 'resourceTemplates' during deserialization, using default []");
+				resourceTemplates = List.of();
+			}
+			return new ListResourceTemplatesResult(resourceTemplates, nextCursor, meta);
+		}
+
+		@Deprecated
 		public ListResourceTemplatesResult(List<ResourceTemplate> resourceTemplates, String nextCursor) {
 			this(resourceTemplates, nextCursor, null);
+		}
+
+		public static Builder builder(List<ResourceTemplate> resourceTemplates) {
+			return new Builder(resourceTemplates);
+		}
+
+		public static class Builder {
+
+			private final List<ResourceTemplate> resourceTemplates;
+
+			private String nextCursor;
+
+			private Map<String, Object> meta;
+
+			private Builder(List<ResourceTemplate> resourceTemplates) {
+				Assert.notNull(resourceTemplates, "resourceTemplates must not be null");
+				this.resourceTemplates = resourceTemplates;
+			}
+
+			public Builder nextCursor(String nextCursor) {
+				this.nextCursor = nextCursor;
+				return this;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public ListResourceTemplatesResult build() {
+				return new ListResourceTemplatesResult(resourceTemplates, nextCursor, meta);
+			}
+
 		}
 	}
 
@@ -1023,8 +1537,50 @@ public final class McpSchema {
 		@JsonProperty("uri") String uri,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Request { // @formatter:on
 
+		public ReadResourceRequest {
+			Assert.notNull(uri, "uri must not be null");
+		}
+
+		@JsonCreator
+		static ReadResourceRequest fromJson(@JsonProperty("uri") String uri,
+				@JsonProperty("_meta") Map<String, Object> meta) {
+			if (uri == null) {
+				logger
+					.warn("ReadResourceRequest: missing required field 'uri' during deserialization, using default ''");
+				uri = "";
+			}
+			return new ReadResourceRequest(uri, meta);
+		}
+
+		@Deprecated
 		public ReadResourceRequest(String uri) {
 			this(uri, null);
+		}
+
+		public static Builder builder(String uri) {
+			return new Builder(uri);
+		}
+
+		public static class Builder {
+
+			private final String uri;
+
+			private Map<String, Object> meta;
+
+			private Builder(String uri) {
+				Assert.hasText(uri, "uri must not be empty");
+				this.uri = uri;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public ReadResourceRequest build() {
+				return new ReadResourceRequest(uri, meta);
+			}
+
 		}
 	}
 
@@ -1040,8 +1596,50 @@ public final class McpSchema {
 		@JsonProperty("contents") List<ResourceContents> contents,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Result { // @formatter:on
 
+		public ReadResourceResult {
+			Assert.notNull(contents, "contents must not be null");
+		}
+
+		@JsonCreator
+		static ReadResourceResult fromJson(@JsonProperty("contents") List<ResourceContents> contents,
+				@JsonProperty("_meta") Map<String, Object> meta) {
+			if (contents == null) {
+				logger.warn(
+						"ReadResourceResult: missing required field 'contents' during deserialization, using default []");
+				contents = List.of();
+			}
+			return new ReadResourceResult(contents, meta);
+		}
+
+		@Deprecated
 		public ReadResourceResult(List<ResourceContents> contents) {
 			this(contents, null);
+		}
+
+		public static Builder builder(List<ResourceContents> contents) {
+			return new Builder(contents);
+		}
+
+		public static class Builder {
+
+			private final List<ResourceContents> contents;
+
+			private Map<String, Object> meta;
+
+			private Builder(List<ResourceContents> contents) {
+				Assert.notNull(contents, "contents must not be null");
+				this.contents = contents;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public ReadResourceResult build() {
+				return new ReadResourceResult(contents, meta);
+			}
+
 		}
 	}
 
@@ -1059,8 +1657,49 @@ public final class McpSchema {
 		@JsonProperty("uri") String uri,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Request { // @formatter:on
 
+		public SubscribeRequest {
+			Assert.notNull(uri, "uri must not be null");
+		}
+
+		@JsonCreator
+		static SubscribeRequest fromJson(@JsonProperty("uri") String uri,
+				@JsonProperty("_meta") Map<String, Object> meta) {
+			if (uri == null) {
+				logger.warn("SubscribeRequest: missing required field 'uri' during deserialization, using default ''");
+				uri = "";
+			}
+			return new SubscribeRequest(uri, meta);
+		}
+
+		@Deprecated
 		public SubscribeRequest(String uri) {
 			this(uri, null);
+		}
+
+		public static Builder builder(String uri) {
+			return new Builder(uri);
+		}
+
+		public static class Builder {
+
+			private final String uri;
+
+			private Map<String, Object> meta;
+
+			private Builder(String uri) {
+				Assert.hasText(uri, "uri must not be empty");
+				this.uri = uri;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public SubscribeRequest build() {
+				return new SubscribeRequest(uri, meta);
+			}
+
 		}
 	}
 
@@ -1077,8 +1716,50 @@ public final class McpSchema {
 		@JsonProperty("uri") String uri,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Request { // @formatter:on
 
+		public UnsubscribeRequest {
+			Assert.notNull(uri, "uri must not be null");
+		}
+
+		@JsonCreator
+		static UnsubscribeRequest fromJson(@JsonProperty("uri") String uri,
+				@JsonProperty("_meta") Map<String, Object> meta) {
+			if (uri == null) {
+				logger
+					.warn("UnsubscribeRequest: missing required field 'uri' during deserialization, using default ''");
+				uri = "";
+			}
+			return new UnsubscribeRequest(uri, meta);
+		}
+
+		@Deprecated
 		public UnsubscribeRequest(String uri) {
 			this(uri, null);
+		}
+
+		public static Builder builder(String uri) {
+			return new Builder(uri);
+		}
+
+		public static class Builder {
+
+			private final String uri;
+
+			private Map<String, Object> meta;
+
+			private Builder(String uri) {
+				Assert.hasText(uri, "uri must not be empty");
+				this.uri = uri;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public UnsubscribeRequest build() {
+				return new UnsubscribeRequest(uri, meta);
+			}
+
 		}
 	}
 
@@ -1121,8 +1802,70 @@ public final class McpSchema {
 		@JsonProperty("text") String text,
 		@JsonProperty("_meta") Map<String, Object> meta) implements ResourceContents { // @formatter:on
 
+		public TextResourceContents {
+			Assert.notNull(uri, "uri must not be null");
+			Assert.notNull(text, "text must not be null");
+		}
+
+		@JsonCreator
+		static TextResourceContents fromJson(@JsonProperty("uri") String uri, @JsonProperty("mimeType") String mimeType,
+				@JsonProperty("text") String text, @JsonProperty("_meta") Map<String, Object> meta) {
+			if (uri == null || text == null) {
+				List<String> missing = new ArrayList<>();
+				if (uri == null) {
+					missing.add("uri -> ''");
+					uri = "";
+				}
+				if (text == null) {
+					missing.add("text -> ''");
+					text = "";
+				}
+				logger.warn("TextResourceContents: missing required fields during deserialization: {}",
+						String.join(", ", missing));
+			}
+			return new TextResourceContents(uri, mimeType, text, meta);
+		}
+
+		@Deprecated
 		public TextResourceContents(String uri, String mimeType, String text) {
 			this(uri, mimeType, text, null);
+		}
+
+		public static Builder builder(String uri, String text) {
+			return new Builder(uri, text);
+		}
+
+		public static class Builder {
+
+			private final String uri;
+
+			private String mimeType;
+
+			private final String text;
+
+			private Map<String, Object> meta;
+
+			private Builder(String uri, String text) {
+				Assert.hasText(uri, "uri must not be empty");
+				Assert.notNull(text, "text must not be null");
+				this.uri = uri;
+				this.text = text;
+			}
+
+			public Builder mimeType(String mimeType) {
+				this.mimeType = mimeType;
+				return this;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public TextResourceContents build() {
+				return new TextResourceContents(uri, mimeType, text, meta);
+			}
+
 		}
 	}
 
@@ -1144,8 +1887,70 @@ public final class McpSchema {
 		@JsonProperty("blob") String blob,
 		@JsonProperty("_meta") Map<String, Object> meta) implements ResourceContents { // @formatter:on
 
+		public BlobResourceContents {
+			Assert.notNull(uri, "uri must not be null");
+			Assert.notNull(blob, "blob must not be null");
+		}
+
+		@JsonCreator
+		static BlobResourceContents fromJson(@JsonProperty("uri") String uri, @JsonProperty("mimeType") String mimeType,
+				@JsonProperty("blob") String blob, @JsonProperty("_meta") Map<String, Object> meta) {
+			if (uri == null || blob == null) {
+				List<String> missing = new ArrayList<>();
+				if (uri == null) {
+					missing.add("uri -> ''");
+					uri = "";
+				}
+				if (blob == null) {
+					missing.add("blob -> ''");
+					blob = "";
+				}
+				logger.warn("BlobResourceContents: missing required fields during deserialization: {}",
+						String.join(", ", missing));
+			}
+			return new BlobResourceContents(uri, mimeType, blob, meta);
+		}
+
+		@Deprecated
 		public BlobResourceContents(String uri, String mimeType, String blob) {
 			this(uri, mimeType, blob, null);
+		}
+
+		public static Builder builder(String uri, String blob) {
+			return new Builder(uri, blob);
+		}
+
+		public static class Builder {
+
+			private final String uri;
+
+			private String mimeType;
+
+			private final String blob;
+
+			private Map<String, Object> meta;
+
+			private Builder(String uri, String blob) {
+				Assert.hasText(uri, "uri must not be empty");
+				Assert.notNull(blob, "blob must not be null");
+				this.uri = uri;
+				this.blob = blob;
+			}
+
+			public Builder mimeType(String mimeType) {
+				this.mimeType = mimeType;
+				return this;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public BlobResourceContents build() {
+				return new BlobResourceContents(uri, mimeType, blob, meta);
+			}
+
 		}
 	}
 
@@ -1170,12 +1975,77 @@ public final class McpSchema {
 		@JsonProperty("arguments") List<PromptArgument> arguments,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Identifier { // @formatter:on
 
+		public Prompt {
+			Assert.notNull(name, "name must not be null");
+		}
+
+		@JsonCreator
+		static Prompt fromJson(@JsonProperty("name") String name, @JsonProperty("title") String title,
+				@JsonProperty("description") String description,
+				@JsonProperty("arguments") List<PromptArgument> arguments,
+				@JsonProperty("_meta") Map<String, Object> meta) {
+			if (name == null) {
+				logger.warn("Prompt: missing required field 'name' during deserialization, using default ''");
+				name = "";
+			}
+			return new Prompt(name, title, description, arguments, meta);
+		}
+
+		@Deprecated
 		public Prompt(String name, String description, List<PromptArgument> arguments) {
 			this(name, null, description, arguments, null);
 		}
 
+		@Deprecated
 		public Prompt(String name, String title, String description, List<PromptArgument> arguments) {
 			this(name, title, description, arguments, null);
+		}
+
+		public static Builder builder(String name) {
+			return new Builder(name);
+		}
+
+		public static class Builder {
+
+			private final String name;
+
+			private String title;
+
+			private String description;
+
+			private List<PromptArgument> arguments;
+
+			private Map<String, Object> meta;
+
+			private Builder(String name) {
+				Assert.hasText(name, "name must not be empty");
+				this.name = name;
+			}
+
+			public Builder title(String title) {
+				this.title = title;
+				return this;
+			}
+
+			public Builder description(String description) {
+				this.description = description;
+				return this;
+			}
+
+			public Builder arguments(List<PromptArgument> arguments) {
+				this.arguments = arguments;
+				return this;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public Prompt build() {
+				return new Prompt(name, title, description, arguments, meta);
+			}
+
 		}
 	}
 
@@ -1195,8 +2065,53 @@ public final class McpSchema {
 		@JsonProperty("description") String description,
 		@JsonProperty("required") Boolean required) implements Identifier { // @formatter:on
 
+		public PromptArgument {
+			Assert.hasText(name, "name must not be empty");
+		}
+
+		@Deprecated
 		public PromptArgument(String name, String description, Boolean required) {
 			this(name, null, description, required);
+		}
+
+		public static Builder builder(String name) {
+			return new Builder(name);
+		}
+
+		public static class Builder {
+
+			private final String name;
+
+			private String title;
+
+			private String description;
+
+			private Boolean required;
+
+			private Builder(String name) {
+				Assert.hasText(name, "name must not be empty");
+				this.name = name;
+			}
+
+			public Builder title(String title) {
+				this.title = title;
+				return this;
+			}
+
+			public Builder description(String description) {
+				this.description = description;
+				return this;
+			}
+
+			public Builder required(Boolean required) {
+				this.required = required;
+				return this;
+			}
+
+			public PromptArgument build() {
+				return new PromptArgument(name, title, description, required);
+			}
+
 		}
 	}
 
@@ -1214,6 +2129,52 @@ public final class McpSchema {
 	public record PromptMessage( // @formatter:off
 		@JsonProperty("role") Role role,
 		@JsonProperty("content") Content content) { // @formatter:on
+
+		public PromptMessage {
+			Assert.notNull(role, "role must not be null");
+			Assert.notNull(content, "content must not be null");
+		}
+
+		@JsonCreator
+		static PromptMessage fromJson(@JsonProperty("role") Role role, @JsonProperty("content") Content content) {
+			if (role == null || content == null) {
+				List<String> missing = new ArrayList<>();
+				if (role == null) {
+					missing.add("role -> 'user'");
+					role = Role.USER;
+				}
+				if (content == null) {
+					missing.add("content -> ''");
+					content = TextContent.builder("").build();
+				}
+				logger.warn("PromptMessage: missing required fields during deserialization: {}",
+						String.join(", ", missing));
+			}
+			return new PromptMessage(role, content);
+		}
+
+		public static Builder builder(Role role, Content content) {
+			return new Builder(role, content);
+		}
+
+		public static class Builder {
+
+			private final Role role;
+
+			private final Content content;
+
+			private Builder(Role role, Content content) {
+				Assert.notNull(role, "role must not be null");
+				Assert.notNull(content, "content must not be null");
+				this.role = role;
+				this.content = content;
+			}
+
+			public PromptMessage build() {
+				return new PromptMessage(role, content);
+			}
+
+		}
 	}
 
 	/**
@@ -1231,8 +2192,57 @@ public final class McpSchema {
 		@JsonProperty("nextCursor") String nextCursor,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Result  { // @formatter:on
 
+		public ListPromptsResult {
+			Assert.notNull(prompts, "prompts must not be null");
+		}
+
+		@JsonCreator
+		static ListPromptsResult fromJson(@JsonProperty("prompts") List<Prompt> prompts,
+				@JsonProperty("nextCursor") String nextCursor, @JsonProperty("_meta") Map<String, Object> meta) {
+			if (prompts == null) {
+				logger.warn(
+						"ListPromptsResult: missing required field 'prompts' during deserialization, using default []");
+				prompts = List.of();
+			}
+			return new ListPromptsResult(prompts, nextCursor, meta);
+		}
+
+		@Deprecated
 		public ListPromptsResult(List<Prompt> prompts, String nextCursor) {
 			this(prompts, nextCursor, null);
+		}
+
+		public static Builder builder(List<Prompt> prompts) {
+			return new Builder(prompts);
+		}
+
+		public static class Builder {
+
+			private final List<Prompt> prompts;
+
+			private String nextCursor;
+
+			private Map<String, Object> meta;
+
+			private Builder(List<Prompt> prompts) {
+				Assert.notNull(prompts, "prompts must not be null");
+				this.prompts = prompts;
+			}
+
+			public Builder nextCursor(String nextCursor) {
+				this.nextCursor = nextCursor;
+				return this;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public ListPromptsResult build() {
+				return new ListPromptsResult(prompts, nextCursor, meta);
+			}
+
 		}
 	}
 
@@ -1250,8 +2260,57 @@ public final class McpSchema {
 		@JsonProperty("arguments") Map<String, Object> arguments,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Request { // @formatter:on
 
+		public GetPromptRequest {
+			Assert.notNull(name, "name must not be null");
+		}
+
+		@JsonCreator
+		static GetPromptRequest fromJson(@JsonProperty("name") String name,
+				@JsonProperty("arguments") Map<String, Object> arguments,
+				@JsonProperty("_meta") Map<String, Object> meta) {
+			if (name == null) {
+				logger.warn("GetPromptRequest: missing required field 'name' during deserialization, using default ''");
+				name = "";
+			}
+			return new GetPromptRequest(name, arguments, meta);
+		}
+
+		@Deprecated
 		public GetPromptRequest(String name, Map<String, Object> arguments) {
 			this(name, arguments, null);
+		}
+
+		public static Builder builder(String name) {
+			return new Builder(name);
+		}
+
+		public static class Builder {
+
+			private final String name;
+
+			private Map<String, Object> arguments;
+
+			private Map<String, Object> meta;
+
+			private Builder(String name) {
+				Assert.hasText(name, "name must not be empty");
+				this.name = name;
+			}
+
+			public Builder arguments(Map<String, Object> arguments) {
+				this.arguments = arguments;
+				return this;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public GetPromptRequest build() {
+				return new GetPromptRequest(name, arguments, meta);
+			}
+
 		}
 	}
 
@@ -1269,8 +2328,58 @@ public final class McpSchema {
 		@JsonProperty("messages") List<PromptMessage> messages,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Result { // @formatter:on
 
+		public GetPromptResult {
+			Assert.notNull(messages, "messages must not be null");
+		}
+
+		@JsonCreator
+		static GetPromptResult fromJson(@JsonProperty("description") String description,
+				@JsonProperty("messages") List<PromptMessage> messages,
+				@JsonProperty("_meta") Map<String, Object> meta) {
+			if (messages == null) {
+				logger.warn(
+						"GetPromptResult: missing required field 'messages' during deserialization, using default []");
+				messages = List.of();
+			}
+			return new GetPromptResult(description, messages, meta);
+		}
+
+		@Deprecated
 		public GetPromptResult(String description, List<PromptMessage> messages) {
 			this(description, messages, null);
+		}
+
+		public static Builder builder(List<PromptMessage> messages) {
+			return new Builder(messages);
+		}
+
+		public static class Builder {
+
+			private String description;
+
+			private final List<PromptMessage> messages;
+
+			private Map<String, Object> meta;
+
+			private Builder(List<PromptMessage> messages) {
+				Assert.notNull(messages, "messages must not be null");
+				this.messages = messages;
+			}
+
+			public Builder description(String description) {
+				this.description = description;
+				return this;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public GetPromptResult build() {
+				return new GetPromptResult(description, messages, meta);
+			}
+
 		}
 	}
 
@@ -1292,8 +2401,56 @@ public final class McpSchema {
 		@JsonProperty("nextCursor") String nextCursor,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Result { // @formatter:on
 
+		public ListToolsResult {
+			Assert.notNull(tools, "tools must not be null");
+		}
+
+		@JsonCreator
+		static ListToolsResult fromJson(@JsonProperty("tools") List<Tool> tools,
+				@JsonProperty("nextCursor") String nextCursor, @JsonProperty("_meta") Map<String, Object> meta) {
+			if (tools == null) {
+				logger.warn("ListToolsResult: missing required field 'tools' during deserialization, using default []");
+				tools = List.of();
+			}
+			return new ListToolsResult(tools, nextCursor, meta);
+		}
+
+		@Deprecated
 		public ListToolsResult(List<Tool> tools, String nextCursor) {
 			this(tools, nextCursor, null);
+		}
+
+		public static Builder builder(List<Tool> tools) {
+			return new Builder(tools);
+		}
+
+		public static class Builder {
+
+			private final List<Tool> tools;
+
+			private String nextCursor;
+
+			private Map<String, Object> meta;
+
+			private Builder(List<Tool> tools) {
+				Assert.notNull(tools, "tools must not be null");
+				this.tools = tools;
+			}
+
+			public Builder nextCursor(String nextCursor) {
+				this.nextCursor = nextCursor;
+				return this;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public ListToolsResult build() {
+				return new ListToolsResult(tools, nextCursor, meta);
+			}
+
 		}
 	}
 
@@ -1318,6 +2475,61 @@ public final class McpSchema {
 		@JsonProperty("additionalProperties") Boolean additionalProperties,
 		@JsonProperty("$defs") Map<String, Object> defs,
 		@JsonProperty("definitions") Map<String, Object> definitions) { // @formatter:on
+
+		public static Builder builder() {
+			return new Builder();
+		}
+
+		public static class Builder {
+
+			private String type;
+
+			private Map<String, Object> properties;
+
+			private List<String> required;
+
+			private Boolean additionalProperties;
+
+			private Map<String, Object> defs;
+
+			private Map<String, Object> definitions;
+
+			public Builder type(String type) {
+				this.type = type;
+				return this;
+			}
+
+			public Builder properties(Map<String, Object> properties) {
+				this.properties = properties;
+				return this;
+			}
+
+			public Builder required(List<String> required) {
+				this.required = required;
+				return this;
+			}
+
+			public Builder additionalProperties(Boolean additionalProperties) {
+				this.additionalProperties = additionalProperties;
+				return this;
+			}
+
+			public Builder defs(Map<String, Object> defs) {
+				this.defs = defs;
+				return this;
+			}
+
+			public Builder definitions(Map<String, Object> definitions) {
+				this.definitions = definitions;
+				return this;
+			}
+
+			public JsonSchema build() {
+				return new JsonSchema(type, properties, required, additionalProperties, defs, definitions);
+			}
+
+		}
+
 	}
 
 	/**
@@ -1339,6 +2551,61 @@ public final class McpSchema {
 		@JsonProperty("idempotentHint") Boolean idempotentHint,
 		@JsonProperty("openWorldHint") Boolean openWorldHint,
 		@JsonProperty("returnDirect") Boolean returnDirect) { // @formatter:on
+
+		public static Builder builder() {
+			return new Builder();
+		}
+
+		public static class Builder {
+
+			private String title;
+
+			private Boolean readOnlyHint;
+
+			private Boolean destructiveHint;
+
+			private Boolean idempotentHint;
+
+			private Boolean openWorldHint;
+
+			private Boolean returnDirect;
+
+			public Builder title(String title) {
+				this.title = title;
+				return this;
+			}
+
+			public Builder readOnlyHint(Boolean readOnlyHint) {
+				this.readOnlyHint = readOnlyHint;
+				return this;
+			}
+
+			public Builder destructiveHint(Boolean destructiveHint) {
+				this.destructiveHint = destructiveHint;
+				return this;
+			}
+
+			public Builder idempotentHint(Boolean idempotentHint) {
+				this.idempotentHint = idempotentHint;
+				return this;
+			}
+
+			public Builder openWorldHint(Boolean openWorldHint) {
+				this.openWorldHint = openWorldHint;
+				return this;
+			}
+
+			public Builder returnDirect(Boolean returnDirect) {
+				this.returnDirect = returnDirect;
+				return this;
+			}
+
+			public ToolAnnotations build() {
+				return new ToolAnnotations(title, readOnlyHint, destructiveHint, idempotentHint, openWorldHint,
+						returnDirect);
+			}
+
+		}
 	}
 
 	/**
@@ -1369,8 +2636,57 @@ public final class McpSchema {
 		@JsonProperty("annotations") ToolAnnotations annotations,
 		@JsonProperty("_meta") Map<String, Object> meta) { // @formatter:on
 
+		public Tool {
+			Assert.notNull(name, "name must not be null");
+			Assert.notNull(inputSchema, "inputSchema must not be null");
+		}
+
+		@JsonCreator
+		static Tool fromJson(@JsonProperty("name") String name, @JsonProperty("title") String title,
+				@JsonProperty("description") String description,
+				@JsonProperty("inputSchema") Map<String, Object> inputSchema,
+				@JsonProperty("outputSchema") Map<String, Object> outputSchema,
+				@JsonProperty("annotations") ToolAnnotations annotations,
+				@JsonProperty("_meta") Map<String, Object> meta) {
+			if (name == null || inputSchema == null) {
+				List<String> missing = new ArrayList<>();
+				if (name == null) {
+					missing.add("name -> ''");
+					name = "";
+				}
+				if (inputSchema == null) {
+					missing.add("inputSchema -> {}");
+					inputSchema = Map.of();
+				}
+				logger.warn("Tool: missing required fields during deserialization: {}", String.join(", ", missing));
+			}
+			return new Tool(name, title, description, inputSchema, outputSchema, annotations, meta);
+		}
+
+		/**
+		 * @deprecated Use {@link #builder(String, Map)} instead.
+		 */
+		@Deprecated
 		public static Builder builder() {
 			return new Builder();
+		}
+
+		/**
+		 * Uses empty input schema.
+		 * @param name
+		 * @return
+		 */
+		@Deprecated
+		public static Builder builder(String name) {
+			return new Builder(name);
+		}
+
+		public static Builder builder(String name, Map<String, Object> inputSchema) {
+			return new Builder(name, inputSchema);
+		}
+
+		public static Builder builder(String name, McpJsonMapper jsonMapper, String inputSchema) {
+			return new Builder(name, schemaToMap(jsonMapper, inputSchema));
 		}
 
 		public static class Builder {
@@ -1388,6 +2704,29 @@ public final class McpSchema {
 			private ToolAnnotations annotations;
 
 			private Map<String, Object> meta;
+
+			/**
+			 * @deprecated Use {@link Tool#builder(String, Map)} instead.
+			 */
+			@Deprecated
+			public Builder() {
+			}
+
+			/**
+			 * @deprecated Use {@link Tool#builder(String, Map)} instead.
+			 */
+			@Deprecated
+			private Builder(String name) {
+				Assert.hasText(name, "name must not be empty");
+				this.name = name;
+			}
+
+			private Builder(String name, Map<String, Object> inputSchema) {
+				Assert.hasText(name, "name must not be empty");
+				Assert.notNull(inputSchema, "inputSchema must not be null");
+				this.name = name;
+				this.inputSchema = inputSchema;
+			}
 
 			public Builder name(String name) {
 				this.name = name;
@@ -1457,6 +2796,10 @@ public final class McpSchema {
 
 			public Tool build() {
 				Assert.hasText(name, "name must not be empty");
+				if (inputSchema == null) {
+					logger.warn("Input schema was not set, falling back to empty schema");
+					inputSchema = Map.of("type", "object");
+				}
 				return new Tool(name, title, description, inputSchema, outputSchema, annotations, meta);
 			}
 
@@ -1489,10 +2832,27 @@ public final class McpSchema {
 		@JsonProperty("arguments") Map<String, Object> arguments,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Request { // @formatter:on
 
+		public CallToolRequest {
+			Assert.notNull(name, "name must not be null");
+		}
+
+		@JsonCreator
+		static CallToolRequest fromJson(@JsonProperty("name") String name,
+				@JsonProperty("arguments") Map<String, Object> arguments,
+				@JsonProperty("_meta") Map<String, Object> meta) {
+			if (name == null) {
+				logger.warn("CallToolRequest: missing required field 'name' during deserialization, using default ''");
+				name = "";
+			}
+			return new CallToolRequest(name, arguments, meta);
+		}
+
+		@Deprecated
 		public CallToolRequest(McpJsonMapper jsonMapper, String name, String jsonArguments) {
 			this(name, parseJsonArguments(jsonMapper, jsonArguments), null);
 		}
 
+		@Deprecated
 		public CallToolRequest(String name, Map<String, Object> arguments) {
 			this(name, arguments, null);
 		}
@@ -1506,8 +2866,16 @@ public final class McpSchema {
 			}
 		}
 
+		/**
+		 * @deprecated Use {@link #builder(String)} instead.
+		 */
+		@Deprecated
 		public static Builder builder() {
 			return new Builder();
+		}
+
+		public static Builder builder(String name) {
+			return new Builder(name);
 		}
 
 		public static class Builder {
@@ -1517,6 +2885,18 @@ public final class McpSchema {
 			private Map<String, Object> arguments;
 
 			private Map<String, Object> meta;
+
+			/**
+			 * @deprecated Use {@link CallToolRequest#builder(String)} instead.
+			 */
+			@Deprecated
+			public Builder() {
+			}
+
+			private Builder(String name) {
+				Assert.hasText(name, "name must not be empty");
+				this.name = name;
+			}
 
 			public Builder name(String name) {
 				this.name = name;
@@ -1564,6 +2944,10 @@ public final class McpSchema {
 	 * @param structuredContent An optional JSON object that represents the structured
 	 * result of the tool call.
 	 * @param meta See specification for notes on _meta usage
+	 * <p>
+	 * Note: {@code content} is required by the MCP specification. Deserialization accepts
+	 * a missing value and substitutes an empty list to avoid breaking existing
+	 * integrations that may omit the field.
 	 */
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
@@ -1573,12 +2957,36 @@ public final class McpSchema {
 		@JsonProperty("structuredContent") Object structuredContent,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Result { // @formatter:on
 
+		public CallToolResult {
+			Assert.notNull(content, "content must not be null");
+		}
+
+		@JsonCreator
+		static CallToolResult fromJson(@JsonProperty("content") List<Content> content,
+				@JsonProperty("isError") Boolean isError, @JsonProperty("structuredContent") Object structuredContent,
+				@JsonProperty("_meta") Map<String, Object> meta) {
+			if (content == null) {
+				logger.warn("CallToolResult: missing required fields during deserialization: content -> []");
+				content = List.of();
+			}
+			return new CallToolResult(content, isError, structuredContent, meta);
+		}
+
+		/**
+		 * Creates a builder for {@link CallToolResult} with the required content list.
+		 * @param content the content list
+		 * @return a new builder instance
+		 */
+		public static Builder builder(List<Content> content) {
+			return new Builder(content);
+		}
+
 		/**
 		 * Creates a builder for {@link CallToolResult}.
 		 * @return a new builder instance
 		 */
 		public static Builder builder() {
-			return new Builder();
+			return new Builder(new ArrayList<>());
 		}
 
 		/**
@@ -1589,6 +2997,18 @@ public final class McpSchema {
 			private List<Content> content = new ArrayList<>();
 
 			private Boolean isError = false;
+
+			/**
+			 * @deprecated Use {@link CallToolResult#builder()} factory method instead of
+			 * instantiating the builder directly.
+			 */
+			@Deprecated
+			public Builder() {
+			}
+
+			private Builder(List<Content> content) {
+				this.content.addAll(content);
+			}
 
 			private Object structuredContent;
 
@@ -1601,7 +3021,7 @@ public final class McpSchema {
 			 */
 			public Builder content(List<Content> content) {
 				Assert.notNull(content, "content must not be null");
-				this.content = content;
+				this.content = new ArrayList<>(content);
 				return this;
 			}
 
@@ -1629,7 +3049,7 @@ public final class McpSchema {
 			 */
 			public Builder textContent(List<String> textContent) {
 				Assert.notNull(textContent, "textContent must not be null");
-				textContent.stream().map(TextContent::new).forEach(this.content::add);
+				textContent.stream().map(t -> TextContent.builder(t).build()).forEach(this.content::add);
 				return this;
 			}
 
@@ -1640,9 +3060,6 @@ public final class McpSchema {
 			 */
 			public Builder addContent(Content contentItem) {
 				Assert.notNull(contentItem, "contentItem must not be null");
-				if (this.content == null) {
-					this.content = new ArrayList<>();
-				}
 				this.content.add(contentItem);
 				return this;
 			}
@@ -1654,7 +3071,7 @@ public final class McpSchema {
 			 */
 			public Builder addTextContent(String text) {
 				Assert.notNull(text, "text must not be null");
-				return addContent(new TextContent(text));
+				return addContent(TextContent.builder(text).build());
 			}
 
 			/**
@@ -1683,6 +3100,7 @@ public final class McpSchema {
 			 * @return a new CallToolResult instance
 			 */
 			public CallToolResult build() {
+				Assert.notNull(content, "content must not be null");
 				return new CallToolResult(content, isError, structuredContent, meta);
 			}
 
@@ -1781,6 +3199,11 @@ public final class McpSchema {
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ModelHint(@JsonProperty("name") String name) {
+
+		/**
+		 * @deprecated Use {@link #ModelHint(String)}
+		 */
+		@Deprecated
 		public static ModelHint of(String name) {
 			return new ModelHint(name);
 		}
@@ -1791,12 +3214,62 @@ public final class McpSchema {
 	 *
 	 * @param role The sender or recipient of messages and data in a conversation
 	 * @param content The content of the message
+	 * <p>
+	 * Note: {@code role} and {@code content} are required by the MCP specification.
+	 * Deserialization accepts missing values and substitutes defaults to avoid breaking
+	 * existing integrations that may omit these fields.
 	 */
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record SamplingMessage( // @formatter:off
 		@JsonProperty("role") Role role,
 		@JsonProperty("content") Content content) { // @formatter:on
+
+		public SamplingMessage {
+			Assert.notNull(role, "role must not be null");
+			Assert.notNull(content, "content must not be null");
+		}
+
+		@JsonCreator
+		static SamplingMessage fromJson(@JsonProperty("role") Role role, @JsonProperty("content") Content content) {
+			if (role == null || content == null) {
+				List<String> missing = new ArrayList<>();
+				if (role == null) {
+					missing.add("role -> 'user'");
+					role = Role.USER;
+				}
+				if (content == null) {
+					missing.add("content -> ''");
+					content = TextContent.builder("").build();
+				}
+				logger.warn("SamplingMessage: missing required fields during deserialization: {}",
+						String.join(", ", missing));
+			}
+			return new SamplingMessage(role, content);
+		}
+
+		public static Builder builder(Role role, Content content) {
+			return new Builder(role, content);
+		}
+
+		public static class Builder {
+
+			private final Role role;
+
+			private final Content content;
+
+			private Builder(Role role, Content content) {
+				Assert.notNull(role, "role must not be null");
+				Assert.notNull(content, "content must not be null");
+				this.role = role;
+				this.content = content;
+			}
+
+			public SamplingMessage build() {
+				return new SamplingMessage(role, content);
+			}
+
+		}
 	}
 
 	/**
@@ -1820,6 +3293,10 @@ public final class McpSchema {
 	 * @param metadata Optional metadata to pass through to the LLM provider. The format
 	 * of this metadata is provider-specific
 	 * @param meta See specification for notes on _meta usage
+	 * <p>
+	 * Note: {@code messages} and {@code maxTokens} are required by the MCP specification.
+	 * Deserialization accepts missing values and substitutes defaults to avoid breaking
+	 * existing integrations that may omit these fields.
 	 */
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
@@ -1833,6 +3310,37 @@ public final class McpSchema {
 		@JsonProperty("stopSequences") List<String> stopSequences,
 		@JsonProperty("metadata") Map<String, Object> metadata,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Request { // @formatter:on
+
+		public CreateMessageRequest {
+			Assert.notNull(messages, "messages must not be null");
+			Assert.notNull(maxTokens, "maxTokens must not be null");
+		}
+
+		@JsonCreator
+		static CreateMessageRequest fromJson(@JsonProperty("messages") List<SamplingMessage> messages,
+				@JsonProperty("modelPreferences") ModelPreferences modelPreferences,
+				@JsonProperty("systemPrompt") String systemPrompt,
+				@JsonProperty("includeContext") ContextInclusionStrategy includeContext,
+				@JsonProperty("temperature") Double temperature, @JsonProperty("maxTokens") Integer maxTokens,
+				@JsonProperty("stopSequences") List<String> stopSequences,
+				@JsonProperty("metadata") Map<String, Object> metadata,
+				@JsonProperty("_meta") Map<String, Object> meta) {
+			if (messages == null || maxTokens == null) {
+				List<String> missing = new ArrayList<>();
+				if (messages == null) {
+					missing.add("messages -> []");
+					messages = List.of();
+				}
+				if (maxTokens == null) {
+					missing.add("maxTokens -> 0");
+					maxTokens = 0;
+				}
+				logger.warn("CreateMessageRequest: missing required fields during deserialization: {}",
+						String.join(", ", missing));
+			}
+			return new CreateMessageRequest(messages, modelPreferences, systemPrompt, includeContext, temperature,
+					maxTokens, stopSequences, metadata, meta);
+		}
 
 		// backwards compatibility constructor
 		public CreateMessageRequest(List<SamplingMessage> messages, ModelPreferences modelPreferences,
@@ -1850,8 +3358,16 @@ public final class McpSchema {
 			@JsonProperty("allServers") ALL_SERVERS
 		} // @formatter:on
 
+		/**
+		 * @deprecated Use {@link #builder(List, int)} instead.
+		 */
+		@Deprecated
 		public static Builder builder() {
 			return new Builder();
+		}
+
+		public static Builder builder(List<SamplingMessage> messages, int maxTokens) {
+			return new Builder(messages, maxTokens);
 		}
 
 		public static class Builder {
@@ -1874,7 +3390,22 @@ public final class McpSchema {
 
 			private Map<String, Object> meta;
 
+			/**
+			 * @deprecated Use {@link CreateMessageRequest#builder(List, int)} factory
+			 * method instead.
+			 */
+			@Deprecated
+			public Builder() {
+			}
+
+			private Builder(List<SamplingMessage> messages, int maxTokens) {
+				Assert.notNull(messages, "messages must not be null");
+				this.messages = messages;
+				this.maxTokens = maxTokens;
+			}
+
 			public Builder messages(List<SamplingMessage> messages) {
+				Assert.notNull(messages, "messages must not be null");
 				this.messages = messages;
 				return this;
 			}
@@ -1928,6 +3459,8 @@ public final class McpSchema {
 			}
 
 			public CreateMessageRequest build() {
+				Assert.notNull(messages, "messages must not be null");
+				Assert.notNull(maxTokens, "maxTokens must not be null");
 				return new CreateMessageRequest(messages, modelPreferences, systemPrompt, includeContext, temperature,
 						maxTokens, stopSequences, metadata, meta);
 			}
@@ -1935,6 +3468,7 @@ public final class McpSchema {
 		}
 	}
 
+	// TODO: role, content and model are required
 	/**
 	 * The client's response to a sampling/create_message request from the server. The
 	 * client should inform the user before returning the sampled message, to allow them
@@ -1955,6 +3489,36 @@ public final class McpSchema {
 		@JsonProperty("model") String model,
 		@JsonProperty("stopReason") StopReason stopReason,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Result { // @formatter:on
+
+		public CreateMessageResult {
+			Assert.notNull(role, "role must not be null");
+			Assert.notNull(content, "content must not be null");
+			Assert.notNull(model, "model must not be null");
+		}
+
+		@JsonCreator
+		static CreateMessageResult fromJson(@JsonProperty("role") Role role, @JsonProperty("content") Content content,
+				@JsonProperty("model") String model, @JsonProperty("stopReason") StopReason stopReason,
+				@JsonProperty("_meta") Map<String, Object> meta) {
+			if (role == null || content == null || model == null) {
+				List<String> missing = new ArrayList<>();
+				if (role == null) {
+					missing.add("role -> 'assistant'");
+					role = Role.ASSISTANT;
+				}
+				if (content == null) {
+					missing.add("content -> ''");
+					content = TextContent.builder("").build();
+				}
+				if (model == null) {
+					missing.add("model -> ''");
+					model = "";
+				}
+				logger.warn("CreateMessageResult: missing required fields during deserialization: {}",
+						String.join(", ", missing));
+			}
+			return new CreateMessageResult(role, content, model, stopReason, meta);
+		}
 
 		public enum StopReason {
 
@@ -1993,13 +3557,22 @@ public final class McpSchema {
 			this(role, content, model, stopReason, null);
 		}
 
+		@Deprecated
 		public static Builder builder() {
-			return new Builder();
+			return new Builder(Role.ASSISTANT);
+		}
+
+		public static Builder builder(Role role, String textContent, String model) {
+			return builder(role, TextContent.builder(textContent).build(), model);
+		}
+
+		public static Builder builder(Role role, Content content, String model) {
+			return new Builder(role, content, model);
 		}
 
 		public static class Builder {
 
-			private Role role = Role.ASSISTANT;
+			private Role role;
 
 			private Content content;
 
@@ -2009,16 +3582,34 @@ public final class McpSchema {
 
 			private Map<String, Object> meta;
 
+			// temporary to keep deprecated use
+			private Builder(Role role) {
+				Assert.notNull(role, "role must not be null");
+				this.role = role;
+			}
+
+			Builder(Role role, Content content, String model) {
+				Assert.notNull(role, "role must not be null");
+				Assert.notNull(content, "content must not be null");
+				Assert.notNull(model, "model must not be null");
+				this.role = role;
+				this.content = content;
+				this.model = model;
+			}
+
+			@Deprecated
 			public Builder role(Role role) {
 				this.role = role;
 				return this;
 			}
 
+			@Deprecated
 			public Builder content(Content content) {
 				this.content = content;
 				return this;
 			}
 
+			@Deprecated
 			public Builder model(String model) {
 				this.model = model;
 				return this;
@@ -2029,8 +3620,9 @@ public final class McpSchema {
 				return this;
 			}
 
+			@Deprecated
 			public Builder message(String message) {
-				this.content = new TextContent(message);
+				this.content = TextContent.builder(message).build();
 				return this;
 			}
 
@@ -2055,6 +3647,10 @@ public final class McpSchema {
 	 * @param requestedSchema A restricted subset of JSON Schema. Only top-level
 	 * properties are allowed, without nesting
 	 * @param meta See specification for notes on _meta usage
+	 * <p>
+	 * Note: {@code message} and {@code requestedSchema} are required by the MCP
+	 * specification. Deserialization accepts missing values and substitutes defaults to
+	 * avoid breaking existing integrations that may omit these fields.
 	 */
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
@@ -2063,13 +3659,46 @@ public final class McpSchema {
 		@JsonProperty("requestedSchema") Map<String, Object> requestedSchema,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Request { // @formatter:on
 
+		public ElicitRequest {
+			Assert.notNull(message, "message must not be null");
+			Assert.notNull(requestedSchema, "requestedSchema must not be null");
+		}
+
+		@JsonCreator
+		static ElicitRequest fromJson(@JsonProperty("message") String message,
+				@JsonProperty("requestedSchema") Map<String, Object> requestedSchema,
+				@JsonProperty("_meta") Map<String, Object> meta) {
+			if (message == null || requestedSchema == null) {
+				List<String> missing = new ArrayList<>();
+				if (message == null) {
+					missing.add("message -> ''");
+					message = "";
+				}
+				if (requestedSchema == null) {
+					missing.add("requestedSchema -> {}");
+					requestedSchema = Map.of();
+				}
+				logger.warn("ElicitRequest: missing required fields during deserialization: {}",
+						String.join(", ", missing));
+			}
+			return new ElicitRequest(message, requestedSchema, meta);
+		}
+
 		// backwards compatibility constructor
 		public ElicitRequest(String message, Map<String, Object> requestedSchema) {
 			this(message, requestedSchema, null);
 		}
 
+		/**
+		 * @deprecated Use {@link #builder(String, Map)} instead.
+		 */
+		@Deprecated
 		public static Builder builder() {
 			return new Builder();
+		}
+
+		public static Builder builder(String message, Map<String, Object> requestedSchema) {
+			return new Builder(message, requestedSchema);
 		}
 
 		public static class Builder {
@@ -2080,12 +3709,29 @@ public final class McpSchema {
 
 			private Map<String, Object> meta;
 
+			/**
+			 * @deprecated Use {@link ElicitRequest#builder(String, Map)} factory method
+			 * instead.
+			 */
+			@Deprecated
+			public Builder() {
+			}
+
+			private Builder(String message, Map<String, Object> requestedSchema) {
+				Assert.notNull(message, "message must not be null");
+				Assert.notNull(requestedSchema, "requestedSchema must not be null");
+				this.message = message;
+				this.requestedSchema = requestedSchema;
+			}
+
 			public Builder message(String message) {
+				Assert.notNull(message, "message must not be null");
 				this.message = message;
 				return this;
 			}
 
 			public Builder requestedSchema(Map<String, Object> requestedSchema) {
+				Assert.notNull(requestedSchema, "requestedSchema must not be null");
 				this.requestedSchema = requestedSchema;
 				return this;
 			}
@@ -2104,6 +3750,8 @@ public final class McpSchema {
 			}
 
 			public ElicitRequest build() {
+				Assert.notNull(message, "message must not be null");
+				Assert.notNull(requestedSchema, "requestedSchema must not be null");
 				return new ElicitRequest(message, requestedSchema, meta);
 			}
 
@@ -2127,6 +3775,21 @@ public final class McpSchema {
 		@JsonProperty("content") Map<String, Object> content,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Result { // @formatter:on
 
+		public ElicitResult {
+			Assert.notNull(action, "action must not be null");
+		}
+
+		@JsonCreator
+		static ElicitResult fromJson(@JsonProperty("action") Action action,
+				@JsonProperty("content") Map<String, Object> content, @JsonProperty("_meta") Map<String, Object> meta) {
+			if (action == null) {
+				logger.warn(
+						"ElicitResult: missing required field 'action' during deserialization, using default 'cancel'");
+				action = Action.CANCEL;
+			}
+			return new ElicitResult(action, content, meta);
+		}
+
 		public enum Action {
 
 		// @formatter:off
@@ -2142,8 +3805,13 @@ public final class McpSchema {
 			this(action, content, null);
 		}
 
+		@Deprecated
 		public static Builder builder() {
 			return new Builder();
+		}
+
+		public static Builder builder(Action action) {
+			return new Builder(action);
 		}
 
 		public static class Builder {
@@ -2154,6 +3822,17 @@ public final class McpSchema {
 
 			private Map<String, Object> meta;
 
+			// tepmorary to support deprecated builder
+			private Builder() {
+
+			}
+
+			private Builder(Action action) {
+				Assert.notNull(action, "action must not be null");
+				this.action = action;
+			}
+
+			@Deprecated
 			public Builder message(Action action) {
 				this.action = action;
 				return this;
@@ -2170,6 +3849,7 @@ public final class McpSchema {
 			}
 
 			public ElicitResult build() {
+				Assert.notNull(action, "action must not be null");
 				return new ElicitResult(action, content, meta);
 			}
 
@@ -2230,6 +3910,10 @@ public final class McpSchema {
 	 * @param total An optional total amount of work to be done, if known.
 	 * @param message An optional message providing additional context about the progress.
 	 * @param meta See specification for notes on _meta usage
+	 * <p>
+	 * Note: {@code progressToken} and {@code progress} are required by the MCP
+	 * specification. Deserialization accepts missing values and substitutes defaults to
+	 * avoid breaking existing integrations that may omit these fields.
 	 */
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
@@ -2240,9 +3924,79 @@ public final class McpSchema {
 		@JsonProperty("message") String message,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Notification { // @formatter:on
 
+		public ProgressNotification {
+			Assert.notNull(progressToken, "progressToken must not be null");
+			Assert.notNull(progress, "progress must not be null");
+		}
+
+		@JsonCreator
+		static ProgressNotification fromJson(@JsonProperty("progressToken") Object progressToken,
+				@JsonProperty("progress") Double progress, @JsonProperty("total") Double total,
+				@JsonProperty("message") String message, @JsonProperty("_meta") Map<String, Object> meta) {
+			if (progressToken == null || progress == null) {
+				List<String> missing = new ArrayList<>();
+				if (progressToken == null) {
+					missing.add("progressToken -> ''");
+					progressToken = "";
+				}
+				if (progress == null) {
+					missing.add("progress -> 0.0");
+					progress = 0.0;
+				}
+				logger.warn("ProgressNotification: missing required fields during deserialization: {}",
+						String.join(", ", missing));
+			}
+			return new ProgressNotification(progressToken, progress, total, message, meta);
+		}
+
+		@Deprecated
 		public ProgressNotification(Object progressToken, double progress, Double total, String message) {
 			this(progressToken, progress, total, message, null);
 		}
+
+		public static Builder builder(Object progressToken, double progress) {
+			return new Builder(progressToken, progress);
+		}
+
+		public static class Builder {
+
+			private final Object progressToken;
+
+			private final Double progress;
+
+			private Double total;
+
+			private String message;
+
+			private Map<String, Object> meta;
+
+			private Builder(Object progressToken, double progress) {
+				Assert.notNull(progressToken, "progressToken must not be null");
+				this.progressToken = progressToken;
+				this.progress = progress;
+			}
+
+			public Builder total(Double total) {
+				this.total = total;
+				return this;
+			}
+
+			public Builder message(String message) {
+				this.message = message;
+				return this;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public ProgressNotification build() {
+				return new ProgressNotification(progressToken, progress, total, message, meta);
+			}
+
+		}
+
 	}
 
 	/**
@@ -2258,8 +4012,23 @@ public final class McpSchema {
 		@JsonProperty("uri") String uri,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Notification { // @formatter:on
 
+		public ResourcesUpdatedNotification {
+			Assert.notNull(uri, "uri must not be null");
+		}
+
 		public ResourcesUpdatedNotification(String uri) {
 			this(uri, null);
+		}
+
+		@JsonCreator
+		static ResourcesUpdatedNotification fromJson(@JsonProperty("uri") String uri,
+				@JsonProperty("_meta") Map<String, Object> meta) {
+			if (uri == null) {
+				logger.warn(
+						"ResourcesUpdatedNotification: missing required field 'uri' during deserialization, using default ''");
+				uri = "";
+			}
+			return new ResourcesUpdatedNotification(uri, meta);
 		}
 	}
 
@@ -2273,6 +4042,10 @@ public final class McpSchema {
 	 * @param logger The logger that generated the message.
 	 * @param data JSON-serializable logging data.
 	 * @param meta See specification for notes on _meta usage
+	 * <p>
+	 * Note: {@code level} and {@code data} are required by the MCP specification.
+	 * Deserialization accepts missing values and substitutes defaults to avoid breaking
+	 * existing integrations that may omit these fields.
 	 */
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
@@ -2282,18 +4055,51 @@ public final class McpSchema {
 		@JsonProperty("data") String data,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Notification { // @formatter:on
 
+		public LoggingMessageNotification {
+			Assert.notNull(level, "level must not be null");
+			Assert.notNull(data, "data must not be null");
+		}
+
+		@JsonCreator
+		static LoggingMessageNotification fromJson(@JsonProperty("level") LoggingLevel level,
+				@JsonProperty("logger") String loggerName, @JsonProperty("data") String data,
+				@JsonProperty("_meta") Map<String, Object> meta) {
+			if (level == null || data == null) {
+				List<String> missing = new ArrayList<>();
+				if (level == null) {
+					missing.add("level -> INFO");
+					level = LoggingLevel.INFO;
+				}
+				if (data == null) {
+					missing.add("data -> ''");
+					data = "";
+				}
+				McpSchema.logger.warn("LoggingMessageNotification: missing required fields during deserialization: {}",
+						String.join(", ", missing));
+			}
+			return new LoggingMessageNotification(level, loggerName, data, meta);
+		}
+
 		// backwards compatibility constructor
 		public LoggingMessageNotification(LoggingLevel level, String logger, String data) {
 			this(level, logger, data, null);
 		}
 
+		/**
+		 * @deprecated Use {@link #builder(LoggingLevel, String)} instead.
+		 */
+		@Deprecated
 		public static Builder builder() {
-			return new Builder();
+			return new Builder().level(LoggingLevel.INFO);
+		}
+
+		public static Builder builder(LoggingLevel level, String data) {
+			return new Builder(level, data);
 		}
 
 		public static class Builder {
 
-			private LoggingLevel level = LoggingLevel.INFO;
+			private LoggingLevel level;
 
 			private String logger = "server";
 
@@ -2301,7 +4107,25 @@ public final class McpSchema {
 
 			private Map<String, Object> meta;
 
+			/**
+			 * @deprecated Use
+			 * {@link LoggingMessageNotification#builder(LoggingLevel, String)} factory
+			 * method instead.
+			 */
+			@Deprecated
+			public Builder() {
+			}
+
+			private Builder(LoggingLevel level, String data) {
+				Assert.notNull(level, "level must not be null");
+				Assert.notNull(data, "data must not be null");
+				this.level = level;
+				this.data = data;
+			}
+
+			@Deprecated
 			public Builder level(LoggingLevel level) {
+				Assert.notNull(level, "level must not be null");
 				this.level = level;
 				return this;
 			}
@@ -2311,7 +4135,9 @@ public final class McpSchema {
 				return this;
 			}
 
+			@Deprecated
 			public Builder data(String data) {
+				Assert.notNull(data, "data must not be null");
 				this.data = data;
 				return this;
 			}
@@ -2322,6 +4148,8 @@ public final class McpSchema {
 			}
 
 			public LoggingMessageNotification build() {
+				Assert.notNull(level, "level must not be null");
+				Assert.notNull(data, "data must not be null");
 				return new LoggingMessageNotification(level, logger, data, meta);
 			}
 
@@ -2384,6 +4212,20 @@ public final class McpSchema {
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record SetLevelRequest(@JsonProperty("level") LoggingLevel level) {
+
+		public SetLevelRequest {
+			Assert.notNull(level, "level must not be null");
+		}
+
+		@JsonCreator
+		static SetLevelRequest fromJson(@JsonProperty("level") LoggingLevel level) {
+			if (level == null) {
+				logger.warn(
+						"SetLevelRequest: missing required field 'level' during deserialization, using default 'info'");
+				level = LoggingLevel.INFO;
+			}
+			return new SetLevelRequest(level);
+		}
 	}
 
 	// ---------------------------
@@ -2401,16 +4243,29 @@ public final class McpSchema {
 			@JsonSubTypes.Type(value = ResourceReference.class, name = ResourceReference.TYPE) })
 	public interface CompleteReference {
 
-		String type();
+		default String type() {
+			if (this instanceof PromptReference) {
+				return PromptReference.TYPE;
+			}
+			else if (this instanceof ResourceReference) {
+				return ResourceReference.TYPE;
+			}
+			throw new IllegalArgumentException("Unknown CompleteReference type: " + this);
+		}
 
-		String identifier();
+		@Deprecated
+		default String identifier() {
+			return null;
+		}
 
 	}
 
 	/**
 	 * Identifies a prompt for completion requests.
 	 *
-	 * @param type The reference type identifier (typically "ref/prompt")
+	 * @param type Always {@value #TYPE}; present as the polymorphic discriminator. Any
+	 * non-null value other than {@value #TYPE} is replaced with {@value #TYPE} and a WARN
+	 * is logged.
 	 * @param name The name of the prompt
 	 * @param title An optional title for the prompt
 	 */
@@ -2419,10 +4274,30 @@ public final class McpSchema {
 	public record PromptReference( // @formatter:off
 		@JsonProperty("type") String type,
 		@JsonProperty("name") String name,
-		@JsonProperty("title") String title ) implements McpSchema.CompleteReference, Identifier { // @formatter:on
+		@JsonProperty("title") String title) implements McpSchema.CompleteReference, Identifier { // @formatter:on
 
 		public static final String TYPE = "ref/prompt";
 
+		public PromptReference {
+			Assert.hasText(name, "name must not be null or empty");
+			if (type != null && !TYPE.equals(type)) {
+				logger.warn("PromptReference: 'type' argument '{}' is ignored, type is always '{}'", type, TYPE);
+			}
+			type = TYPE;
+		}
+
+		@JsonCreator
+		static PromptReference fromJson(@JsonProperty("type") String type, @JsonProperty("name") String name,
+				@JsonProperty("title") String title) {
+			return new PromptReference(type, name, title);
+		}
+
+		/**
+		 * @deprecated The {@code type} argument is ignored — the type discriminator is
+		 * always {@value #TYPE}. Use {@link #PromptReference(String)} or the
+		 * {@link #builder(String)} instead.
+		 */
+		@Deprecated
 		public PromptReference(String type, String name) {
 			this(type, name, null);
 		}
@@ -2443,32 +4318,73 @@ public final class McpSchema {
 			if (obj == null || getClass() != obj.getClass())
 				return false;
 			PromptReference that = (PromptReference) obj;
-			return java.util.Objects.equals(identifier(), that.identifier())
-					&& java.util.Objects.equals(type(), that.type());
+			return java.util.Objects.equals(name, that.name);
 		}
 
 		@Override
 		public int hashCode() {
-			return java.util.Objects.hash(identifier(), type());
+			return java.util.Objects.hash(name);
 		}
+
+		public static Builder builder(String name) {
+			return new Builder(name);
+		}
+
+		public static final class Builder {
+
+			private final String name;
+
+			private String title;
+
+			private Builder(String name) {
+				this.name = name;
+			}
+
+			public Builder title(String title) {
+				this.title = title;
+				return this;
+			}
+
+			public PromptReference build() {
+				return new PromptReference(TYPE, name, title);
+			}
+
+		}
+
 	}
 
+	// TODO: this should actually be a ResourceTemplateReference
 	/**
 	 * A reference to a resource or resource template definition for completion requests.
 	 *
-	 * @param type The reference type identifier (typically "ref/resource")
 	 * @param uri The URI or URI template of the resource
 	 */
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ResourceReference( // @formatter:off
-		@JsonProperty("type") String type,
 		@JsonProperty("uri") String uri) implements McpSchema.CompleteReference { // @formatter:on
 
 		public static final String TYPE = "ref/resource";
 
-		public ResourceReference(String uri) {
-			this(TYPE, uri);
+		public ResourceReference {
+			Assert.notNull(uri, "uri must not be null");
+		}
+
+		@JsonProperty("type")
+		@Override
+		public String type() {
+			return CompleteReference.super.type();
+		}
+
+		@JsonCreator
+		static ResourceReference fromJson(@JsonProperty("uri") String uri, @JsonProperty("type") String type) {
+			return new ResourceReference(uri);
+		}
+
+		@Deprecated
+		public ResourceReference(String type, String uri) {
+			this(uri);
+			logger.warn("ResourceReference: type argument '{}' is ignored, type is always '{}'", type, TYPE);
 		}
 
 		@Override
@@ -2493,16 +4409,68 @@ public final class McpSchema {
 		@JsonProperty("_meta") Map<String, Object> meta,
 		@JsonProperty("context") CompleteContext context) implements Request { // @formatter:on
 
+		public CompleteRequest {
+			Assert.notNull(ref, "ref must not be null");
+			Assert.notNull(argument, "argument must not be null");
+		}
+
+		@JsonCreator
+		static CompleteRequest fromJson(@JsonProperty("ref") McpSchema.CompleteReference ref,
+				@JsonProperty("argument") CompleteArgument argument, @JsonProperty("_meta") Map<String, Object> meta,
+				@JsonProperty("context") CompleteContext context) {
+			return new CompleteRequest(ref, argument, meta, context);
+		}
+
+		@Deprecated
 		public CompleteRequest(McpSchema.CompleteReference ref, CompleteArgument argument, Map<String, Object> meta) {
 			this(ref, argument, meta, null);
 		}
 
+		@Deprecated
 		public CompleteRequest(McpSchema.CompleteReference ref, CompleteArgument argument, CompleteContext context) {
 			this(ref, argument, null, context);
 		}
 
+		@Deprecated
 		public CompleteRequest(McpSchema.CompleteReference ref, CompleteArgument argument) {
 			this(ref, argument, null, null);
+		}
+
+		public static Builder builder(McpSchema.CompleteReference ref, CompleteArgument argument) {
+			return new Builder(ref, argument);
+		}
+
+		public static class Builder {
+
+			private final McpSchema.CompleteReference ref;
+
+			private final CompleteArgument argument;
+
+			private Map<String, Object> meta;
+
+			private CompleteContext context;
+
+			private Builder(McpSchema.CompleteReference ref, CompleteArgument argument) {
+				Assert.notNull(ref, "ref must not be null");
+				Assert.notNull(argument, "argument must not be null");
+				this.ref = ref;
+				this.argument = argument;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public Builder context(CompleteContext context) {
+				this.context = context;
+				return this;
+			}
+
+			public CompleteRequest build() {
+				return new CompleteRequest(ref, argument, meta, context);
+			}
+
 		}
 
 		/**
@@ -2514,6 +4482,10 @@ public final class McpSchema {
 		@JsonInclude(JsonInclude.Include.NON_ABSENT)
 		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record CompleteArgument(@JsonProperty("name") String name, @JsonProperty("value") String value) {
+			public CompleteArgument {
+				Assert.hasText(name, "name must not be empty");
+				Assert.notNull(value, "value must not be null");
+			}
 		}
 
 		/**
@@ -2524,6 +4496,25 @@ public final class McpSchema {
 		@JsonInclude(JsonInclude.Include.NON_ABSENT)
 		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record CompleteContext(@JsonProperty("arguments") Map<String, String> arguments) {
+
+			public static Builder builder() {
+				return new Builder();
+			}
+
+			public static class Builder {
+
+				private Map<String, String> arguments;
+
+				public Builder arguments(Map<String, String> arguments) {
+					this.arguments = arguments;
+					return this;
+				}
+
+				public CompleteContext build() {
+					return new CompleteContext(arguments);
+				}
+
+			}
 		}
 	}
 
@@ -2539,7 +4530,21 @@ public final class McpSchema {
 			@JsonProperty("completion") CompleteCompletion completion,
 			@JsonProperty("_meta") Map<String, Object> meta) implements Result { // @formatter:on
 
-		// backwards compatibility constructor
+		public CompleteResult {
+			Assert.notNull(completion, "completion must not be null");
+		}
+
+		@JsonCreator
+		static CompleteResult fromJson(@JsonProperty("completion") CompleteCompletion completion,
+				@JsonProperty("_meta") Map<String, Object> meta) {
+			if (completion == null) {
+				logger.warn(
+						"CompleteResult: missing required field 'completion' during deserialization, using default {values=[]}");
+				completion = new CompleteCompletion(List.of(), null, null);
+			}
+			return new CompleteResult(completion, meta);
+		}
+
 		public CompleteResult(CompleteCompletion completion) {
 			this(completion, null);
 		}
@@ -2562,6 +4567,10 @@ public final class McpSchema {
 
 			public CompleteCompletion {
 				Assert.notNull(values, "values must not be null");
+			}
+
+			public CompleteCompletion(List<String> values) {
+				this(values, null, null);
 			}
 		}
 	}
@@ -2618,12 +4627,61 @@ public final class McpSchema {
 		@JsonProperty("text") String text,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Annotated, Content { // @formatter:on
 
+		public TextContent {
+			Assert.notNull(text, "text must not be null");
+		}
+
+		@JsonCreator
+		static TextContent fromJson(@JsonProperty("annotations") Annotations annotations,
+				@JsonProperty("text") String text, @JsonProperty("_meta") Map<String, Object> meta) {
+			if (text == null) {
+				logger.warn("TextContent: missing required field 'text' during deserialization, using default ''");
+				text = "";
+			}
+			return new TextContent(annotations, text, meta);
+		}
+
+		@Deprecated
 		public TextContent(Annotations annotations, String text) {
 			this(annotations, text, null);
 		}
 
+		@Deprecated
 		public TextContent(String content) {
 			this(null, content, null);
+		}
+
+		public static Builder builder(String text) {
+			return new Builder(text);
+		}
+
+		public static class Builder {
+
+			private Annotations annotations;
+
+			private final String text;
+
+			private Map<String, Object> meta;
+
+			private Builder(String text) {
+				Assert.notNull(text, "text must not be null");
+				this.text = text;
+			}
+
+			public Builder annotations(Annotations annotations) {
+				this.annotations = annotations;
+				return this;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public TextContent build() {
+				return new TextContent(annotations, text, meta);
+			}
+
 		}
 	}
 
@@ -2644,8 +4702,71 @@ public final class McpSchema {
 		@JsonProperty("mimeType") String mimeType,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Annotated, Content { // @formatter:on
 
+		public ImageContent {
+			Assert.notNull(data, "data must not be null");
+			Assert.notNull(mimeType, "mimeType must not be null");
+		}
+
+		@JsonCreator
+		static ImageContent fromJson(@JsonProperty("annotations") Annotations annotations,
+				@JsonProperty("data") String data, @JsonProperty("mimeType") String mimeType,
+				@JsonProperty("_meta") Map<String, Object> meta) {
+			if (data == null || mimeType == null) {
+				List<String> missing = new ArrayList<>();
+				if (data == null) {
+					missing.add("data -> ''");
+					data = "";
+				}
+				if (mimeType == null) {
+					missing.add("mimeType -> ''");
+					mimeType = "";
+				}
+				logger.warn("ImageContent: missing required fields during deserialization: {}",
+						String.join(", ", missing));
+			}
+			return new ImageContent(annotations, data, mimeType, meta);
+		}
+
+		@Deprecated
 		public ImageContent(Annotations annotations, String data, String mimeType) {
 			this(annotations, data, mimeType, null);
+		}
+
+		public static Builder builder(String data, String mimeType) {
+			return new Builder(data, mimeType);
+		}
+
+		public static class Builder {
+
+			private Annotations annotations;
+
+			private final String data;
+
+			private final String mimeType;
+
+			private Map<String, Object> meta;
+
+			private Builder(String data, String mimeType) {
+				Assert.notNull(data, "data must not be null");
+				Assert.notNull(mimeType, "mimeType must not be null");
+				this.data = data;
+				this.mimeType = mimeType;
+			}
+
+			public Builder annotations(Annotations annotations) {
+				this.annotations = annotations;
+				return this;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public ImageContent build() {
+				return new ImageContent(annotations, data, mimeType, meta);
+			}
+
 		}
 	}
 
@@ -2666,9 +4787,72 @@ public final class McpSchema {
 		@JsonProperty("mimeType") String mimeType,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Annotated, Content { // @formatter:on
 
+		public AudioContent {
+			Assert.notNull(data, "data must not be null");
+			Assert.notNull(mimeType, "mimeType must not be null");
+		}
+
+		@JsonCreator
+		static AudioContent fromJson(@JsonProperty("annotations") Annotations annotations,
+				@JsonProperty("data") String data, @JsonProperty("mimeType") String mimeType,
+				@JsonProperty("_meta") Map<String, Object> meta) {
+			if (data == null || mimeType == null) {
+				List<String> missing = new ArrayList<>();
+				if (data == null) {
+					missing.add("data -> ''");
+					data = "";
+				}
+				if (mimeType == null) {
+					missing.add("mimeType -> ''");
+					mimeType = "";
+				}
+				logger.warn("AudioContent: missing required fields during deserialization: {}",
+						String.join(", ", missing));
+			}
+			return new AudioContent(annotations, data, mimeType, meta);
+		}
+
 		// backwards compatibility constructor
+		@Deprecated
 		public AudioContent(Annotations annotations, String data, String mimeType) {
 			this(annotations, data, mimeType, null);
+		}
+
+		public static Builder builder(String data, String mimeType) {
+			return new Builder(data, mimeType);
+		}
+
+		public static class Builder {
+
+			private Annotations annotations;
+
+			private final String data;
+
+			private final String mimeType;
+
+			private Map<String, Object> meta;
+
+			private Builder(String data, String mimeType) {
+				Assert.notNull(data, "data must not be null");
+				Assert.notNull(mimeType, "mimeType must not be null");
+				this.data = data;
+				this.mimeType = mimeType;
+			}
+
+			public Builder annotations(Annotations annotations) {
+				this.annotations = annotations;
+				return this;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public AudioContent build() {
+				return new AudioContent(annotations, data, mimeType, meta);
+			}
+
 		}
 	}
 
@@ -2689,9 +4873,58 @@ public final class McpSchema {
 		@JsonProperty("resource") ResourceContents resource,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Annotated, Content { // @formatter:on
 
+		public EmbeddedResource {
+			Assert.notNull(resource, "resource must not be null");
+		}
+
+		@JsonCreator
+		static EmbeddedResource fromJson(@JsonProperty("annotations") Annotations annotations,
+				@JsonProperty("resource") ResourceContents resource, @JsonProperty("_meta") Map<String, Object> meta) {
+			if (resource == null) {
+				logger.warn(
+						"EmbeddedResource: missing required field 'resource' during deserialization, using empty text resource");
+				resource = new TextResourceContents("", null, "", null);
+			}
+			return new EmbeddedResource(annotations, resource, meta);
+		}
+
 		// backwards compatibility constructor
+		@Deprecated
 		public EmbeddedResource(Annotations annotations, ResourceContents resource) {
 			this(annotations, resource, null);
+		}
+
+		public static Builder builder(ResourceContents resource) {
+			return new Builder(resource);
+		}
+
+		public static class Builder {
+
+			private Annotations annotations;
+
+			private final ResourceContents resource;
+
+			private Map<String, Object> meta;
+
+			private Builder(ResourceContents resource) {
+				Assert.notNull(resource, "resource must not be null");
+				this.resource = resource;
+			}
+
+			public Builder annotations(Annotations annotations) {
+				this.annotations = annotations;
+				return this;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public EmbeddedResource build() {
+				return new EmbeddedResource(annotations, resource, meta);
+			}
+
 		}
 	}
 
@@ -2818,8 +5051,55 @@ public final class McpSchema {
 		@JsonProperty("name") String name,
 		@JsonProperty("_meta") Map<String, Object> meta) { // @formatter:on
 
+		public Root {
+			Assert.notNull(uri, "uri must not be null");
+		}
+
+		@JsonCreator
+		static Root fromJson(@JsonProperty("uri") String uri, @JsonProperty("name") String name,
+				@JsonProperty("_meta") Map<String, Object> meta) {
+			if (uri == null) {
+				logger.warn("Root: missing required field 'uri' during deserialization, using default ''");
+				uri = "";
+			}
+			return new Root(uri, name, meta);
+		}
+
 		public Root(String uri, String name) {
 			this(uri, name, null);
+		}
+
+		public static Builder builder(String uri) {
+			return new Builder(uri);
+		}
+
+		public static class Builder {
+
+			private final String uri;
+
+			private String name;
+
+			private Map<String, Object> meta;
+
+			private Builder(String uri) {
+				Assert.hasText(uri, "uri must not be empty");
+				this.uri = uri;
+			}
+
+			public Builder name(String name) {
+				this.name = name;
+				return this;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public Root build() {
+				return new Root(uri, name, meta);
+			}
+
 		}
 	}
 
@@ -2842,12 +5122,61 @@ public final class McpSchema {
 		@JsonProperty("nextCursor") String nextCursor,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Result { // @formatter:on
 
-		public ListRootsResult(List<Root> roots) {
-			this(roots, null);
+		public ListRootsResult {
+			Assert.notNull(roots, "roots must not be null");
 		}
 
+		@JsonCreator
+		static ListRootsResult fromJson(@JsonProperty("roots") List<Root> roots,
+				@JsonProperty("nextCursor") String nextCursor, @JsonProperty("_meta") Map<String, Object> meta) {
+			if (roots == null) {
+				logger.warn("ListRootsResult: missing required field 'roots' during deserialization, using default []");
+				roots = List.of();
+			}
+			return new ListRootsResult(roots, nextCursor, meta);
+		}
+
+		@Deprecated
+		public ListRootsResult(List<Root> roots) {
+			this(roots, null, null);
+		}
+
+		@Deprecated
 		public ListRootsResult(List<Root> roots, String nextCursor) {
 			this(roots, nextCursor, null);
+		}
+
+		public static Builder builder(List<Root> roots) {
+			return new Builder(roots);
+		}
+
+		public static class Builder {
+
+			private final List<Root> roots;
+
+			private String nextCursor;
+
+			private Map<String, Object> meta;
+
+			private Builder(List<Root> roots) {
+				Assert.notNull(roots, "roots must not be null");
+				this.roots = roots;
+			}
+
+			public Builder nextCursor(String nextCursor) {
+				this.nextCursor = nextCursor;
+				return this;
+			}
+
+			public Builder meta(Map<String, Object> meta) {
+				this.meta = meta;
+				return this;
+			}
+
+			public ListRootsResult build() {
+				return new ListRootsResult(roots, nextCursor, meta);
+			}
+
 		}
 	}
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
@@ -153,8 +153,7 @@ public class McpServerSession implements McpLoggableSession {
 
 		return Mono.<McpSchema.JSONRPCResponse>create(sink -> {
 			this.pendingResponses.put(requestId, sink);
-			McpSchema.JSONRPCRequest jsonrpcRequest = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, method,
-					requestId, requestParams);
+			McpSchema.JSONRPCRequest jsonrpcRequest = new McpSchema.JSONRPCRequest(method, requestId, requestParams);
 			this.transport.sendMessage(jsonrpcRequest).subscribe(v -> {
 			}, error -> {
 				this.pendingResponses.remove(requestId);
@@ -177,8 +176,7 @@ public class McpServerSession implements McpLoggableSession {
 
 	@Override
 	public Mono<Void> sendNotification(String method, Object params) {
-		McpSchema.JSONRPCNotification jsonrpcNotification = new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION,
-				method, params);
+		McpSchema.JSONRPCNotification jsonrpcNotification = new McpSchema.JSONRPCNotification(method, params);
 		return this.transport.sendMessage(jsonrpcNotification);
 	}
 
@@ -223,8 +221,7 @@ public class McpServerSession implements McpLoggableSession {
 							&& mcpError.getJsonRpcError() != null) ? mcpError.getJsonRpcError()
 									: new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INTERNAL_ERROR,
 											error.getMessage(), McpError.aggregateExceptionMessages(error));
-					var errorResponse = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), null,
-							jsonRpcError);
+					var errorResponse = McpSchema.JSONRPCResponse.error(request.id(), jsonRpcError);
 					// TODO: Should the error go to SSE or back as POST return?
 					return this.transport.sendMessage(errorResponse).then(Mono.empty());
 				}).flatMap(this.transport::sendMessage);
@@ -270,24 +267,21 @@ public class McpServerSession implements McpLoggableSession {
 				var handler = this.requestHandlers.get(request.method());
 				if (handler == null) {
 					MethodNotFoundError error = getMethodNotFoundError(request.method());
-					return Mono.just(new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), null,
-							new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.METHOD_NOT_FOUND,
-									error.message(), error.data())));
+					return Mono
+						.just(McpSchema.JSONRPCResponse.error(request.id(), new McpSchema.JSONRPCResponse.JSONRPCError(
+								McpSchema.ErrorCodes.METHOD_NOT_FOUND, error.message(), error.data())));
 				}
 
 				resultMono = this.exchangeSink.asMono()
 					.flatMap(exchange -> handler.handle(copyExchange(exchange, transportContext), request.params()));
 			}
-			return resultMono
-				.map(result -> new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), result, null))
+			return resultMono.map(result -> McpSchema.JSONRPCResponse.result(request.id(), result))
 				.onErrorResume(error -> {
 					McpSchema.JSONRPCResponse.JSONRPCError jsonRpcError = (error instanceof McpError mcpError
 							&& mcpError.getJsonRpcError() != null) ? mcpError.getJsonRpcError()
-									// TODO: add error message through the data field
 									: new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INTERNAL_ERROR,
 											error.getMessage(), McpError.aggregateExceptionMessages(error));
-					return Mono.just(
-							new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), null, jsonRpcError));
+					return Mono.just(McpSchema.JSONRPCResponse.error(request.id(), jsonRpcError));
 				});
 		});
 	}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpStreamableServerSession.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpStreamableServerSession.java
@@ -190,24 +190,21 @@ public class McpStreamableServerSession implements McpLoggableSession {
 			// (sink)
 			if (requestHandler == null) {
 				MethodNotFoundError error = getMethodNotFoundError(jsonrpcRequest.method());
-				return transport
-					.sendMessage(new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, jsonrpcRequest.id(), null,
-							new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.METHOD_NOT_FOUND,
-									error.message(), error.data())));
+				return transport.sendMessage(
+						McpSchema.JSONRPCResponse.error(jsonrpcRequest.id(), new McpSchema.JSONRPCResponse.JSONRPCError(
+								McpSchema.ErrorCodes.METHOD_NOT_FOUND, error.message(), error.data())));
 			}
 			return requestHandler
 				.handle(new McpAsyncServerExchange(this.id, stream, clientCapabilities.get(), clientInfo.get(),
 						transportContext), jsonrpcRequest.params())
-				.map(result -> new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, jsonrpcRequest.id(), result,
-						null))
+				.map(result -> McpSchema.JSONRPCResponse.result(jsonrpcRequest.id(), result))
 				.onErrorResume(e -> {
 					McpSchema.JSONRPCResponse.JSONRPCError jsonRpcError = (e instanceof McpError mcpError
 							&& mcpError.getJsonRpcError() != null) ? mcpError.getJsonRpcError()
 									: new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INTERNAL_ERROR,
 											e.getMessage(), McpError.aggregateExceptionMessages(e));
 
-					var errorResponse = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, jsonrpcRequest.id(),
-							null, jsonRpcError);
+					var errorResponse = McpSchema.JSONRPCResponse.error(jsonrpcRequest.id(), jsonRpcError);
 					return Mono.just(errorResponse);
 				})
 				.flatMap(transport::sendMessage)
@@ -381,8 +378,8 @@ public class McpStreamableServerSession implements McpLoggableSession {
 
 			return Mono.<McpSchema.JSONRPCResponse>create(sink -> {
 				this.pendingResponses.put(requestId, sink);
-				McpSchema.JSONRPCRequest jsonrpcRequest = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION,
-						method, requestId, requestParams);
+				McpSchema.JSONRPCRequest jsonrpcRequest = new McpSchema.JSONRPCRequest(method, requestId,
+						requestParams);
 				String messageId = this.uuidGenerator.get();
 				// TODO: store message in history
 				this.transport.sendMessage(jsonrpcRequest, messageId).subscribe(v -> {
@@ -407,8 +404,7 @@ public class McpStreamableServerSession implements McpLoggableSession {
 
 		@Override
 		public Mono<Void> sendNotification(String method, Object params) {
-			McpSchema.JSONRPCNotification jsonrpcNotification = new McpSchema.JSONRPCNotification(
-					McpSchema.JSONRPC_VERSION, method, params);
+			McpSchema.JSONRPCNotification jsonrpcNotification = new McpSchema.JSONRPCNotification(method, params);
 			String messageId = this.uuidGenerator.get();
 			// TODO: store message in history
 			return this.transport.sendMessage(jsonrpcNotification, messageId);

--- a/mcp-core/src/main/java/io/modelcontextprotocol/util/ToolInputValidator.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/util/ToolInputValidator.java
@@ -36,7 +36,7 @@ public final class ToolInputValidator {
 	 */
 	public static CallToolResult validate(McpSchema.Tool tool, Map<String, Object> arguments,
 			boolean validateToolInputs, JsonSchemaValidator validator) {
-		if (!validateToolInputs || tool.inputSchema() == null || validator == null) {
+		if (!validateToolInputs || tool.inputSchema() == null || tool.inputSchema().isEmpty() || validator == null) {
 			return null;
 		}
 		Map<String, Object> args = arguments != null ? arguments : Map.of();
@@ -44,7 +44,7 @@ public final class ToolInputValidator {
 		if (!validation.valid()) {
 			logger.warn("Tool '{}' input validation failed: {}", tool.name(), validation.errorMessage());
 			return CallToolResult.builder()
-				.content(List.of(new McpSchema.TextContent(validation.errorMessage())))
+				.content(List.of(McpSchema.TextContent.builder(validation.errorMessage()).build()))
 				.isError(true)
 				.build();
 		}

--- a/mcp-core/src/test/java/io/modelcontextprotocol/client/LifecycleInitializerPostInitializationHookTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/client/LifecycleInitializerPostInitializationHookTests.java
@@ -43,13 +43,16 @@ class LifecycleInitializerPostInitializationHookTests {
 	private static final McpSchema.ClientCapabilities CLIENT_CAPABILITIES = McpSchema.ClientCapabilities.builder()
 		.build();
 
-	private static final McpSchema.Implementation CLIENT_INFO = new McpSchema.Implementation("test-client", "1.0.0");
+	private static final McpSchema.Implementation CLIENT_INFO = McpSchema.Implementation.builder("test-client", "1.0.0")
+		.build();
 
 	private static final List<String> PROTOCOL_VERSIONS = List.of("1.0.0", "2.0.0");
 
-	private static final McpSchema.InitializeResult MOCK_INIT_RESULT = new McpSchema.InitializeResult("2.0.0",
-			McpSchema.ServerCapabilities.builder().build(), new McpSchema.Implementation("test-server", "1.0.0"),
-			"Test instructions");
+	private static final McpSchema.InitializeResult MOCK_INIT_RESULT = McpSchema.InitializeResult
+		.builder("2.0.0", McpSchema.ServerCapabilities.builder().build(),
+				McpSchema.Implementation.builder("test-server", "1.0.0").build())
+		.instructions("Test instructions")
+		.build();
 
 	@Mock
 	private McpClientSession mockClientSession;

--- a/mcp-core/src/test/java/io/modelcontextprotocol/client/LifecycleInitializerTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/client/LifecycleInitializerTests.java
@@ -44,13 +44,16 @@ class LifecycleInitializerTests {
 	private static final McpSchema.ClientCapabilities CLIENT_CAPABILITIES = McpSchema.ClientCapabilities.builder()
 		.build();
 
-	private static final McpSchema.Implementation CLIENT_INFO = new McpSchema.Implementation("test-client", "1.0.0");
+	private static final McpSchema.Implementation CLIENT_INFO = McpSchema.Implementation.builder("test-client", "1.0.0")
+		.build();
 
 	private static final List<String> PROTOCOL_VERSIONS = List.of("1.0.0", "2.0.0");
 
-	private static final McpSchema.InitializeResult MOCK_INIT_RESULT = new McpSchema.InitializeResult("2.0.0",
-			McpSchema.ServerCapabilities.builder().build(), new McpSchema.Implementation("test-server", "1.0.0"),
-			"Test instructions");
+	private static final McpSchema.InitializeResult MOCK_INIT_RESULT = McpSchema.InitializeResult
+		.builder("2.0.0", McpSchema.ServerCapabilities.builder().build(),
+				McpSchema.Implementation.builder("test-server", "1.0.0").build())
+		.instructions("Test instructions")
+		.build();
 
 	@Mock
 	private McpClientSession mockClientSession;
@@ -148,10 +151,12 @@ class LifecycleInitializerTests {
 
 	@Test
 	void shouldFailForUnsupportedProtocolVersion() {
-		McpSchema.InitializeResult unsupportedResult = new McpSchema.InitializeResult("999.0.0", // Unsupported
-																									// version
-				McpSchema.ServerCapabilities.builder().build(), new McpSchema.Implementation("test-server", "1.0.0"),
-				"Test instructions");
+		McpSchema.InitializeResult unsupportedResult = McpSchema.InitializeResult.builder("999.0.0", // Unsupported
+																										// version
+				McpSchema.ServerCapabilities.builder().build(),
+				McpSchema.Implementation.builder("test-server", "1.0.0").build())
+			.instructions("Test instructions")
+			.build();
 
 		when(mockClientSession.sendRequest(eq(McpSchema.METHOD_INITIALIZE), any(), any()))
 			.thenReturn(Mono.just(unsupportedResult));
@@ -342,8 +347,11 @@ class LifecycleInitializerTests {
 
 		when(mockClientSession.sendRequest(eq(McpSchema.METHOD_INITIALIZE), any(), any())).thenAnswer(invocation -> {
 			capturedRequest.set((McpSchema.InitializeRequest) invocation.getArgument(1));
-			return Mono.just(new McpSchema.InitializeResult("4.0.0", McpSchema.ServerCapabilities.builder().build(),
-					new McpSchema.Implementation("test-server", "1.0.0"), "Test instructions"));
+			return Mono.just(McpSchema.InitializeResult
+				.builder("4.0.0", McpSchema.ServerCapabilities.builder().build(),
+						McpSchema.Implementation.builder("test-server", "1.0.0").build())
+				.instructions("Test instructions")
+				.build());
 		});
 
 		StepVerifier.create(initializer.withInitialization("test", init -> Mono.just(init.initializeResult())))

--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/AsyncToolSpecificationBuilderTest.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/AsyncToolSpecificationBuilderTest.java
@@ -42,16 +42,15 @@ class AsyncToolSpecificationBuilderTest {
 	@Test
 	void builderShouldCreateValidAsyncToolSpecification() {
 
-		Tool tool = McpSchema.Tool.builder()
-			.name("test-tool")
-			.title("A test tool")
-			.inputSchema(EMPTY_JSON_SCHEMA)
-			.build();
+		Tool tool = McpSchema.Tool.builder("test-tool", EMPTY_JSON_SCHEMA).title("A test tool").build();
 
 		McpServerFeatures.AsyncToolSpecification specification = McpServerFeatures.AsyncToolSpecification.builder()
 			.tool(tool)
-			.callHandler((exchange, request) -> Mono
-				.just(CallToolResult.builder().content(List.of(new TextContent("Test result"))).isError(false).build()))
+			.callHandler((exchange,
+					request) -> Mono.just(CallToolResult.builder()
+						.content(List.of(TextContent.builder("Test result").build()))
+						.isError(false)
+						.build()))
 			.build();
 
 		assertThat(specification).isNotNull();
@@ -69,11 +68,7 @@ class AsyncToolSpecificationBuilderTest {
 
 	@Test
 	void builderShouldThrowExceptionWhenCallToolIsNull() {
-		Tool tool = McpSchema.Tool.builder()
-			.name("test-tool")
-			.title("A test tool")
-			.inputSchema(EMPTY_JSON_SCHEMA)
-			.build();
+		Tool tool = McpSchema.Tool.builder("test-tool", EMPTY_JSON_SCHEMA).title("A test tool").build();
 
 		assertThatThrownBy(() -> McpServerFeatures.AsyncToolSpecification.builder().tool(tool).build())
 			.isInstanceOf(IllegalArgumentException.class)
@@ -82,11 +77,7 @@ class AsyncToolSpecificationBuilderTest {
 
 	@Test
 	void builderShouldAllowMethodChaining() {
-		Tool tool = McpSchema.Tool.builder()
-			.name("test-tool")
-			.title("A test tool")
-			.inputSchema(EMPTY_JSON_SCHEMA)
-			.build();
+		Tool tool = McpSchema.Tool.builder("test-tool", EMPTY_JSON_SCHEMA).title("A test tool").build();
 		McpServerFeatures.AsyncToolSpecification.Builder builder = McpServerFeatures.AsyncToolSpecification.builder();
 
 		// Then - verify method chaining returns the same builder instance
@@ -98,20 +89,19 @@ class AsyncToolSpecificationBuilderTest {
 
 	@Test
 	void builtSpecificationShouldExecuteCallToolCorrectly() {
-		Tool tool = McpSchema.Tool.builder()
-			.name("calculator")
-			.title("Simple calculator")
-			.inputSchema(EMPTY_JSON_SCHEMA)
-			.build();
+		Tool tool = McpSchema.Tool.builder("calculator", EMPTY_JSON_SCHEMA).title("Simple calculator").build();
 		String expectedResult = "42";
 
 		McpServerFeatures.AsyncToolSpecification specification = McpServerFeatures.AsyncToolSpecification.builder()
 			.tool(tool)
-			.callHandler((exchange, request) -> Mono.just(
-					CallToolResult.builder().content(List.of(new TextContent(expectedResult))).isError(false).build()))
+			.callHandler((exchange,
+					request) -> Mono.just(CallToolResult.builder()
+						.content(List.of(TextContent.builder(expectedResult).build()))
+						.isError(false)
+						.build()))
 			.build();
 
-		CallToolRequest request = new CallToolRequest("calculator", Map.of());
+		CallToolRequest request = CallToolRequest.builder("calculator").build();
 		Mono<CallToolResult> resultMono = specification.callHandler().apply(null, request);
 
 		StepVerifier.create(resultMono).assertNext(result -> {
@@ -125,18 +115,14 @@ class AsyncToolSpecificationBuilderTest {
 
 	@Test
 	void fromSyncShouldConvertSyncToolSpecificationCorrectly() {
-		Tool tool = McpSchema.Tool.builder()
-			.name("sync-tool")
-			.title("A sync tool")
-			.inputSchema(EMPTY_JSON_SCHEMA)
-			.build();
+		Tool tool = McpSchema.Tool.builder("sync-tool", EMPTY_JSON_SCHEMA).title("A sync tool").build();
 		String expectedResult = "sync result";
 
 		// Create a sync tool specification
 		McpServerFeatures.SyncToolSpecification syncSpec = McpServerFeatures.SyncToolSpecification.builder()
 			.tool(tool)
 			.callHandler((exchange, request) -> CallToolResult.builder()
-				.content(List.of(new TextContent(expectedResult)))
+				.content(List.of(TextContent.builder(expectedResult).build()))
 				.isError(false)
 				.build())
 			.build();
@@ -150,7 +136,7 @@ class AsyncToolSpecificationBuilderTest {
 		assertThat(asyncSpec.callHandler()).isNotNull();
 
 		// Test that the converted async specification works correctly
-		CallToolRequest request = new CallToolRequest("sync-tool", Map.of("param", "value"));
+		CallToolRequest request = CallToolRequest.builder("sync-tool").arguments(Map.of("param", "value")).build();
 		Mono<CallToolResult> resultMono = asyncSpec.callHandler().apply(null, request);
 
 		StepVerifier.create(resultMono).assertNext(result -> {
@@ -193,7 +179,7 @@ class AsyncToolSpecificationBuilderTest {
 
 		@Test
 		void defaultShouldThrowOnInvalidName() {
-			Tool invalidTool = Tool.builder().name("invalid tool name").build();
+			Tool invalidTool = Tool.builder("invalid tool name", EMPTY_JSON_SCHEMA).build();
 
 			assertThatThrownBy(
 					() -> McpServer.async(transportProvider).toolCall(invalidTool, (exchange, request) -> null))
@@ -204,7 +190,7 @@ class AsyncToolSpecificationBuilderTest {
 		@Test
 		void lenientDefaultShouldLogOnInvalidName() {
 			System.setProperty(ToolNameValidator.STRICT_VALIDATION_PROPERTY, "false");
-			Tool invalidTool = Tool.builder().name("invalid tool name").build();
+			Tool invalidTool = Tool.builder("invalid tool name", EMPTY_JSON_SCHEMA).build();
 
 			assertThatCode(() -> McpServer.async(transportProvider).toolCall(invalidTool, (exchange, request) -> null))
 				.doesNotThrowAnyException();
@@ -213,7 +199,7 @@ class AsyncToolSpecificationBuilderTest {
 
 		@Test
 		void lenientConfigurationShouldLogOnInvalidName() {
-			Tool invalidTool = Tool.builder().name("invalid tool name").build();
+			Tool invalidTool = Tool.builder("invalid tool name", EMPTY_JSON_SCHEMA).build();
 
 			assertThatCode(() -> McpServer.async(transportProvider)
 				.strictToolNameValidation(false)
@@ -224,7 +210,7 @@ class AsyncToolSpecificationBuilderTest {
 		@Test
 		void serverConfigurationShouldOverrideDefault() {
 			System.setProperty(ToolNameValidator.STRICT_VALIDATION_PROPERTY, "false");
-			Tool invalidTool = Tool.builder().name("invalid tool name").build();
+			Tool invalidTool = Tool.builder("invalid tool name", EMPTY_JSON_SCHEMA).build();
 
 			assertThatThrownBy(() -> McpServer.async(transportProvider)
 				.strictToolNameValidation(true)

--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/McpAsyncServerExchangeTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/McpAsyncServerExchangeTests.java
@@ -52,7 +52,7 @@ class McpAsyncServerExchangeTests {
 
 		clientCapabilities = McpSchema.ClientCapabilities.builder().roots(true).build();
 
-		clientInfo = new McpSchema.Implementation("test-client", "1.0.0");
+		clientInfo = McpSchema.Implementation.builder("test-client", "1.0.0").build();
 
 		exchange = new McpAsyncServerExchange("testSessionId", mockSession, clientCapabilities, clientInfo,
 				McpTransportContext.EMPTY);
@@ -61,9 +61,10 @@ class McpAsyncServerExchangeTests {
 	@Test
 	void testListRootsWithSinglePage() {
 
-		List<McpSchema.Root> roots = Arrays.asList(new McpSchema.Root("file:///home/user/project1", "Project 1"),
-				new McpSchema.Root("file:///home/user/project2", "Project 2"));
-		McpSchema.ListRootsResult singlePageResult = new McpSchema.ListRootsResult(roots, null);
+		List<McpSchema.Root> roots = Arrays.asList(
+				McpSchema.Root.builder("file:///home/user/project1").name("Project 1").build(),
+				McpSchema.Root.builder("file:///home/user/project2").name("Project 2").build());
+		McpSchema.ListRootsResult singlePageResult = McpSchema.ListRootsResult.builder(roots).build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(McpSchema.PaginatedRequest.class),
 				any(TypeRef.class)))
@@ -78,7 +79,7 @@ class McpAsyncServerExchangeTests {
 			assertThat(result.nextCursor()).isNull();
 
 			// Verify that the returned list is unmodifiable
-			assertThatThrownBy(() -> result.roots().add(new McpSchema.Root("file:///test", "Test")))
+			assertThatThrownBy(() -> result.roots().add(McpSchema.Root.builder("file:///test").name("Test").build()))
 				.isInstanceOf(UnsupportedOperationException.class);
 		}).verifyComplete();
 	}
@@ -86,14 +87,18 @@ class McpAsyncServerExchangeTests {
 	@Test
 	void testListRootsWithMultiplePages() {
 
-		List<McpSchema.Root> page1Roots = Arrays.asList(new McpSchema.Root("file:///home/user/project1", "Project 1"),
-				new McpSchema.Root("file:///home/user/project2", "Project 2"));
-		List<McpSchema.Root> page2Roots = Arrays.asList(new McpSchema.Root("file:///home/user/project3", "Project 3"));
+		List<McpSchema.Root> page1Roots = Arrays.asList(
+				McpSchema.Root.builder("file:///home/user/project1").name("Project 1").build(),
+				McpSchema.Root.builder("file:///home/user/project2").name("Project 2").build());
+		List<McpSchema.Root> page2Roots = Arrays
+			.asList(McpSchema.Root.builder("file:///home/user/project3").name("Project 3").build());
 
-		McpSchema.ListRootsResult page1Result = new McpSchema.ListRootsResult(page1Roots, "cursor1");
-		McpSchema.ListRootsResult page2Result = new McpSchema.ListRootsResult(page2Roots, null);
+		McpSchema.ListRootsResult page1Result = McpSchema.ListRootsResult.builder(page1Roots)
+			.nextCursor("cursor1")
+			.build();
+		McpSchema.ListRootsResult page2Result = McpSchema.ListRootsResult.builder(page2Roots).build();
 
-		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), eq(new McpSchema.PaginatedRequest(null)),
+		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), eq(new McpSchema.PaginatedRequest()),
 				any(TypeRef.class)))
 			.thenReturn(Mono.just(page1Result));
 
@@ -109,7 +114,7 @@ class McpAsyncServerExchangeTests {
 			assertThat(result.nextCursor()).isNull();
 
 			// Verify that the returned list is unmodifiable
-			assertThatThrownBy(() -> result.roots().add(new McpSchema.Root("file:///test", "Test")))
+			assertThatThrownBy(() -> result.roots().add(McpSchema.Root.builder("file:///test").name("Test").build()))
 				.isInstanceOf(UnsupportedOperationException.class);
 		}).verifyComplete();
 	}
@@ -117,7 +122,7 @@ class McpAsyncServerExchangeTests {
 	@Test
 	void testListRootsWithEmptyResult() {
 
-		McpSchema.ListRootsResult emptyResult = new McpSchema.ListRootsResult(new ArrayList<>(), null);
+		McpSchema.ListRootsResult emptyResult = McpSchema.ListRootsResult.builder(new ArrayList<>()).build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(McpSchema.PaginatedRequest.class),
 				any(TypeRef.class)))
@@ -128,7 +133,7 @@ class McpAsyncServerExchangeTests {
 			assertThat(result.nextCursor()).isNull();
 
 			// Verify that the returned list is unmodifiable
-			assertThatThrownBy(() -> result.roots().add(new McpSchema.Root("file:///test", "Test")))
+			assertThatThrownBy(() -> result.roots().add(McpSchema.Root.builder("file:///test").name("Test").build()))
 				.isInstanceOf(UnsupportedOperationException.class);
 		}).verifyComplete();
 	}
@@ -136,8 +141,9 @@ class McpAsyncServerExchangeTests {
 	@Test
 	void testListRootsWithSpecificCursor() {
 
-		List<McpSchema.Root> roots = Arrays.asList(new McpSchema.Root("file:///home/user/project3", "Project 3"));
-		McpSchema.ListRootsResult result = new McpSchema.ListRootsResult(roots, "nextCursor");
+		List<McpSchema.Root> roots = Arrays
+			.asList(McpSchema.Root.builder("file:///home/user/project3").name("Project 3").build());
+		McpSchema.ListRootsResult result = McpSchema.ListRootsResult.builder(roots).nextCursor("nextCursor").build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), eq(new McpSchema.PaginatedRequest("someCursor")),
 				any(TypeRef.class)))
@@ -167,12 +173,14 @@ class McpAsyncServerExchangeTests {
 	void testListRootsUnmodifiabilityAfterAccumulation() {
 
 		List<McpSchema.Root> page1Roots = new ArrayList<>(
-				Arrays.asList(new McpSchema.Root("file:///home/user/project1", "Project 1")));
+				Arrays.asList(McpSchema.Root.builder("file:///home/user/project1").name("Project 1").build()));
 		List<McpSchema.Root> page2Roots = new ArrayList<>(
-				Arrays.asList(new McpSchema.Root("file:///home/user/project2", "Project 2")));
+				Arrays.asList(McpSchema.Root.builder("file:///home/user/project2").name("Project 2").build()));
 
-		McpSchema.ListRootsResult page1Result = new McpSchema.ListRootsResult(page1Roots, "cursor1");
-		McpSchema.ListRootsResult page2Result = new McpSchema.ListRootsResult(page2Roots, null);
+		McpSchema.ListRootsResult page1Result = McpSchema.ListRootsResult.builder(page1Roots)
+			.nextCursor("cursor1")
+			.build();
+		McpSchema.ListRootsResult page2Result = McpSchema.ListRootsResult.builder(page2Roots).build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), eq(new McpSchema.PaginatedRequest(null)),
 				any(TypeRef.class)))
@@ -187,7 +195,7 @@ class McpAsyncServerExchangeTests {
 			assertThat(result.roots()).hasSize(2);
 
 			// Verify that the returned list is unmodifiable
-			assertThatThrownBy(() -> result.roots().add(new McpSchema.Root("file:///test", "Test")))
+			assertThatThrownBy(() -> result.roots().add(McpSchema.Root.builder("file:///test").name("Test").build()))
 				.isInstanceOf(UnsupportedOperationException.class);
 
 			// Verify that clear() also throws UnsupportedOperationException
@@ -227,10 +235,9 @@ class McpAsyncServerExchangeTests {
 
 	@Test
 	void testLoggingNotificationWithAllowedLevel() {
-		McpSchema.LoggingMessageNotification notification = McpSchema.LoggingMessageNotification.builder()
-			.level(McpSchema.LoggingLevel.ERROR)
+		McpSchema.LoggingMessageNotification notification = McpSchema.LoggingMessageNotification
+			.builder(McpSchema.LoggingLevel.ERROR, "Test error message")
 			.logger("test-logger")
-			.data("Test error message")
 			.build();
 
 		when(mockSession.isNotificationForLevelAllowed(any())).thenReturn(Boolean.TRUE);
@@ -248,10 +255,9 @@ class McpAsyncServerExchangeTests {
 		exchange.setMinLoggingLevel(McpSchema.LoggingLevel.DEBUG);
 		verify(mockSession, times(1)).setMinLoggingLevel(eq(McpSchema.LoggingLevel.DEBUG));
 
-		McpSchema.LoggingMessageNotification debugNotification = McpSchema.LoggingMessageNotification.builder()
-			.level(McpSchema.LoggingLevel.DEBUG)
+		McpSchema.LoggingMessageNotification debugNotification = McpSchema.LoggingMessageNotification
+			.builder(McpSchema.LoggingLevel.DEBUG, "Debug message that should be filtered")
 			.logger("test-logger")
-			.data("Debug message that should be filtered")
 			.build();
 
 		when(mockSession.isNotificationForLevelAllowed(eq(McpSchema.LoggingLevel.DEBUG))).thenReturn(Boolean.TRUE);
@@ -264,10 +270,9 @@ class McpAsyncServerExchangeTests {
 		verify(mockSession, times(1)).sendNotification(eq(McpSchema.METHOD_NOTIFICATION_MESSAGE),
 				eq(debugNotification));
 
-		McpSchema.LoggingMessageNotification warningNotification = McpSchema.LoggingMessageNotification.builder()
-			.level(McpSchema.LoggingLevel.WARNING)
+		McpSchema.LoggingMessageNotification warningNotification = McpSchema.LoggingMessageNotification
+			.builder(McpSchema.LoggingLevel.WARNING, "Debug message that should be filtered")
 			.logger("test-logger")
-			.data("Debug message that should be filtered")
 			.build();
 
 		StepVerifier.create(exchange.loggingNotification(warningNotification)).verifyComplete();
@@ -279,10 +284,9 @@ class McpAsyncServerExchangeTests {
 
 	@Test
 	void testLoggingNotificationWithSessionError() {
-		McpSchema.LoggingMessageNotification notification = McpSchema.LoggingMessageNotification.builder()
-			.level(McpSchema.LoggingLevel.ERROR)
+		McpSchema.LoggingMessageNotification notification = McpSchema.LoggingMessageNotification
+			.builder(McpSchema.LoggingLevel.ERROR, "Test error message")
 			.logger("test-logger")
-			.data("Test error message")
 			.build();
 
 		when(mockSession.isNotificationForLevelAllowed(any())).thenReturn(Boolean.TRUE);
@@ -304,8 +308,8 @@ class McpAsyncServerExchangeTests {
 		McpAsyncServerExchange exchangeWithNullCapabilities = new McpAsyncServerExchange("testSessionId", mockSession,
 				null, clientInfo, McpTransportContext.EMPTY);
 
-		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest.builder()
-			.message("Please provide your name")
+		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest
+			.builder("Please provide your name", Map.of("type", "object"))
 			.build();
 
 		StepVerifier.create(exchangeWithNullCapabilities.createElicitation(elicitRequest))
@@ -328,8 +332,8 @@ class McpAsyncServerExchangeTests {
 		McpAsyncServerExchange exchangeWithoutElicitation = new McpAsyncServerExchange("testSessionId", mockSession,
 				capabilitiesWithoutElicitation, clientInfo, McpTransportContext.EMPTY);
 
-		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest.builder()
-			.message("Please provide your name")
+		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest
+			.builder("Please provide your name", Map.of("type", "object"))
 			.build();
 
 		StepVerifier.create(exchangeWithoutElicitation.createElicitation(elicitRequest)).verifyErrorSatisfies(error -> {
@@ -359,17 +363,15 @@ class McpAsyncServerExchangeTests {
 				java.util.Map.of("type", "number")));
 		requestedSchema.put("required", java.util.List.of("name"));
 
-		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest.builder()
-			.message("Please provide your personal information")
-			.requestedSchema(requestedSchema)
+		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest
+			.builder("Please provide your personal information", requestedSchema)
 			.build();
 
 		java.util.Map<String, Object> responseContent = new java.util.HashMap<>();
 		responseContent.put("name", "John Doe");
 		responseContent.put("age", 30);
 
-		McpSchema.ElicitResult expectedResult = McpSchema.ElicitResult.builder()
-			.message(McpSchema.ElicitResult.Action.ACCEPT)
+		McpSchema.ElicitResult expectedResult = McpSchema.ElicitResult.builder(McpSchema.ElicitResult.Action.ACCEPT)
 			.content(responseContent)
 			.build();
 
@@ -395,12 +397,11 @@ class McpAsyncServerExchangeTests {
 		McpAsyncServerExchange exchangeWithElicitation = new McpAsyncServerExchange("testSessionId", mockSession,
 				capabilitiesWithElicitation, clientInfo, McpTransportContext.EMPTY);
 
-		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest.builder()
-			.message("Please provide sensitive information")
+		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest
+			.builder("Please provide sensitive information", Map.of("type", "object"))
 			.build();
 
-		McpSchema.ElicitResult expectedResult = McpSchema.ElicitResult.builder()
-			.message(McpSchema.ElicitResult.Action.DECLINE)
+		McpSchema.ElicitResult expectedResult = McpSchema.ElicitResult.builder(McpSchema.ElicitResult.Action.DECLINE)
 			.build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), eq(elicitRequest), any(TypeRef.class)))
@@ -422,12 +423,11 @@ class McpAsyncServerExchangeTests {
 		McpAsyncServerExchange exchangeWithElicitation = new McpAsyncServerExchange("testSessionId", mockSession,
 				capabilitiesWithElicitation, clientInfo, McpTransportContext.EMPTY);
 
-		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest.builder()
-			.message("Please provide your information")
+		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest
+			.builder("Please provide your information", Map.of("type", "object"))
 			.build();
 
-		McpSchema.ElicitResult expectedResult = McpSchema.ElicitResult.builder()
-			.message(McpSchema.ElicitResult.Action.CANCEL)
+		McpSchema.ElicitResult expectedResult = McpSchema.ElicitResult.builder(McpSchema.ElicitResult.Action.CANCEL)
 			.build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), eq(elicitRequest), any(TypeRef.class)))
@@ -449,8 +449,8 @@ class McpAsyncServerExchangeTests {
 		McpAsyncServerExchange exchangeWithElicitation = new McpAsyncServerExchange("testSessionId", mockSession,
 				capabilitiesWithElicitation, clientInfo, McpTransportContext.EMPTY);
 
-		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest.builder()
-			.message("Please provide your name")
+		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest
+			.builder("Please provide your name", Map.of("type", "object"))
 			.build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), eq(elicitRequest), any(TypeRef.class)))
@@ -471,9 +471,10 @@ class McpAsyncServerExchangeTests {
 		McpAsyncServerExchange exchangeWithNullCapabilities = new McpAsyncServerExchange("testSessionId", mockSession,
 				null, clientInfo, McpTransportContext.EMPTY);
 
-		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest.builder()
-			.messages(Arrays
-				.asList(new McpSchema.SamplingMessage(McpSchema.Role.USER, new McpSchema.TextContent("Hello, world!"))))
+		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest
+			.builder(Arrays.asList(McpSchema.SamplingMessage
+				.builder(McpSchema.Role.USER, McpSchema.TextContent.builder("Hello, world!").build())
+				.build()), 1000)
 			.build();
 
 		StepVerifier.create(exchangeWithNullCapabilities.createMessage(createMessageRequest))
@@ -497,9 +498,10 @@ class McpAsyncServerExchangeTests {
 		McpAsyncServerExchange exchangeWithoutSampling = new McpAsyncServerExchange("testSessionId", mockSession,
 				capabilitiesWithoutSampling, clientInfo, McpTransportContext.EMPTY);
 
-		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest.builder()
-			.messages(Arrays
-				.asList(new McpSchema.SamplingMessage(McpSchema.Role.USER, new McpSchema.TextContent("Hello, world!"))))
+		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest
+			.builder(Arrays.asList(McpSchema.SamplingMessage
+				.builder(McpSchema.Role.USER, McpSchema.TextContent.builder("Hello, world!").build())
+				.build()), 1000)
 			.build();
 
 		StepVerifier.create(exchangeWithoutSampling.createMessage(createMessageRequest)).verifyErrorSatisfies(error -> {
@@ -522,15 +524,15 @@ class McpAsyncServerExchangeTests {
 		McpAsyncServerExchange exchangeWithSampling = new McpAsyncServerExchange("testSessionId", mockSession,
 				capabilitiesWithSampling, clientInfo, McpTransportContext.EMPTY);
 
-		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest.builder()
-			.messages(Arrays
-				.asList(new McpSchema.SamplingMessage(McpSchema.Role.USER, new McpSchema.TextContent("Hello, world!"))))
+		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest
+			.builder(Arrays.asList(McpSchema.SamplingMessage
+				.builder(McpSchema.Role.USER, McpSchema.TextContent.builder("Hello, world!").build())
+				.build()), 1000)
 			.build();
 
-		McpSchema.CreateMessageResult expectedResult = McpSchema.CreateMessageResult.builder()
-			.role(McpSchema.Role.ASSISTANT)
-			.content(new McpSchema.TextContent("Hello! How can I help you today?"))
-			.model("gpt-4")
+		McpSchema.CreateMessageResult expectedResult = McpSchema.CreateMessageResult
+			.builder(McpSchema.Role.ASSISTANT,
+					McpSchema.TextContent.builder("Hello! How can I help you today?").build(), "gpt-4")
 			.stopReason(McpSchema.CreateMessageResult.StopReason.END_TURN)
 			.build();
 
@@ -559,16 +561,20 @@ class McpAsyncServerExchangeTests {
 				capabilitiesWithSampling, clientInfo, McpTransportContext.EMPTY);
 
 		// Create request with image content
-		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest.builder()
-			.messages(Arrays.asList(new McpSchema.SamplingMessage(McpSchema.Role.USER,
-					new McpSchema.ImageContent(null, "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD...",
-							"image/jpeg"))))
+		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest.builder(Arrays.asList(
+				McpSchema.SamplingMessage
+					.builder(McpSchema.Role.USER,
+							McpSchema.ImageContent
+								.builder("data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD...", "image/jpeg")
+								.build())
+					.build()),
+				1000)
 			.build();
 
-		McpSchema.CreateMessageResult expectedResult = McpSchema.CreateMessageResult.builder()
-			.role(McpSchema.Role.ASSISTANT)
-			.content(new McpSchema.TextContent("I can see an image. It appears to be a photograph."))
-			.model("gpt-4-vision")
+		McpSchema.CreateMessageResult expectedResult = McpSchema.CreateMessageResult
+			.builder(McpSchema.Role.ASSISTANT,
+					McpSchema.TextContent.builder("I can see an image. It appears to be a photograph.").build(),
+					"gpt-4-vision")
 			.stopReason(McpSchema.CreateMessageResult.StopReason.END_TURN)
 			.build();
 
@@ -593,9 +599,10 @@ class McpAsyncServerExchangeTests {
 		McpAsyncServerExchange exchangeWithSampling = new McpAsyncServerExchange("testSessionId", mockSession,
 				capabilitiesWithSampling, clientInfo, McpTransportContext.EMPTY);
 
-		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest.builder()
-			.messages(Arrays
-				.asList(new McpSchema.SamplingMessage(McpSchema.Role.USER, new McpSchema.TextContent("Hello"))))
+		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest.builder(Arrays.asList(
+				McpSchema.SamplingMessage.builder(McpSchema.Role.USER, McpSchema.TextContent.builder("Hello").build())
+					.build()),
+				1000)
 			.build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_SAMPLING_CREATE_MESSAGE), eq(createMessageRequest),
@@ -617,16 +624,17 @@ class McpAsyncServerExchangeTests {
 		McpAsyncServerExchange exchangeWithSampling = new McpAsyncServerExchange("testSessionId", mockSession,
 				capabilitiesWithSampling, clientInfo, McpTransportContext.EMPTY);
 
-		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest.builder()
-			.messages(Arrays.asList(new McpSchema.SamplingMessage(McpSchema.Role.USER,
-					new McpSchema.TextContent("What files are available?"))))
+		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest
+			.builder(Arrays.asList(McpSchema.SamplingMessage
+				.builder(McpSchema.Role.USER, McpSchema.TextContent.builder("What files are available?").build())
+				.build()), 1000)
 			.includeContext(McpSchema.CreateMessageRequest.ContextInclusionStrategy.ALL_SERVERS)
 			.build();
 
-		McpSchema.CreateMessageResult expectedResult = McpSchema.CreateMessageResult.builder()
-			.role(McpSchema.Role.ASSISTANT)
-			.content(new McpSchema.TextContent("Based on the available context, I can see several files..."))
-			.model("gpt-4")
+		McpSchema.CreateMessageResult expectedResult = McpSchema.CreateMessageResult
+			.builder(McpSchema.Role.ASSISTANT,
+					McpSchema.TextContent.builder("Based on the available context, I can see several files...").build(),
+					"gpt-4")
 			.stopReason(McpSchema.CreateMessageResult.StopReason.END_TURN)
 			.build();
 

--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/McpSyncServerExchangeTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/McpSyncServerExchangeTests.java
@@ -53,7 +53,7 @@ class McpSyncServerExchangeTests {
 
 		clientCapabilities = McpSchema.ClientCapabilities.builder().roots(true).build();
 
-		clientInfo = new McpSchema.Implementation("test-client", "1.0.0");
+		clientInfo = McpSchema.Implementation.builder("test-client", "1.0.0").build();
 
 		asyncExchange = new McpAsyncServerExchange("testSessionId", mockSession, clientCapabilities, clientInfo,
 				McpTransportContext.EMPTY);
@@ -63,9 +63,10 @@ class McpSyncServerExchangeTests {
 	@Test
 	void testListRootsWithSinglePage() {
 
-		List<McpSchema.Root> roots = Arrays.asList(new McpSchema.Root("file:///home/user/project1", "Project 1"),
-				new McpSchema.Root("file:///home/user/project2", "Project 2"));
-		McpSchema.ListRootsResult singlePageResult = new McpSchema.ListRootsResult(roots, null);
+		List<McpSchema.Root> roots = Arrays.asList(
+				McpSchema.Root.builder("file:///home/user/project1").name("Project 1").build(),
+				McpSchema.Root.builder("file:///home/user/project2").name("Project 2").build());
+		McpSchema.ListRootsResult singlePageResult = McpSchema.ListRootsResult.builder(roots).build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(McpSchema.PaginatedRequest.class),
 				any(TypeRef.class)))
@@ -81,19 +82,23 @@ class McpSyncServerExchangeTests {
 		assertThat(result.nextCursor()).isNull();
 
 		// Verify that the returned list is unmodifiable
-		assertThatThrownBy(() -> result.roots().add(new McpSchema.Root("file:///test", "Test")))
+		assertThatThrownBy(() -> result.roots().add(McpSchema.Root.builder("file:///test").name("Test").build()))
 			.isInstanceOf(UnsupportedOperationException.class);
 	}
 
 	@Test
 	void testListRootsWithMultiplePages() {
 
-		List<McpSchema.Root> page1Roots = Arrays.asList(new McpSchema.Root("file:///home/user/project1", "Project 1"),
-				new McpSchema.Root("file:///home/user/project2", "Project 2"));
-		List<McpSchema.Root> page2Roots = Arrays.asList(new McpSchema.Root("file:///home/user/project3", "Project 3"));
+		List<McpSchema.Root> page1Roots = Arrays.asList(
+				McpSchema.Root.builder("file:///home/user/project1").name("Project 1").build(),
+				McpSchema.Root.builder("file:///home/user/project2").name("Project 2").build());
+		List<McpSchema.Root> page2Roots = Arrays
+			.asList(McpSchema.Root.builder("file:///home/user/project3").name("Project 3").build());
 
-		McpSchema.ListRootsResult page1Result = new McpSchema.ListRootsResult(page1Roots, "cursor1");
-		McpSchema.ListRootsResult page2Result = new McpSchema.ListRootsResult(page2Roots, null);
+		McpSchema.ListRootsResult page1Result = McpSchema.ListRootsResult.builder(page1Roots)
+			.nextCursor("cursor1")
+			.build();
+		McpSchema.ListRootsResult page2Result = McpSchema.ListRootsResult.builder(page2Roots).build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), eq(new McpSchema.PaginatedRequest(null)),
 				any(TypeRef.class)))
@@ -112,14 +117,14 @@ class McpSyncServerExchangeTests {
 		assertThat(result.nextCursor()).isNull();
 
 		// Verify that the returned list is unmodifiable
-		assertThatThrownBy(() -> result.roots().add(new McpSchema.Root("file:///test", "Test")))
+		assertThatThrownBy(() -> result.roots().add(McpSchema.Root.builder("file:///test").name("Test").build()))
 			.isInstanceOf(UnsupportedOperationException.class);
 	}
 
 	@Test
 	void testListRootsWithEmptyResult() {
 
-		McpSchema.ListRootsResult emptyResult = new McpSchema.ListRootsResult(new ArrayList<>(), null);
+		McpSchema.ListRootsResult emptyResult = McpSchema.ListRootsResult.builder(new ArrayList<>()).build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(McpSchema.PaginatedRequest.class),
 				any(TypeRef.class)))
@@ -131,15 +136,16 @@ class McpSyncServerExchangeTests {
 		assertThat(result.nextCursor()).isNull();
 
 		// Verify that the returned list is unmodifiable
-		assertThatThrownBy(() -> result.roots().add(new McpSchema.Root("file:///test", "Test")))
+		assertThatThrownBy(() -> result.roots().add(McpSchema.Root.builder("file:///test").name("Test").build()))
 			.isInstanceOf(UnsupportedOperationException.class);
 	}
 
 	@Test
 	void testListRootsWithSpecificCursor() {
 
-		List<McpSchema.Root> roots = Arrays.asList(new McpSchema.Root("file:///home/user/project3", "Project 3"));
-		McpSchema.ListRootsResult result = new McpSchema.ListRootsResult(roots, "nextCursor");
+		List<McpSchema.Root> roots = Arrays
+			.asList(McpSchema.Root.builder("file:///home/user/project3").name("Project 3").build());
+		McpSchema.ListRootsResult result = McpSchema.ListRootsResult.builder(roots).nextCursor("nextCursor").build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), eq(new McpSchema.PaginatedRequest("someCursor")),
 				any(TypeRef.class)))
@@ -167,12 +173,14 @@ class McpSyncServerExchangeTests {
 	void testListRootsUnmodifiabilityAfterAccumulation() {
 
 		List<McpSchema.Root> page1Roots = new ArrayList<>(
-				Arrays.asList(new McpSchema.Root("file:///home/user/project1", "Project 1")));
+				Arrays.asList(McpSchema.Root.builder("file:///home/user/project1").name("Project 1").build()));
 		List<McpSchema.Root> page2Roots = new ArrayList<>(
-				Arrays.asList(new McpSchema.Root("file:///home/user/project2", "Project 2")));
+				Arrays.asList(McpSchema.Root.builder("file:///home/user/project2").name("Project 2").build()));
 
-		McpSchema.ListRootsResult page1Result = new McpSchema.ListRootsResult(page1Roots, "cursor1");
-		McpSchema.ListRootsResult page2Result = new McpSchema.ListRootsResult(page2Roots, null);
+		McpSchema.ListRootsResult page1Result = McpSchema.ListRootsResult.builder(page1Roots)
+			.nextCursor("cursor1")
+			.build();
+		McpSchema.ListRootsResult page2Result = McpSchema.ListRootsResult.builder(page2Roots).build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), eq(new McpSchema.PaginatedRequest(null)),
 				any(TypeRef.class)))
@@ -188,7 +196,7 @@ class McpSyncServerExchangeTests {
 		assertThat(result.roots()).hasSize(2);
 
 		// Verify that the returned list is unmodifiable
-		assertThatThrownBy(() -> result.roots().add(new McpSchema.Root("file:///test", "Test")))
+		assertThatThrownBy(() -> result.roots().add(McpSchema.Root.builder("file:///test").name("Test").build()))
 			.isInstanceOf(UnsupportedOperationException.class);
 
 		// Verify that clear() also throws UnsupportedOperationException
@@ -221,10 +229,9 @@ class McpSyncServerExchangeTests {
 	@Test
 	void testLoggingNotificationWithAllowedLevel() {
 
-		McpSchema.LoggingMessageNotification notification = McpSchema.LoggingMessageNotification.builder()
-			.level(McpSchema.LoggingLevel.ERROR)
+		McpSchema.LoggingMessageNotification notification = McpSchema.LoggingMessageNotification
+			.builder(McpSchema.LoggingLevel.ERROR, "Test error message")
 			.logger("test-logger")
-			.data("Test error message")
 			.build();
 
 		when(mockSession.isNotificationForLevelAllowed(any())).thenReturn(Boolean.TRUE);
@@ -243,10 +250,9 @@ class McpSyncServerExchangeTests {
 		asyncExchange.setMinLoggingLevel(McpSchema.LoggingLevel.DEBUG);
 		verify(mockSession, times(1)).setMinLoggingLevel(McpSchema.LoggingLevel.DEBUG);
 
-		McpSchema.LoggingMessageNotification debugNotification = McpSchema.LoggingMessageNotification.builder()
-			.level(McpSchema.LoggingLevel.DEBUG)
+		McpSchema.LoggingMessageNotification debugNotification = McpSchema.LoggingMessageNotification
+			.builder(McpSchema.LoggingLevel.DEBUG, "Debug message that should be filtered")
 			.logger("test-logger")
-			.data("Debug message that should be filtered")
 			.build();
 
 		when(mockSession.isNotificationForLevelAllowed(eq(McpSchema.LoggingLevel.DEBUG))).thenReturn(Boolean.TRUE);
@@ -259,10 +265,9 @@ class McpSyncServerExchangeTests {
 		verify(mockSession, times(1)).sendNotification(eq(McpSchema.METHOD_NOTIFICATION_MESSAGE),
 				eq(debugNotification));
 
-		McpSchema.LoggingMessageNotification warningNotification = McpSchema.LoggingMessageNotification.builder()
-			.level(McpSchema.LoggingLevel.WARNING)
+		McpSchema.LoggingMessageNotification warningNotification = McpSchema.LoggingMessageNotification
+			.builder(McpSchema.LoggingLevel.WARNING, "Debug message that should be filtered")
 			.logger("test-logger")
-			.data("Debug message that should be filtered")
 			.build();
 
 		exchange.loggingNotification(warningNotification);
@@ -275,10 +280,9 @@ class McpSyncServerExchangeTests {
 	@Test
 	void testLoggingNotificationWithSessionError() {
 
-		McpSchema.LoggingMessageNotification notification = McpSchema.LoggingMessageNotification.builder()
-			.level(McpSchema.LoggingLevel.ERROR)
+		McpSchema.LoggingMessageNotification notification = McpSchema.LoggingMessageNotification
+			.builder(McpSchema.LoggingLevel.ERROR, "Test error message")
 			.logger("test-logger")
-			.data("Test error message")
 			.build();
 
 		when(mockSession.isNotificationForLevelAllowed(any())).thenReturn(Boolean.TRUE);
@@ -301,8 +305,8 @@ class McpSyncServerExchangeTests {
 		McpSyncServerExchange exchangeWithNullCapabilities = new McpSyncServerExchange(
 				asyncExchangeWithNullCapabilities);
 
-		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest.builder()
-			.message("Please provide your name")
+		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest
+			.builder("Please provide your name", Map.of("type", "object"))
 			.build();
 
 		assertThatThrownBy(() -> exchangeWithNullCapabilities.createElicitation(elicitRequest))
@@ -324,8 +328,8 @@ class McpSyncServerExchangeTests {
 				mockSession, capabilitiesWithoutElicitation, clientInfo, McpTransportContext.EMPTY);
 		McpSyncServerExchange exchangeWithoutElicitation = new McpSyncServerExchange(asyncExchangeWithoutElicitation);
 
-		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest.builder()
-			.message("Please provide your name")
+		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest
+			.builder("Please provide your name", Map.of("type", "object"))
 			.build();
 
 		assertThatThrownBy(() -> exchangeWithoutElicitation.createElicitation(elicitRequest))
@@ -355,17 +359,15 @@ class McpSyncServerExchangeTests {
 				java.util.Map.of("type", "number")));
 		requestedSchema.put("required", java.util.List.of("name"));
 
-		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest.builder()
-			.message("Please provide your personal information")
-			.requestedSchema(requestedSchema)
+		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest
+			.builder("Please provide your personal information", requestedSchema)
 			.build();
 
 		java.util.Map<String, Object> responseContent = new java.util.HashMap<>();
 		responseContent.put("name", "John Doe");
 		responseContent.put("age", 30);
 
-		McpSchema.ElicitResult expectedResult = McpSchema.ElicitResult.builder()
-			.message(McpSchema.ElicitResult.Action.ACCEPT)
+		McpSchema.ElicitResult expectedResult = McpSchema.ElicitResult.builder(McpSchema.ElicitResult.Action.ACCEPT)
 			.content(responseContent)
 			.build();
 
@@ -392,12 +394,11 @@ class McpSyncServerExchangeTests {
 				capabilitiesWithElicitation, clientInfo, McpTransportContext.EMPTY);
 		McpSyncServerExchange exchangeWithElicitation = new McpSyncServerExchange(asyncExchangeWithElicitation);
 
-		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest.builder()
-			.message("Please provide sensitive information")
+		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest
+			.builder("Please provide sensitive information", Map.of("type", "object"))
 			.build();
 
-		McpSchema.ElicitResult expectedResult = McpSchema.ElicitResult.builder()
-			.message(McpSchema.ElicitResult.Action.DECLINE)
+		McpSchema.ElicitResult expectedResult = McpSchema.ElicitResult.builder(McpSchema.ElicitResult.Action.DECLINE)
 			.build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), eq(elicitRequest), any(TypeRef.class)))
@@ -420,12 +421,11 @@ class McpSyncServerExchangeTests {
 				capabilitiesWithElicitation, clientInfo, McpTransportContext.EMPTY);
 		McpSyncServerExchange exchangeWithElicitation = new McpSyncServerExchange(asyncExchangeWithElicitation);
 
-		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest.builder()
-			.message("Please provide your information")
+		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest
+			.builder("Please provide your information", Map.of("type", "object"))
 			.build();
 
-		McpSchema.ElicitResult expectedResult = McpSchema.ElicitResult.builder()
-			.message(McpSchema.ElicitResult.Action.CANCEL)
+		McpSchema.ElicitResult expectedResult = McpSchema.ElicitResult.builder(McpSchema.ElicitResult.Action.CANCEL)
 			.build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), eq(elicitRequest), any(TypeRef.class)))
@@ -448,8 +448,8 @@ class McpSyncServerExchangeTests {
 				capabilitiesWithElicitation, clientInfo, McpTransportContext.EMPTY);
 		McpSyncServerExchange exchangeWithElicitation = new McpSyncServerExchange(asyncExchangeWithElicitation);
 
-		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest.builder()
-			.message("Please provide your name")
+		McpSchema.ElicitRequest elicitRequest = McpSchema.ElicitRequest
+			.builder("Please provide your name", Map.of("type", "object"))
 			.build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ELICITATION_CREATE), eq(elicitRequest), any(TypeRef.class)))
@@ -472,9 +472,10 @@ class McpSyncServerExchangeTests {
 		McpSyncServerExchange exchangeWithNullCapabilities = new McpSyncServerExchange(
 				asyncExchangeWithNullCapabilities);
 
-		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest.builder()
-			.messages(Arrays
-				.asList(new McpSchema.SamplingMessage(McpSchema.Role.USER, new McpSchema.TextContent("Hello, world!"))))
+		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest
+			.builder(Arrays.asList(McpSchema.SamplingMessage
+				.builder(McpSchema.Role.USER, McpSchema.TextContent.builder("Hello, world!").build())
+				.build()), 1000)
 			.build();
 
 		assertThatThrownBy(() -> exchangeWithNullCapabilities.createMessage(createMessageRequest))
@@ -497,9 +498,10 @@ class McpSyncServerExchangeTests {
 				capabilitiesWithoutSampling, clientInfo, McpTransportContext.EMPTY);
 		McpSyncServerExchange exchangeWithoutSampling = new McpSyncServerExchange(asyncExchangeWithoutSampling);
 
-		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest.builder()
-			.messages(Arrays
-				.asList(new McpSchema.SamplingMessage(McpSchema.Role.USER, new McpSchema.TextContent("Hello, world!"))))
+		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest
+			.builder(Arrays.asList(McpSchema.SamplingMessage
+				.builder(McpSchema.Role.USER, McpSchema.TextContent.builder("Hello, world!").build())
+				.build()), 1000)
 			.build();
 
 		assertThatThrownBy(() -> exchangeWithoutSampling.createMessage(createMessageRequest))
@@ -522,15 +524,15 @@ class McpSyncServerExchangeTests {
 				capabilitiesWithSampling, clientInfo, McpTransportContext.EMPTY);
 		McpSyncServerExchange exchangeWithSampling = new McpSyncServerExchange(asyncExchangeWithSampling);
 
-		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest.builder()
-			.messages(Arrays
-				.asList(new McpSchema.SamplingMessage(McpSchema.Role.USER, new McpSchema.TextContent("Hello, world!"))))
+		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest
+			.builder(Arrays.asList(McpSchema.SamplingMessage
+				.builder(McpSchema.Role.USER, McpSchema.TextContent.builder("Hello, world!").build())
+				.build()), 1000)
 			.build();
 
-		McpSchema.CreateMessageResult expectedResult = McpSchema.CreateMessageResult.builder()
-			.role(McpSchema.Role.ASSISTANT)
-			.content(new McpSchema.TextContent("Hello! How can I help you today?"))
-			.model("gpt-4")
+		McpSchema.CreateMessageResult expectedResult = McpSchema.CreateMessageResult
+			.builder(McpSchema.Role.ASSISTANT,
+					McpSchema.TextContent.builder("Hello! How can I help you today?").build(), "gpt-4")
 			.stopReason(McpSchema.CreateMessageResult.StopReason.END_TURN)
 			.build();
 
@@ -560,16 +562,20 @@ class McpSyncServerExchangeTests {
 		McpSyncServerExchange exchangeWithSampling = new McpSyncServerExchange(asyncExchangeWithSampling);
 
 		// Create request with image content
-		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest.builder()
-			.messages(Arrays.asList(new McpSchema.SamplingMessage(McpSchema.Role.USER,
-					new McpSchema.ImageContent(null, "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD...",
-							"image/jpeg"))))
+		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest.builder(Arrays.asList(
+				McpSchema.SamplingMessage
+					.builder(McpSchema.Role.USER,
+							McpSchema.ImageContent
+								.builder("data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD...", "image/jpeg")
+								.build())
+					.build()),
+				1000)
 			.build();
 
-		McpSchema.CreateMessageResult expectedResult = McpSchema.CreateMessageResult.builder()
-			.role(McpSchema.Role.ASSISTANT)
-			.content(new McpSchema.TextContent("I can see an image. It appears to be a photograph."))
-			.model("gpt-4-vision")
+		McpSchema.CreateMessageResult expectedResult = McpSchema.CreateMessageResult
+			.builder(McpSchema.Role.ASSISTANT,
+					McpSchema.TextContent.builder("I can see an image. It appears to be a photograph.").build(),
+					"gpt-4-vision")
 			.stopReason(McpSchema.CreateMessageResult.StopReason.END_TURN)
 			.build();
 
@@ -595,9 +601,10 @@ class McpSyncServerExchangeTests {
 				capabilitiesWithSampling, clientInfo, McpTransportContext.EMPTY);
 		McpSyncServerExchange exchangeWithSampling = new McpSyncServerExchange(asyncExchangeWithSampling);
 
-		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest.builder()
-			.messages(Arrays
-				.asList(new McpSchema.SamplingMessage(McpSchema.Role.USER, new McpSchema.TextContent("Hello"))))
+		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest.builder(Arrays.asList(
+				McpSchema.SamplingMessage.builder(McpSchema.Role.USER, McpSchema.TextContent.builder("Hello").build())
+					.build()),
+				1000)
 			.build();
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_SAMPLING_CREATE_MESSAGE), eq(createMessageRequest),
@@ -620,16 +627,17 @@ class McpSyncServerExchangeTests {
 				capabilitiesWithSampling, clientInfo, McpTransportContext.EMPTY);
 		McpSyncServerExchange exchangeWithSampling = new McpSyncServerExchange(asyncExchangeWithSampling);
 
-		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest.builder()
-			.messages(Arrays.asList(new McpSchema.SamplingMessage(McpSchema.Role.USER,
-					new McpSchema.TextContent("What files are available?"))))
+		McpSchema.CreateMessageRequest createMessageRequest = McpSchema.CreateMessageRequest
+			.builder(Arrays.asList(McpSchema.SamplingMessage
+				.builder(McpSchema.Role.USER, McpSchema.TextContent.builder("What files are available?").build())
+				.build()), 1000)
 			.includeContext(McpSchema.CreateMessageRequest.ContextInclusionStrategy.ALL_SERVERS)
 			.build();
 
-		McpSchema.CreateMessageResult expectedResult = McpSchema.CreateMessageResult.builder()
-			.role(McpSchema.Role.ASSISTANT)
-			.content(new McpSchema.TextContent("Based on the available context, I can see several files..."))
-			.model("gpt-4")
+		McpSchema.CreateMessageResult expectedResult = McpSchema.CreateMessageResult
+			.builder(McpSchema.Role.ASSISTANT,
+					McpSchema.TextContent.builder("Based on the available context, I can see several files...").build(),
+					"gpt-4")
 			.stopReason(McpSchema.CreateMessageResult.StopReason.END_TURN)
 			.build();
 

--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/ResourceTemplateListingTest.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/ResourceTemplateListingTest.java
@@ -41,24 +41,12 @@ public class ResourceTemplateListingTest {
 	void testResourceListingWithMixedResources() {
 		// Create resource list with both regular and template resources
 		List<McpSchema.Resource> allResources = List.of(
-				McpSchema.Resource.builder()
-					.uri("file:///test/doc1.txt")
-					.name("Document 1")
+				McpSchema.Resource.builder("file:///test/doc1.txt", "Document 1").mimeType("text/plain").build(),
+				McpSchema.Resource.builder("file:///test/doc2.txt", "Document 2").mimeType("text/plain").build(),
+				McpSchema.Resource.builder("file:///test/{type}/document.txt", "Typed Document")
 					.mimeType("text/plain")
 					.build(),
-				McpSchema.Resource.builder()
-					.uri("file:///test/doc2.txt")
-					.name("Document 2")
-					.mimeType("text/plain")
-					.build(),
-				McpSchema.Resource.builder()
-					.uri("file:///test/{type}/document.txt")
-					.name("Typed Document")
-					.mimeType("text/plain")
-					.build(),
-				McpSchema.Resource.builder()
-					.uri("file:///users/{userId}/files/{fileId}")
-					.name("User File")
+				McpSchema.Resource.builder("file:///users/{userId}/files/{fileId}", "User File")
 					.mimeType("text/plain")
 					.build());
 
@@ -77,20 +65,18 @@ public class ResourceTemplateListingTest {
 	void testResourceTemplatesListedSeparately() {
 		// Create mixed resources
 		List<McpSchema.Resource> resources = List.of(
-				McpSchema.Resource.builder()
-					.uri("file:///test/regular.txt")
-					.name("Regular Resource")
+				McpSchema.Resource.builder("file:///test/regular.txt", "Regular Resource")
 					.mimeType("text/plain")
 					.build(),
-				McpSchema.Resource.builder()
-					.uri("file:///test/user/{userId}/profile.txt")
-					.name("User Profile")
+				McpSchema.Resource.builder("file:///test/user/{userId}/profile.txt", "User Profile")
 					.mimeType("text/plain")
 					.build());
 
 		// Create explicit resource template
-		McpSchema.ResourceTemplate explicitTemplate = new McpSchema.ResourceTemplate(
-				"file:///test/document/{docId}/content.txt", "Document Template", null, "text/plain", null);
+		McpSchema.ResourceTemplate explicitTemplate = McpSchema.ResourceTemplate
+			.builder("file:///test/document/{docId}/content.txt", "Document Template")
+			.mimeType("text/plain")
+			.build();
 
 		// Filter regular resources (those without template parameters)
 		List<McpSchema.Resource> regularResources = resources.stream()
@@ -100,8 +86,11 @@ public class ResourceTemplateListingTest {
 		// Extract template resources (those with template parameters)
 		List<McpSchema.ResourceTemplate> templateResources = resources.stream()
 			.filter(resource -> resource.uri().contains("{"))
-			.map(resource -> new McpSchema.ResourceTemplate(resource.uri(), resource.name(), resource.description(),
-					resource.mimeType(), resource.annotations()))
+			.map(resource -> McpSchema.ResourceTemplate.builder(resource.uri(), resource.name())
+				.description(resource.description())
+				.mimeType(resource.mimeType())
+				.annotations(resource.annotations())
+				.build())
 			.collect(Collectors.toList());
 
 		// Verify regular resources list

--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/SyncToolSpecificationBuilderTest.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/SyncToolSpecificationBuilderTest.java
@@ -39,12 +39,12 @@ class SyncToolSpecificationBuilderTest {
 	@Test
 	void builderShouldCreateValidSyncToolSpecification() {
 
-		Tool tool = Tool.builder().name("test-tool").title("A test tool").inputSchema(EMPTY_JSON_SCHEMA).build();
+		Tool tool = Tool.builder("test-tool", EMPTY_JSON_SCHEMA).title("A test tool").build();
 
 		McpServerFeatures.SyncToolSpecification specification = McpServerFeatures.SyncToolSpecification.builder()
 			.tool(tool)
 			.callHandler((exchange, request) -> CallToolResult.builder()
-				.content(List.of(new TextContent("Test result")))
+				.content(List.of(TextContent.builder("Test result").build()))
 				.isError(false)
 				.build())
 			.build();
@@ -63,7 +63,7 @@ class SyncToolSpecificationBuilderTest {
 
 	@Test
 	void builderShouldThrowExceptionWhenCallToolIsNull() {
-		Tool tool = Tool.builder().name("test-tool").description("A test tool").inputSchema(EMPTY_JSON_SCHEMA).build();
+		Tool tool = Tool.builder("test-tool", EMPTY_JSON_SCHEMA).description("A test tool").build();
 
 		assertThatThrownBy(() -> McpServerFeatures.SyncToolSpecification.builder().tool(tool).build())
 			.isInstanceOf(IllegalArgumentException.class)
@@ -72,7 +72,7 @@ class SyncToolSpecificationBuilderTest {
 
 	@Test
 	void builderShouldAllowMethodChaining() {
-		Tool tool = Tool.builder().name("test-tool").description("A test tool").inputSchema(EMPTY_JSON_SCHEMA).build();
+		Tool tool = Tool.builder("test-tool", EMPTY_JSON_SCHEMA).description("A test tool").build();
 		McpServerFeatures.SyncToolSpecification.Builder builder = McpServerFeatures.SyncToolSpecification.builder();
 
 		// Then - verify method chaining returns the same builder instance
@@ -84,11 +84,7 @@ class SyncToolSpecificationBuilderTest {
 
 	@Test
 	void builtSpecificationShouldExecuteCallToolCorrectly() {
-		Tool tool = Tool.builder()
-			.name("calculator")
-			.description("Simple calculator")
-			.inputSchema(EMPTY_JSON_SCHEMA)
-			.build();
+		Tool tool = Tool.builder("calculator", EMPTY_JSON_SCHEMA).description("Simple calculator").build();
 		String expectedResult = "42";
 
 		McpServerFeatures.SyncToolSpecification specification = McpServerFeatures.SyncToolSpecification.builder()
@@ -96,13 +92,13 @@ class SyncToolSpecificationBuilderTest {
 			.callHandler((exchange, request) -> {
 				// Simple test implementation
 				return CallToolResult.builder()
-					.content(List.of(new TextContent(expectedResult)))
+					.content(List.of(TextContent.builder(expectedResult).build()))
 					.isError(false)
 					.build();
 			})
 			.build();
 
-		CallToolRequest request = new CallToolRequest("calculator", Map.of());
+		CallToolRequest request = CallToolRequest.builder("calculator").build();
 		CallToolResult result = specification.callHandler().apply(null, request);
 
 		assertThat(result).isNotNull();
@@ -138,7 +134,7 @@ class SyncToolSpecificationBuilderTest {
 
 		@Test
 		void defaultShouldThrowOnInvalidName() {
-			Tool invalidTool = Tool.builder().name("invalid tool name").build();
+			Tool invalidTool = Tool.builder("invalid tool name", EMPTY_JSON_SCHEMA).build();
 
 			assertThatThrownBy(
 					() -> McpServer.sync(transportProvider).toolCall(invalidTool, (exchange, request) -> null))
@@ -149,7 +145,7 @@ class SyncToolSpecificationBuilderTest {
 		@Test
 		void lenientDefaultShouldLogOnInvalidName() {
 			System.setProperty(ToolNameValidator.STRICT_VALIDATION_PROPERTY, "false");
-			Tool invalidTool = Tool.builder().name("invalid tool name").build();
+			Tool invalidTool = Tool.builder("invalid tool name", EMPTY_JSON_SCHEMA).build();
 
 			assertThatCode(() -> McpServer.sync(transportProvider).toolCall(invalidTool, (exchange, request) -> null))
 				.doesNotThrowAnyException();
@@ -158,7 +154,7 @@ class SyncToolSpecificationBuilderTest {
 
 		@Test
 		void lenientConfigurationShouldLogOnInvalidName() {
-			Tool invalidTool = Tool.builder().name("invalid tool name").build();
+			Tool invalidTool = Tool.builder("invalid tool name", EMPTY_JSON_SCHEMA).build();
 
 			assertThatCode(() -> McpServer.sync(transportProvider)
 				.strictToolNameValidation(false)
@@ -169,7 +165,7 @@ class SyncToolSpecificationBuilderTest {
 		@Test
 		void serverConfigurationShouldOverrideDefault() {
 			System.setProperty(ToolNameValidator.STRICT_VALIDATION_PROPERTY, "false");
-			Tool invalidTool = Tool.builder().name("invalid tool name").build();
+			Tool invalidTool = Tool.builder("invalid tool name", EMPTY_JSON_SCHEMA).build();
 
 			assertThatThrownBy(() -> McpServer.sync(transportProvider)
 				.strictToolNameValidation(true)

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/JSONRPCRequestMcpValidationTest.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/JSONRPCRequestMcpValidationTest.java
@@ -20,7 +20,7 @@ public class JSONRPCRequestMcpValidationTest {
 	@Test
 	public void testValidStringId() {
 		assertDoesNotThrow(() -> {
-			var request = new McpSchema.JSONRPCRequest("2.0", "test/method", "string-id", null);
+			var request = new McpSchema.JSONRPCRequest("test/method", "string-id");
 			assertEquals("string-id", request.id());
 		});
 	}
@@ -28,7 +28,7 @@ public class JSONRPCRequestMcpValidationTest {
 	@Test
 	public void testValidIntegerId() {
 		assertDoesNotThrow(() -> {
-			var request = new McpSchema.JSONRPCRequest("2.0", "test/method", 123, null);
+			var request = new McpSchema.JSONRPCRequest("test/method", 123);
 			assertEquals(123, request.id());
 		});
 	}
@@ -36,7 +36,7 @@ public class JSONRPCRequestMcpValidationTest {
 	@Test
 	public void testValidLongId() {
 		assertDoesNotThrow(() -> {
-			var request = new McpSchema.JSONRPCRequest("2.0", "test/method", 123L, null);
+			var request = new McpSchema.JSONRPCRequest("test/method", 123L);
 			assertEquals(123L, request.id());
 		});
 	}
@@ -44,7 +44,7 @@ public class JSONRPCRequestMcpValidationTest {
 	@Test
 	public void testNullIdThrowsException() {
 		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-			new McpSchema.JSONRPCRequest("2.0", "test/method", null, null);
+			new McpSchema.JSONRPCRequest("test/method", null);
 		});
 
 		assertTrue(exception.getMessage().contains("MCP requests MUST include an ID"));
@@ -54,7 +54,7 @@ public class JSONRPCRequestMcpValidationTest {
 	@Test
 	public void testDoubleIdTypeThrowsException() {
 		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-			new McpSchema.JSONRPCRequest("2.0", "test/method", 123.45, null);
+			new McpSchema.JSONRPCRequest("test/method", 123.45);
 		});
 
 		assertTrue(exception.getMessage().contains("MCP requests MUST have an ID that is either a string or integer"));
@@ -63,7 +63,7 @@ public class JSONRPCRequestMcpValidationTest {
 	@Test
 	public void testBooleanIdThrowsException() {
 		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-			new McpSchema.JSONRPCRequest("2.0", "test/method", true, null);
+			new McpSchema.JSONRPCRequest("test/method", true);
 		});
 
 		assertTrue(exception.getMessage().contains("MCP requests MUST have an ID that is either a string or integer"));
@@ -72,7 +72,7 @@ public class JSONRPCRequestMcpValidationTest {
 	@Test
 	public void testArrayIdThrowsException() {
 		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-			new McpSchema.JSONRPCRequest("2.0", "test/method", new String[] { "array" }, null);
+			new McpSchema.JSONRPCRequest("test/method", new String[] { "array" });
 		});
 
 		assertTrue(exception.getMessage().contains("MCP requests MUST have an ID that is either a string or integer"));
@@ -81,7 +81,7 @@ public class JSONRPCRequestMcpValidationTest {
 	@Test
 	public void testObjectIdThrowsException() {
 		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-			new McpSchema.JSONRPCRequest("2.0", "test/method", new Object(), null);
+			new McpSchema.JSONRPCRequest("test/method", new Object());
 		});
 
 		assertTrue(exception.getMessage().contains("MCP requests MUST have an ID that is either a string or integer"));

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/McpClientSessionTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/McpClientSessionTests.java
@@ -55,8 +55,7 @@ class McpClientSessionTests {
 		// Verify response handling
 		StepVerifier.create(responseMono).then(() -> {
 			McpSchema.JSONRPCRequest request = transport.getLastSentMessageAsRequest();
-			transport.simulateIncomingMessage(
-					new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), responseData, null));
+			transport.simulateIncomingMessage(McpSchema.JSONRPCResponse.result(request.id(), responseData));
 		}).consumeNextWith(response -> {
 			// Verify the request was sent
 			McpSchema.JSONRPCMessage sentMessage = transport.getLastSentMessageAsRequest();
@@ -84,9 +83,8 @@ class McpClientSessionTests {
 			McpSchema.JSONRPCRequest request = transport.getLastSentMessageAsRequest();
 			// Simulate error response
 			McpSchema.JSONRPCResponse.JSONRPCError error = new McpSchema.JSONRPCResponse.JSONRPCError(
-					McpSchema.ErrorCodes.METHOD_NOT_FOUND, "Method not found", null);
-			transport.simulateIncomingMessage(
-					new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), null, error));
+					McpSchema.ErrorCodes.METHOD_NOT_FOUND, "Method not found");
+			transport.simulateIncomingMessage(McpSchema.JSONRPCResponse.error(request.id(), error));
 		}).expectError(McpError.class).verify();
 
 		session.close();
@@ -140,8 +138,7 @@ class McpClientSessionTests {
 		var session = new McpClientSession(TIMEOUT, transport, requestHandlers, Map.of(), Function.identity());
 
 		// Simulate incoming request
-		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, ECHO_METHOD,
-				"test-id", echoMessage);
+		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(ECHO_METHOD, "test-id", echoMessage);
 		transport.simulateIncomingMessage(request);
 
 		// Verify response
@@ -166,8 +163,8 @@ class McpClientSessionTests {
 		// Simulate incoming notification from the server
 		Map<String, Object> notificationParams = Map.of("status", "ready");
 
-		McpSchema.JSONRPCNotification notification = new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION,
-				TEST_NOTIFICATION, notificationParams);
+		McpSchema.JSONRPCNotification notification = new McpSchema.JSONRPCNotification(TEST_NOTIFICATION,
+				notificationParams);
 
 		transport.simulateIncomingMessage(notification);
 
@@ -186,8 +183,7 @@ class McpClientSessionTests {
 				Function.identity());
 
 		// Simulate incoming request for unknown method
-		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, "unknown.method",
-				"test-id", null);
+		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest("unknown.method", "test-id");
 		transport.simulateIncomingMessage(request);
 
 		// Verify error response
@@ -214,8 +210,7 @@ class McpClientSessionTests {
 				Function.identity());
 
 		// Simulate incoming request that will trigger the error
-		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, testMethod,
-				"test-id", null);
+		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(testMethod, "test-id");
 		transport.simulateIncomingMessage(request);
 
 		// Verify: The response should contain the custom error from McpError
@@ -242,8 +237,7 @@ class McpClientSessionTests {
 				Function.identity());
 
 		// Simulate incoming request that will trigger the error
-		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, testMethod,
-				"test-id", null);
+		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(testMethod, "test-id");
 		transport.simulateIncomingMessage(request);
 
 		// Verify: The response should contain INTERNAL_ERROR with aggregated exception
@@ -276,8 +270,7 @@ class McpClientSessionTests {
 				Function.identity());
 
 		// Simulate incoming request that will trigger the error
-		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, testMethod,
-				"test-id", null);
+		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(testMethod, "test-id");
 		transport.simulateIncomingMessage(request);
 
 		// Verify: The response should contain INTERNAL_ERROR with full exception chain

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/PromptReferenceEqualsTest.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/PromptReferenceEqualsTest.java
@@ -18,10 +18,8 @@ class PromptReferenceEqualsTest {
 
 	@Test
 	void testEqualsWithSameIdentifierAndType() {
-		McpSchema.PromptReference ref1 = new McpSchema.PromptReference(PromptReference.TYPE, "test-prompt",
-				"Test Title");
-		McpSchema.PromptReference ref2 = new McpSchema.PromptReference(PromptReference.TYPE, "test-prompt",
-				"Different Title");
+		McpSchema.PromptReference ref1 = PromptReference.builder("test-prompt").title("Test Title").build();
+		McpSchema.PromptReference ref2 = PromptReference.builder("test-prompt").title("Different Title").build();
 
 		assertTrue(ref1.equals(ref2), "PromptReferences with same identifier and type should be equal");
 		assertEquals(ref1.hashCode(), ref2.hashCode(), "Equal objects should have same hash code");
@@ -29,35 +27,22 @@ class PromptReferenceEqualsTest {
 
 	@Test
 	void testEqualsWithDifferentIdentifier() {
-		McpSchema.PromptReference ref1 = new McpSchema.PromptReference(PromptReference.TYPE, "test-prompt-1",
-				"Test Title");
-		McpSchema.PromptReference ref2 = new McpSchema.PromptReference(PromptReference.TYPE, "test-prompt-2",
-				"Test Title");
+		McpSchema.PromptReference ref1 = PromptReference.builder("test-prompt-1").title("Test Title").build();
+		McpSchema.PromptReference ref2 = PromptReference.builder("test-prompt-2").title("Test Title").build();
 
 		assertFalse(ref1.equals(ref2), "PromptReferences with different identifiers should not be equal");
 	}
 
 	@Test
-	void testEqualsWithDifferentType() {
-		McpSchema.PromptReference ref1 = new McpSchema.PromptReference(PromptReference.TYPE, "test-prompt",
-				"Test Title");
-		McpSchema.PromptReference ref2 = new McpSchema.PromptReference("ref/other", "test-prompt", "Test Title");
-
-		assertFalse(ref1.equals(ref2), "PromptReferences with different types should not be equal");
-	}
-
-	@Test
 	void testEqualsWithNull() {
-		McpSchema.PromptReference ref1 = new McpSchema.PromptReference(PromptReference.TYPE, "test-prompt",
-				"Test Title");
+		McpSchema.PromptReference ref1 = PromptReference.builder("test-prompt").title("Test Title").build();
 
 		assertFalse(ref1.equals(null), "PromptReference should not be equal to null");
 	}
 
 	@Test
 	void testEqualsWithDifferentClass() {
-		McpSchema.PromptReference ref1 = new McpSchema.PromptReference(PromptReference.TYPE, "test-prompt",
-				"Test Title");
+		McpSchema.PromptReference ref1 = PromptReference.builder("test-prompt").title("Test Title").build();
 		String other = "not a PromptReference";
 
 		assertFalse(ref1.equals(other), "PromptReference should not be equal to different class");
@@ -65,17 +50,16 @@ class PromptReferenceEqualsTest {
 
 	@Test
 	void testEqualsWithSameInstance() {
-		McpSchema.PromptReference ref1 = new McpSchema.PromptReference(PromptReference.TYPE, "test-prompt",
-				"Test Title");
+		McpSchema.PromptReference ref1 = PromptReference.builder("test-prompt").title("Test Title").build();
 
 		assertTrue(ref1.equals(ref1), "PromptReference should be equal to itself");
 	}
 
 	@Test
 	void testEqualsIgnoresTitle() {
-		McpSchema.PromptReference ref1 = new McpSchema.PromptReference(PromptReference.TYPE, "test-prompt", "Title 1");
-		McpSchema.PromptReference ref2 = new McpSchema.PromptReference(PromptReference.TYPE, "test-prompt", "Title 2");
-		McpSchema.PromptReference ref3 = new McpSchema.PromptReference(PromptReference.TYPE, "test-prompt", null);
+		McpSchema.PromptReference ref1 = PromptReference.builder("test-prompt").title("Title 1").build();
+		McpSchema.PromptReference ref2 = PromptReference.builder("test-prompt").title("Title 2").build();
+		McpSchema.PromptReference ref3 = new PromptReference("test-prompt");
 
 		assertTrue(ref1.equals(ref2), "PromptReferences should be equal regardless of title");
 		assertTrue(ref1.equals(ref3), "PromptReferences should be equal even when one has null title");
@@ -84,14 +68,11 @@ class PromptReferenceEqualsTest {
 
 	@Test
 	void testHashCodeConsistency() {
-		McpSchema.PromptReference ref1 = new McpSchema.PromptReference(PromptReference.TYPE, "test-prompt",
-				"Test Title");
-		McpSchema.PromptReference ref2 = new McpSchema.PromptReference(PromptReference.TYPE, "test-prompt",
-				"Different Title");
+		McpSchema.PromptReference ref1 = PromptReference.builder("test-prompt").title("Test Title").build();
+		McpSchema.PromptReference ref2 = PromptReference.builder("test-prompt").title("Different Title").build();
 
 		assertEquals(ref1.hashCode(), ref2.hashCode(), "Objects that are equal should have the same hash code");
 
-		// Call hashCode multiple times to ensure consistency
 		int hashCode1 = ref1.hashCode();
 		int hashCode2 = ref1.hashCode();
 		assertEquals(hashCode1, hashCode2, "Hash code should be consistent across multiple calls");

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/json/gson/GsonMcpJsonMapperTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/json/gson/GsonMcpJsonMapperTests.java
@@ -105,13 +105,13 @@ class GsonMcpJsonMapperTests {
 		var gsonMapper = new GsonMcpJsonMapper();
 
 		// Tool builder parsing of input/output schema strings
-		var tool = McpSchema.Tool.builder().name("echo").description("Echo tool").inputSchema(gsonMapper, """
+		var tool = McpSchema.Tool.builder("echo", gsonMapper, """
 				{
 				  "type": "object",
 				  "properties": { "x": { "type": "integer" } },
 				  "required": ["x"]
 				}
-				""").outputSchema(gsonMapper, """
+				""").description("Echo tool").outputSchema(gsonMapper, """
 				{
 				  "type": "object",
 				  "properties": { "y": { "type": "string" } }

--- a/mcp-core/src/test/java/io/modelcontextprotocol/util/ToolInputValidatorTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/util/ToolInputValidatorTests.java
@@ -16,10 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests for {@link ToolInputValidator}.
@@ -33,13 +30,9 @@ class ToolInputValidatorTests {
 	private final Map<String, Object> inputSchema = Map.of("type", "object", "properties",
 			Map.of("name", Map.of("type", "string")), "required", List.of("name"));
 
-	private final Tool toolWithSchema = Tool.builder()
-		.name("test-tool")
-		.description("Test tool")
-		.inputSchema(inputSchema)
-		.build();
+	private final Tool toolWithSchema = Tool.builder("test-tool", inputSchema).description("Test tool").build();
 
-	private final Tool toolWithoutSchema = Tool.builder().name("test-tool").description("Test tool").build();
+	private final Tool toolWithoutSchema = Tool.builder("test-tool").description("Test tool").build();
 
 	@Test
 	void validate_whenDisabled_returnsNull() {
@@ -51,10 +44,12 @@ class ToolInputValidatorTests {
 
 	@Test
 	void validate_whenNoSchema_returnsNull() {
+		when(validator.validate(any(), any())).thenReturn(ValidationResponse.asValid(null));
+
 		CallToolResult result = ToolInputValidator.validate(toolWithoutSchema, Map.of("name", "test"), true, validator);
 
 		assertThat(result).isNull();
-		verify(validator, never()).validate(any(), any());
+		verify(validator).validate(any(), any());
 	}
 
 	@Test

--- a/mcp-test/src/main/java/io/modelcontextprotocol/AbstractMcpClientServerIntegrationTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/AbstractMcpClientServerIntegrationTests.java
@@ -87,7 +87,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			.build();
 		try (
 				// Create client without sampling capabilities
-				var client = clientBuilder.clientInfo(new McpSchema.Implementation("Sample " + "client", "0.0.0"))
+				var client = clientBuilder
+					.clientInfo(McpSchema.Implementation.builder("Sample " + "client", "0.0.0").build())
 					.requestTimeout(Duration.ofSeconds(1000))
 					.build()) {
 
@@ -109,7 +110,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 		var clientBuilder = clientBuilders.get(clientType);
 
 		McpServerFeatures.AsyncToolSpecification tool = McpServerFeatures.AsyncToolSpecification.builder()
-			.tool(Tool.builder().name("tool1").description("tool1 description").inputSchema(EMPTY_JSON_SCHEMA).build())
+			.tool(Tool.builder("tool1", EMPTY_JSON_SCHEMA).description("tool1 description").build())
 			.callHandler((exchange, request) -> {
 				return exchange.createMessage(mock(McpSchema.CreateMessageRequest.class))
 					.then(Mono.just(mock(CallToolResult.class)));
@@ -120,13 +121,14 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 
 		try (
 				// Create client without sampling capabilities
-				var client = clientBuilder.clientInfo(new McpSchema.Implementation("Sample " + "client", "0.0.0"))
+				var client = clientBuilder
+					.clientInfo(McpSchema.Implementation.builder("Sample " + "client", "0.0.0").build())
 					.build()) {
 
 			assertThat(client.initialize()).isNotNull();
 
 			try {
-				client.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
+				client.callTool(McpSchema.CallToolRequest.builder("tool1").arguments(Map.of()).build());
 			}
 			catch (McpError e) {
 				assertThat(e).isInstanceOf(McpError.class)
@@ -148,23 +150,26 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			assertThat(request.messages()).hasSize(1);
 			assertThat(request.messages().get(0).content()).isInstanceOf(McpSchema.TextContent.class);
 
-			return new CreateMessageResult(Role.USER, new McpSchema.TextContent("Test message"), "MockModelName",
-					CreateMessageResult.StopReason.STOP_SEQUENCE);
+			return CreateMessageResult
+				.builder(Role.USER, McpSchema.TextContent.builder("Test message").build(), "MockModelName")
+				.stopReason(CreateMessageResult.StopReason.STOP_SEQUENCE)
+				.build();
 		};
 
 		CallToolResult callResponse = McpSchema.CallToolResult.builder()
-			.addContent(new McpSchema.TextContent("CALL RESPONSE"))
+			.addContent(McpSchema.TextContent.builder("CALL RESPONSE").build())
 			.build();
 
 		AtomicReference<CreateMessageResult> samplingResult = new AtomicReference<>();
 
 		McpServerFeatures.AsyncToolSpecification tool = McpServerFeatures.AsyncToolSpecification.builder()
-			.tool(Tool.builder().name("tool1").description("tool1 description").inputSchema(EMPTY_JSON_SCHEMA).build())
+			.tool(Tool.builder("tool1", EMPTY_JSON_SCHEMA).description("tool1 description").build())
 			.callHandler((exchange, request) -> {
 
-				var createMessageRequest = McpSchema.CreateMessageRequest.builder()
-					.messages(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
-							new McpSchema.TextContent("Test message"))))
+				var createMessageRequest = McpSchema.CreateMessageRequest
+					.builder(List.of(McpSchema.SamplingMessage
+						.builder(McpSchema.Role.USER, McpSchema.TextContent.builder("Test message").build())
+						.build()), 1000)
 					.modelPreferences(ModelPreferences.builder()
 						.hints(List.of())
 						.costPriority(1.0)
@@ -181,7 +186,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 
 		var mcpServer = prepareAsyncServerBuilder().serverInfo("test-server", "1.0.0").tools(tool).build();
 
-		try (var mcpClient = clientBuilder.clientInfo(new McpSchema.Implementation("Sample client", "0.0.0"))
+		try (var mcpClient = clientBuilder
+			.clientInfo(McpSchema.Implementation.builder("Sample client", "0.0.0").build())
 			.capabilities(ClientCapabilities.builder().sampling().build())
 			.sampling(samplingHandler)
 			.build()) {
@@ -189,7 +195,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			InitializeResult initResult = mcpClient.initialize();
 			assertThat(initResult).isNotNull();
 
-			CallToolResult response = mcpClient.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
+			CallToolResult response = mcpClient
+				.callTool(McpSchema.CallToolRequest.builder("tool1").arguments(Map.of()).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response).isEqualTo(callResponse);
@@ -225,25 +232,28 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			catch (InterruptedException e) {
 				throw new RuntimeException(e);
 			}
-			return new CreateMessageResult(Role.USER, new McpSchema.TextContent("Test message"), "MockModelName",
-					CreateMessageResult.StopReason.STOP_SEQUENCE);
+			return CreateMessageResult
+				.builder(Role.USER, McpSchema.TextContent.builder("Test message").build(), "MockModelName")
+				.stopReason(CreateMessageResult.StopReason.STOP_SEQUENCE)
+				.build();
 		};
 
 		// Server
 
 		CallToolResult callResponse = McpSchema.CallToolResult.builder()
-			.addContent(new McpSchema.TextContent("CALL RESPONSE"))
+			.addContent(McpSchema.TextContent.builder("CALL RESPONSE").build())
 			.build();
 
 		AtomicReference<CreateMessageResult> samplingResult = new AtomicReference<>();
 
 		McpServerFeatures.AsyncToolSpecification tool = McpServerFeatures.AsyncToolSpecification.builder()
-			.tool(Tool.builder().name("tool1").description("tool1 description").inputSchema(EMPTY_JSON_SCHEMA).build())
+			.tool(Tool.builder("tool1", EMPTY_JSON_SCHEMA).description("tool1 description").build())
 			.callHandler((exchange, request) -> {
 
-				var createMessageRequest = McpSchema.CreateMessageRequest.builder()
-					.messages(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
-							new McpSchema.TextContent("Test message"))))
+				var createMessageRequest = McpSchema.CreateMessageRequest
+					.builder(List.of(McpSchema.SamplingMessage
+						.builder(McpSchema.Role.USER, McpSchema.TextContent.builder("Test message").build())
+						.build()), 1000)
 					.modelPreferences(ModelPreferences.builder()
 						.hints(List.of())
 						.costPriority(1.0)
@@ -262,7 +272,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			.requestTimeout(Duration.ofSeconds(4))
 			.tools(tool)
 			.build();
-		try (var mcpClient = clientBuilder.clientInfo(new McpSchema.Implementation("Sample client", "0.0.0"))
+		try (var mcpClient = clientBuilder
+			.clientInfo(McpSchema.Implementation.builder("Sample client", "0.0.0").build())
 			.capabilities(ClientCapabilities.builder().sampling().build())
 			.sampling(samplingHandler)
 			.build()) {
@@ -270,7 +281,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			InitializeResult initResult = mcpClient.initialize();
 			assertThat(initResult).isNotNull();
 
-			CallToolResult response = mcpClient.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
+			CallToolResult response = mcpClient
+				.callTool(McpSchema.CallToolRequest.builder("tool1").arguments(Map.of()).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response).isEqualTo(callResponse);
@@ -304,21 +316,24 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			catch (InterruptedException e) {
 				throw new RuntimeException(e);
 			}
-			return new CreateMessageResult(Role.USER, new McpSchema.TextContent("Test message"), "MockModelName",
-					CreateMessageResult.StopReason.STOP_SEQUENCE);
+			return CreateMessageResult
+				.builder(Role.USER, McpSchema.TextContent.builder("Test message").build(), "MockModelName")
+				.stopReason(CreateMessageResult.StopReason.STOP_SEQUENCE)
+				.build();
 		};
 
 		CallToolResult callResponse = McpSchema.CallToolResult.builder()
-			.addContent(new McpSchema.TextContent("CALL RESPONSE"))
+			.addContent(McpSchema.TextContent.builder("CALL RESPONSE").build())
 			.build();
 
 		McpServerFeatures.AsyncToolSpecification tool = McpServerFeatures.AsyncToolSpecification.builder()
-			.tool(Tool.builder().name("tool1").description("tool1 description").inputSchema(EMPTY_JSON_SCHEMA).build())
+			.tool(Tool.builder("tool1", EMPTY_JSON_SCHEMA).description("tool1 description").build())
 			.callHandler((exchange, request) -> {
 
-				var createMessageRequest = McpSchema.CreateMessageRequest.builder()
-					.messages(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
-							new McpSchema.TextContent("Test message"))))
+				var createMessageRequest = McpSchema.CreateMessageRequest
+					.builder(List.of(McpSchema.SamplingMessage
+						.builder(McpSchema.Role.USER, McpSchema.TextContent.builder("Test message").build())
+						.build()), 1000)
 					.modelPreferences(ModelPreferences.builder()
 						.hints(List.of())
 						.costPriority(1.0)
@@ -336,7 +351,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			.tools(tool)
 			.build();
 
-		try (var mcpClient = clientBuilder.clientInfo(new McpSchema.Implementation("Sample client", "0.0.0"))
+		try (var mcpClient = clientBuilder
+			.clientInfo(McpSchema.Implementation.builder("Sample client", "0.0.0").build())
 			.capabilities(ClientCapabilities.builder().sampling().build())
 			.sampling(samplingHandler)
 			.build()) {
@@ -345,7 +361,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			assertThat(initResult).isNotNull();
 
 			assertThatExceptionOfType(McpError.class).isThrownBy(() -> {
-				mcpClient.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
+				mcpClient.callTool(McpSchema.CallToolRequest.builder("tool1").arguments(Map.of()).build());
 			}).withMessageContaining("1000ms");
 		}
 		finally {
@@ -363,7 +379,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 		var clientBuilder = clientBuilders.get(clientType);
 
 		McpServerFeatures.AsyncToolSpecification tool = McpServerFeatures.AsyncToolSpecification.builder()
-			.tool(Tool.builder().name("tool1").description("tool1 description").inputSchema(EMPTY_JSON_SCHEMA).build())
+			.tool(Tool.builder("tool1", EMPTY_JSON_SCHEMA).description("tool1 description").build())
 			.callHandler((exchange, request) -> exchange.createElicitation(mock(ElicitRequest.class))
 				.then(Mono.just(mock(CallToolResult.class))))
 			.build();
@@ -371,12 +387,13 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 		var server = prepareAsyncServerBuilder().serverInfo("test-server", "1.0.0").tools(tool).build();
 
 		// Create client without elicitation capabilities
-		try (var client = clientBuilder.clientInfo(new McpSchema.Implementation("Sample client", "0.0.0")).build()) {
+		try (var client = clientBuilder.clientInfo(McpSchema.Implementation.builder("Sample client", "0.0.0").build())
+			.build()) {
 
 			assertThat(client.initialize()).isNotNull();
 
 			try {
-				client.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
+				client.callTool(McpSchema.CallToolRequest.builder("tool1").arguments(Map.of()).build());
 			}
 			catch (McpError e) {
 				assertThat(e).isInstanceOf(McpError.class)
@@ -398,23 +415,23 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			assertThat(request.message()).isNotEmpty();
 			assertThat(request.requestedSchema()).isNotNull();
 
-			return new McpSchema.ElicitResult(McpSchema.ElicitResult.Action.ACCEPT,
-					Map.of("message", request.message()));
+			return McpSchema.ElicitResult.builder(McpSchema.ElicitResult.Action.ACCEPT)
+				.content(Map.of("message", request.message()))
+				.build();
 		};
 
 		CallToolResult callResponse = McpSchema.CallToolResult.builder()
-			.addContent(new McpSchema.TextContent("CALL RESPONSE"))
+			.addContent(McpSchema.TextContent.builder("CALL RESPONSE").build())
 			.build();
 
 		AtomicReference<McpSchema.ElicitResult> elicitResultRef = new AtomicReference<>();
 
 		McpServerFeatures.AsyncToolSpecification tool = McpServerFeatures.AsyncToolSpecification.builder()
-			.tool(Tool.builder().name("tool1").description("tool1 description").inputSchema(EMPTY_JSON_SCHEMA).build())
+			.tool(Tool.builder("tool1", EMPTY_JSON_SCHEMA).description("tool1 description").build())
 			.callHandler((exchange, request) -> {
 
-				var elicitationRequest = McpSchema.ElicitRequest.builder()
-					.message("Test message")
-					.requestedSchema(
+				var elicitationRequest = McpSchema.ElicitRequest
+					.builder("Test message",
 							Map.of("type", "object", "properties", Map.of("message", Map.of("type", "string"))))
 					.build();
 
@@ -426,7 +443,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 
 		var mcpServer = prepareAsyncServerBuilder().serverInfo("test-server", "1.0.0").tools(tool).build();
 
-		try (var mcpClient = clientBuilder.clientInfo(new McpSchema.Implementation("Sample client", "0.0.0"))
+		try (var mcpClient = clientBuilder
+			.clientInfo(McpSchema.Implementation.builder("Sample client", "0.0.0").build())
 			.capabilities(ClientCapabilities.builder().elicitation().build())
 			.elicitation(elicitationHandler)
 			.build()) {
@@ -434,7 +452,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			InitializeResult initResult = mcpClient.initialize();
 			assertThat(initResult).isNotNull();
 
-			CallToolResult response = mcpClient.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
+			CallToolResult response = mcpClient
+				.callTool(McpSchema.CallToolRequest.builder("tool1").arguments(Map.of()).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response).isEqualTo(callResponse);
@@ -458,22 +477,23 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 		Function<ElicitRequest, ElicitResult> elicitationHandler = request -> {
 			assertThat(request.message()).isNotEmpty();
 			assertThat(request.requestedSchema()).isNotNull();
-			return new ElicitResult(ElicitResult.Action.ACCEPT, Map.of("message", request.message()));
+			return ElicitResult.builder(ElicitResult.Action.ACCEPT)
+				.content(Map.of("message", request.message()))
+				.build();
 		};
 
 		CallToolResult callResponse = McpSchema.CallToolResult.builder()
-			.addContent(new McpSchema.TextContent("CALL RESPONSE"))
+			.addContent(McpSchema.TextContent.builder("CALL RESPONSE").build())
 			.build();
 
 		AtomicReference<ElicitResult> resultRef = new AtomicReference<>();
 
 		McpServerFeatures.AsyncToolSpecification tool = McpServerFeatures.AsyncToolSpecification.builder()
-			.tool(Tool.builder().name("tool1").description("tool1 description").inputSchema(EMPTY_JSON_SCHEMA).build())
+			.tool(Tool.builder("tool1", EMPTY_JSON_SCHEMA).description("tool1 description").build())
 			.callHandler((exchange, request) -> {
 
-				var elicitationRequest = McpSchema.ElicitRequest.builder()
-					.message("Test message")
-					.requestedSchema(
+				var elicitationRequest = McpSchema.ElicitRequest
+					.builder("Test message",
 							Map.of("type", "object", "properties", Map.of("message", Map.of("type", "string"))))
 					.build();
 
@@ -488,7 +508,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			.tools(tool)
 			.build();
 
-		try (var mcpClient = clientBuilder.clientInfo(new McpSchema.Implementation("Sample client", "0.0.0"))
+		try (var mcpClient = clientBuilder
+			.clientInfo(McpSchema.Implementation.builder("Sample client", "0.0.0").build())
 			.capabilities(ClientCapabilities.builder().elicitation().build())
 			.elicitation(elicitationHandler)
 			.build()) {
@@ -496,7 +517,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			InitializeResult initResult = mcpClient.initialize();
 			assertThat(initResult).isNotNull();
 
-			CallToolResult response = mcpClient.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
+			CallToolResult response = mcpClient
+				.callTool(McpSchema.CallToolRequest.builder("tool1").arguments(Map.of()).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response).isEqualTo(callResponse);
@@ -531,20 +553,23 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			catch (InterruptedException e) {
 				throw new RuntimeException(e);
 			}
-			return new ElicitResult(ElicitResult.Action.ACCEPT, Map.of("message", request.message()));
+			return ElicitResult.builder(ElicitResult.Action.ACCEPT)
+				.content(Map.of("message", request.message()))
+				.build();
 		};
 
-		CallToolResult callResponse = CallToolResult.builder().addContent(new TextContent("CALL RESPONSE")).build();
+		CallToolResult callResponse = CallToolResult.builder()
+			.addContent(TextContent.builder("CALL RESPONSE").build())
+			.build();
 
 		AtomicReference<ElicitResult> resultRef = new AtomicReference<>();
 
 		McpServerFeatures.AsyncToolSpecification tool = McpServerFeatures.AsyncToolSpecification.builder()
-			.tool(Tool.builder().name("tool1").description("tool1 description").inputSchema(EMPTY_JSON_SCHEMA).build())
+			.tool(Tool.builder("tool1", EMPTY_JSON_SCHEMA).description("tool1 description").build())
 			.callHandler((exchange, request) -> {
 
-				var elicitationRequest = ElicitRequest.builder()
-					.message("Test message")
-					.requestedSchema(
+				var elicitationRequest = ElicitRequest
+					.builder("Test message",
 							Map.of("type", "object", "properties", Map.of("message", Map.of("type", "string"))))
 					.build();
 
@@ -559,7 +584,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			.tools(tool)
 			.build();
 
-		try (var mcpClient = clientBuilder.clientInfo(new McpSchema.Implementation("Sample client", "0.0.0"))
+		try (var mcpClient = clientBuilder
+			.clientInfo(McpSchema.Implementation.builder("Sample client", "0.0.0").build())
 			.capabilities(ClientCapabilities.builder().elicitation().build())
 			.elicitation(elicitationHandler)
 			.build()) {
@@ -568,7 +594,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			assertThat(initResult).isNotNull();
 
 			assertThatExceptionOfType(McpError.class).isThrownBy(() -> {
-				mcpClient.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
+				mcpClient.callTool(McpSchema.CallToolRequest.builder("tool1").arguments(Map.of()).build());
 			}).withMessageContaining("within 1000ms");
 
 			ElicitResult elicitResult = resultRef.get();
@@ -587,7 +613,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 	void testRootsSuccess(String clientType) {
 		var clientBuilder = clientBuilders.get(clientType);
 
-		List<Root> roots = List.of(new Root("uri1://", "root1"), new Root("uri2://", "root2"));
+		List<Root> roots = List.of(Root.builder("uri1://").name("root1").build(),
+				Root.builder("uri2://").name("root2").build());
 
 		AtomicReference<List<Root>> rootsRef = new AtomicReference<>();
 
@@ -618,7 +645,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			});
 
 			// Add a new root
-			var root3 = new Root("uri3://", "root3");
+			var root3 = Root.builder("uri3://").name("root3").build();
 			mcpClient.addRoot(root3);
 
 			await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
@@ -637,7 +664,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 		var clientBuilder = clientBuilders.get(clientType);
 
 		McpServerFeatures.SyncToolSpecification tool = McpServerFeatures.SyncToolSpecification.builder()
-			.tool(Tool.builder().name("tool1").description("tool1 description").inputSchema(EMPTY_JSON_SCHEMA).build())
+			.tool(Tool.builder("tool1", EMPTY_JSON_SCHEMA).description("tool1 description").build())
 			.callHandler((exchange, request) -> {
 
 				exchange.listRoots(); // try to list roots
@@ -658,7 +685,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 
 			// Attempt to list roots should fail
 			try {
-				mcpClient.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
+				mcpClient.callTool(McpSchema.CallToolRequest.builder("tool1").arguments(Map.of()).build());
 			}
 			catch (McpError e) {
 				assertThat(e).isInstanceOf(McpError.class).hasMessage("Roots not supported");
@@ -705,7 +732,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 
 		var clientBuilder = clientBuilders.get(clientType);
 
-		List<Root> roots = List.of(new Root("uri1://", "root1"));
+		List<Root> roots = List.of(Root.builder("uri1://").name("root1").build());
 
 		AtomicReference<List<Root>> rootsRef1 = new AtomicReference<>();
 		AtomicReference<List<Root>> rootsRef2 = new AtomicReference<>();
@@ -739,7 +766,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 
 		var clientBuilder = clientBuilders.get(clientType);
 
-		List<Root> roots = List.of(new Root("uri1://", "root1"));
+		List<Root> roots = List.of(Root.builder("uri1://").name("root1").build());
 
 		AtomicReference<List<Root>> rootsRef = new AtomicReference<>();
 
@@ -776,10 +803,10 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 
 		var responseBodyIsNullOrBlank = new AtomicBoolean(false);
 		var callResponse = McpSchema.CallToolResult.builder()
-			.addContent(new McpSchema.TextContent("CALL RESPONSE; ctx=importantValue"))
+			.addContent(McpSchema.TextContent.builder("CALL RESPONSE; ctx=importantValue").build())
 			.build();
 		McpServerFeatures.SyncToolSpecification tool1 = McpServerFeatures.SyncToolSpecification.builder()
-			.tool(Tool.builder().name("tool1").description("tool1 description").inputSchema(EMPTY_JSON_SCHEMA).build())
+			.tool(Tool.builder("tool1", EMPTY_JSON_SCHEMA).description("tool1 description").build())
 			.callHandler((exchange, request) -> {
 
 				try {
@@ -811,7 +838,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 
 			assertThat(mcpClient.listTools().tools()).contains(tool1.tool());
 
-			CallToolResult response = mcpClient.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
+			CallToolResult response = mcpClient
+				.callTool(McpSchema.CallToolRequest.builder("tool1").arguments(Map.of()).build());
 
 			assertThat(responseBodyIsNullOrBlank.get()).isFalse();
 			assertThat(response).isNotNull().isEqualTo(callResponse);
@@ -830,11 +858,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 		McpSyncServer mcpServer = prepareSyncServerBuilder()
 			.capabilities(ServerCapabilities.builder().tools(true).build())
 			.tools(McpServerFeatures.SyncToolSpecification.builder()
-				.tool(Tool.builder()
-					.name("tool1")
-					.description("tool1 description")
-					.inputSchema(EMPTY_JSON_SCHEMA)
-					.build())
+				.tool(Tool.builder("tool1", EMPTY_JSON_SCHEMA).description("tool1 description").build())
 				.callHandler((exchange, request) -> {
 					// We trigger a timeout on blocking read, raising an exception
 					Mono.never().block(Duration.ofSeconds(1));
@@ -849,8 +873,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 
 			// We expect the tool call to fail immediately with the exception raised by
 			// the offending tool instead of getting back a timeout.
-			assertThatExceptionOfType(McpError.class)
-				.isThrownBy(() -> mcpClient.callTool(new McpSchema.CallToolRequest("tool1", Map.of())))
+			assertThatExceptionOfType(McpError.class).isThrownBy(
+					() -> mcpClient.callTool(McpSchema.CallToolRequest.builder("tool1").arguments(Map.of()).build()))
 				.withMessageContaining("Timeout on blocking read");
 		}
 		finally {
@@ -869,10 +893,10 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 		var responseBodyIsNullOrBlank = new AtomicBoolean(false);
 
 		var expectedCallResponse = McpSchema.CallToolResult.builder()
-			.addContent(new McpSchema.TextContent("CALL RESPONSE; ctx=value"))
+			.addContent(McpSchema.TextContent.builder("CALL RESPONSE; ctx=value").build())
 			.build();
 		McpServerFeatures.SyncToolSpecification tool1 = McpServerFeatures.SyncToolSpecification.builder()
-			.tool(Tool.builder().name("tool1").description("tool1 description").inputSchema(EMPTY_JSON_SCHEMA).build())
+			.tool(Tool.builder("tool1", EMPTY_JSON_SCHEMA).description("tool1 description").build())
 			.callHandler((exchange, request) -> {
 
 				McpTransportContext transportContext = exchange.transportContext();
@@ -889,7 +913,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 				}
 
 				return McpSchema.CallToolResult.builder()
-					.addContent(new McpSchema.TextContent("CALL RESPONSE; ctx=" + ctxValue))
+					.addContent(McpSchema.TextContent.builder("CALL RESPONSE; ctx=" + ctxValue).build())
 					.build();
 			})
 			.build();
@@ -905,7 +929,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 
 			assertThat(mcpClient.listTools().tools()).contains(tool1.tool());
 
-			CallToolResult response = mcpClient.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
+			CallToolResult response = mcpClient
+				.callTool(McpSchema.CallToolRequest.builder("tool1").arguments(Map.of()).build());
 
 			assertThat(transportContextIsNull.get()).isFalse();
 			assertThat(transportContextIsEmpty.get()).isFalse();
@@ -933,15 +958,11 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 				""";
 
 		McpServerFeatures.SyncToolSpecification nonAsciiTool = McpServerFeatures.SyncToolSpecification.builder()
-			.tool(Tool.builder()
-				.name("greeter")
-				.description("打招呼")
-				.inputSchema(McpJsonDefaults.getMapper(), inputSchema)
-				.build())
+			.tool(Tool.builder("greeter", McpJsonDefaults.getMapper(), inputSchema).description("打招呼").build())
 			.callHandler((exchange, request) -> {
 				String username = (String) request.arguments().get("username");
 				return McpSchema.CallToolResult.builder()
-					.addContent(new McpSchema.TextContent("Hello " + username))
+					.addContent(McpSchema.TextContent.builder("Hello " + username).build())
 					.build();
 			})
 			.build();
@@ -961,7 +982,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			assertThat(tools.get(0).description()).isEqualTo("打招呼");
 
 			CallToolResult response = mcpClient
-				.callTool(new McpSchema.CallToolRequest("greeter", Map.of("username", "测试用户")));
+				.callTool(McpSchema.CallToolRequest.builder("greeter").arguments(Map.of("username", "测试用户")).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response.isError()).isFalse();
@@ -980,11 +1001,11 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 		var clientBuilder = clientBuilders.get(clientType);
 
 		var callResponse = McpSchema.CallToolResult.builder()
-			.addContent(new McpSchema.TextContent("CALL RESPONSE"))
+			.addContent(McpSchema.TextContent.builder("CALL RESPONSE").build())
 			.build();
 
 		McpServerFeatures.SyncToolSpecification tool1 = McpServerFeatures.SyncToolSpecification.builder()
-			.tool(Tool.builder().name("tool1").description("tool1 description").inputSchema(EMPTY_JSON_SCHEMA).build())
+			.tool(Tool.builder("tool1", EMPTY_JSON_SCHEMA).description("tool1 description").build())
 			.callHandler((exchange, request) -> {
 				// perform a blocking call to a remote service
 				try {
@@ -1050,11 +1071,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 
 			// Add a new tool
 			McpServerFeatures.SyncToolSpecification tool2 = McpServerFeatures.SyncToolSpecification.builder()
-				.tool(Tool.builder()
-					.name("tool2")
-					.description("tool2 description")
-					.inputSchema(EMPTY_JSON_SCHEMA)
-					.build())
+				.tool(Tool.builder("tool2", EMPTY_JSON_SCHEMA).description("tool2 description").build())
 				.callHandler((exchange, request) -> callResponse)
 				.build();
 
@@ -1102,48 +1119,39 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 
 		// Create server with a tool that sends logging notifications
 		McpServerFeatures.AsyncToolSpecification tool = McpServerFeatures.AsyncToolSpecification.builder()
-			.tool(Tool.builder()
-				.name("logging-test")
-				.description("Test logging notifications")
-				.inputSchema(EMPTY_JSON_SCHEMA)
-				.build())
+			.tool(Tool.builder("logging-test", EMPTY_JSON_SCHEMA).description("Test logging notifications").build())
 			.callHandler((exchange, request) -> {
 
 				// Create and send notifications with different levels
 
 			//@formatter:off
 					return exchange // This should be filtered out (DEBUG < NOTICE)
-						.loggingNotification(McpSchema.LoggingMessageNotification.builder()
-								.level(McpSchema.LoggingLevel.DEBUG)
+						.loggingNotification(McpSchema.LoggingMessageNotification
+								.builder(McpSchema.LoggingLevel.DEBUG, "Debug message")
 								.logger("test-logger")
-								.data("Debug message")
 								.build())
 					.then(exchange // This should be sent (NOTICE >= NOTICE)
-						.loggingNotification(McpSchema.LoggingMessageNotification.builder()
-								.level(McpSchema.LoggingLevel.NOTICE)
+						.loggingNotification(McpSchema.LoggingMessageNotification
+								.builder(McpSchema.LoggingLevel.NOTICE, "Notice message")
 								.logger("test-logger")
-								.data("Notice message")
 								.build()))
 					.then(exchange // This should be sent (ERROR > NOTICE)
-						.loggingNotification(McpSchema.LoggingMessageNotification.builder()
-							.level(McpSchema.LoggingLevel.ERROR)
+						.loggingNotification(McpSchema.LoggingMessageNotification
+							.builder(McpSchema.LoggingLevel.ERROR, "Error message")
 							.logger("test-logger")
-							.data("Error message")
 							.build()))
 					.then(exchange // This should be filtered out (INFO < NOTICE)
-						.loggingNotification(McpSchema.LoggingMessageNotification.builder()
-								.level(McpSchema.LoggingLevel.INFO)
+						.loggingNotification(McpSchema.LoggingMessageNotification
+								.builder(McpSchema.LoggingLevel.INFO, "Another info message")
 								.logger("test-logger")
-								.data("Another info message")
 								.build()))
 					.then(exchange // This should be sent (ERROR >= NOTICE)
-						.loggingNotification(McpSchema.LoggingMessageNotification.builder()
-								.level(McpSchema.LoggingLevel.ERROR)
+						.loggingNotification(McpSchema.LoggingMessageNotification
+								.builder(McpSchema.LoggingLevel.ERROR, "Another error message")
 								.logger("test-logger")
-								.data("Another error message")
 								.build()))
 					.thenReturn(CallToolResult.builder()
-						.content(List.of(new McpSchema.TextContent("Logging test completed")))
+						.content(List.of(McpSchema.TextContent.builder("Logging test completed").build()))
 						.isError(false)
 						.build());
 					//@formatter:on
@@ -1170,7 +1178,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			mcpClient.setLoggingLevel(McpSchema.LoggingLevel.NOTICE);
 
 			// Call the tool that sends logging notifications
-			CallToolResult result = mcpClient.callTool(new McpSchema.CallToolRequest("logging-test", Map.of()));
+			CallToolResult result = mcpClient
+				.callTool(McpSchema.CallToolRequest.builder("logging-test").arguments(Map.of()).build());
 			assertThat(result).isNotNull();
 			assertThat(result.content().get(0)).isInstanceOf(McpSchema.TextContent.class);
 			assertThat(((McpSchema.TextContent) result.content().get(0)).text()).isEqualTo("Logging test completed");
@@ -1219,10 +1228,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 
 		// Create server with a tool that sends logging notifications
 		McpServerFeatures.AsyncToolSpecification tool = McpServerFeatures.AsyncToolSpecification.builder()
-			.tool(McpSchema.Tool.builder()
-				.name("progress-test")
+			.tool(McpSchema.Tool.builder("progress-test", EMPTY_JSON_SCHEMA)
 				.description("Test progress notifications")
-				.inputSchema(EMPTY_JSON_SCHEMA)
 				.build())
 			.callHandler((exchange, request) -> {
 
@@ -1230,18 +1237,25 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 				var progressToken = (String) request.meta().get("progressToken");
 
 				return exchange
-					.progressNotification(
-							new McpSchema.ProgressNotification(progressToken, 0.0, 1.0, "Processing started"))
-					.then(exchange.progressNotification(
-							new McpSchema.ProgressNotification(progressToken, 0.5, 1.0, "Processing data")))
-					.then(// Send a progress notification with another progress value
-							// should
-							exchange.progressNotification(new McpSchema.ProgressNotification("another-progress-token",
-									0.0, 1.0, "Another processing started")))
-					.then(exchange.progressNotification(
-							new McpSchema.ProgressNotification(progressToken, 1.0, 1.0, "Processing completed")))
+					.progressNotification(McpSchema.ProgressNotification.builder(progressToken, 0.0)
+						.total(1.0)
+						.message("Processing started")
+						.build())
+					.then(exchange.progressNotification(McpSchema.ProgressNotification.builder(progressToken, 0.5)
+						.total(1.0)
+						.message("Processing data")
+						.build()))
+					.then(exchange
+						.progressNotification(McpSchema.ProgressNotification.builder("another-progress-token", 0.0)
+							.total(1.0)
+							.message("Another processing started")
+							.build()))
+					.then(exchange.progressNotification(McpSchema.ProgressNotification.builder(progressToken, 1.0)
+						.total(1.0)
+						.message("Processing completed")
+						.build()))
 					.thenReturn(CallToolResult.builder()
-						.content(List.of(new McpSchema.TextContent("Progress test completed")))
+						.content(List.of(McpSchema.TextContent.builder("Progress test completed").build()))
 						.isError(false)
 						.build());
 			})
@@ -1321,9 +1335,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 		var clientBuilder = clientBuilders.get(clientType);
 
 		var expectedValues = List.of("python", "pytorch", "pyside");
-		var completionResponse = new McpSchema.CompleteResult(new CompleteResult.CompleteCompletion(expectedValues, 10, // total
-				true // hasMore
-		));
+		var completionResponse = new McpSchema.CompleteResult(
+				new CompleteResult.CompleteCompletion(expectedValues, 10, true));
 
 		AtomicReference<CompleteRequest> samplingRequest = new AtomicReference<>();
 		BiFunction<McpSyncServerExchange, CompleteRequest, CompleteResult> completionHandler = (mcpSyncServerExchange,
@@ -1333,13 +1346,17 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 		};
 
 		var mcpServer = prepareSyncServerBuilder().capabilities(ServerCapabilities.builder().completions().build())
-			.prompts(new McpServerFeatures.SyncPromptSpecification(
-					new Prompt("code_review", "Code review", "this is code review prompt",
-							List.of(new PromptArgument("language", "Language", "string", false))),
-					(mcpSyncServerExchange, getPromptRequest) -> null))
+			.prompts(new McpServerFeatures.SyncPromptSpecification(Prompt.builder("code_review")
+				.title("Code review")
+				.description("this is code review prompt")
+				.arguments(List.of(PromptArgument.builder("language")
+					.title("Language")
+					.description("string")
+					.required(false)
+					.build()))
+				.build(), (mcpSyncServerExchange, getPromptRequest) -> null))
 			.completions(new McpServerFeatures.SyncCompletionSpecification(
-					new McpSchema.PromptReference(PromptReference.TYPE, "code_review", "Code review"),
-					completionHandler))
+					McpSchema.PromptReference.builder("code_review").title("Code review").build(), completionHandler))
 			.build();
 
 		try (var mcpClient = clientBuilder.build()) {
@@ -1347,9 +1364,10 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			InitializeResult initResult = mcpClient.initialize();
 			assertThat(initResult).isNotNull();
 
-			CompleteRequest request = new CompleteRequest(
-					new PromptReference(PromptReference.TYPE, "code_review", "Code review"),
-					new CompleteRequest.CompleteArgument("language", "py"));
+			CompleteRequest request = CompleteRequest
+				.builder(PromptReference.builder("code_review").title("Code review").build(),
+						new CompleteRequest.CompleteArgument("language", "py"))
+				.build();
 
 			CompleteResult result = mcpClient.completeCompletion(request);
 
@@ -1377,11 +1395,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 		AtomicReference<String> executionOrder = new AtomicReference<>("");
 
 		McpServerFeatures.AsyncToolSpecification tool = McpServerFeatures.AsyncToolSpecification.builder()
-			.tool(Tool.builder()
-				.name("ping-async-test")
-				.description("Test ping async behavior")
-				.inputSchema(EMPTY_JSON_SCHEMA)
-				.build())
+			.tool(Tool.builder("ping-async-test", EMPTY_JSON_SCHEMA).description("Test ping async behavior").build())
 			.callHandler((exchange, request) -> {
 
 				executionOrder.set(executionOrder.get() + "1");
@@ -1398,7 +1412,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 				}).then(Mono.fromCallable(() -> {
 					executionOrder.set(executionOrder.get() + "3");
 					return CallToolResult.builder()
-						.content(List.of(new McpSchema.TextContent("Async ping test completed")))
+						.content(List.of(McpSchema.TextContent.builder("Async ping test completed").build()))
 						.isError(false)
 						.build();
 				}));
@@ -1417,7 +1431,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			assertThat(initResult).isNotNull();
 
 			// Call the tool that tests ping async behavior
-			CallToolResult result = mcpClient.callTool(new McpSchema.CallToolRequest("ping-async-test", Map.of()));
+			CallToolResult result = mcpClient
+				.callTool(McpSchema.CallToolRequest.builder("ping-async-test").arguments(Map.of()).build());
 			assertThat(result).isNotNull();
 			assertThat(result.content().get(0)).isInstanceOf(McpSchema.TextContent.class);
 			assertThat(((McpSchema.TextContent) result.content().get(0)).text()).isEqualTo("Async ping test completed");
@@ -1444,8 +1459,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 						Map.of("type", "string"), "timestamp", Map.of("type", "string")),
 				"required", List.of("result", "operation"));
 
-		Tool calculatorTool = Tool.builder()
-			.name("calculator")
+		Tool calculatorTool = Tool.builder("calculator")
 			.description("Performs mathematical calculations")
 			.outputSchema(outputSchema)
 			.build();
@@ -1478,8 +1492,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			// Note: outputSchema might be null in sync server, but validation still works
 
 			// Call tool with valid structured output
-			CallToolResult response = mcpClient
-				.callTool(new McpSchema.CallToolRequest("calculator", Map.of("expression", "2 + 3")));
+			CallToolResult response = mcpClient.callTool(
+					McpSchema.CallToolRequest.builder("calculator").arguments(Map.of("expression", "2 + 3")).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response.isError()).isFalse();
@@ -1523,8 +1537,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 					"age", Map.of("type", "number")),					
 				"required", List.of("name", "age"))); // @formatter:on
 
-		Tool calculatorTool = Tool.builder()
-			.name("getMembers")
+		Tool calculatorTool = Tool.builder("getMembers")
 			.description("Returns a list of members")
 			.outputSchema(outputSchema)
 			.build();
@@ -1547,7 +1560,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			assertThat(mcpClient.initialize()).isNotNull();
 
 			// Call tool with valid structured output of type array
-			CallToolResult response = mcpClient.callTool(new McpSchema.CallToolRequest("getMembers", Map.of()));
+			CallToolResult response = mcpClient
+				.callTool(McpSchema.CallToolRequest.builder("getMembers").arguments(Map.of()).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response.isError()).isFalse();
@@ -1577,8 +1591,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 						Map.of("type", "string"), "timestamp", Map.of("type", "string")),
 				"required", List.of("result", "operation"));
 
-		Tool calculatorTool = Tool.builder()
-			.name("calculator")
+		Tool calculatorTool = Tool.builder("calculator")
 			.description("Performs mathematical calculations")
 			.outputSchema(outputSchema)
 			.build();
@@ -1588,7 +1601,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			.tool(calculatorTool)
 			.callHandler((exchange, request) -> CallToolResult.builder()
 				.isError(true)
-				.content(List.of(new TextContent("Error calling tool: Simulated in-handler error")))
+				.content(List.of(TextContent.builder("Error calling tool: Simulated in-handler error").build()))
 				.build())
 			.build();
 
@@ -1608,14 +1621,14 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			// Note: outputSchema might be null in sync server, but validation still works
 
 			// Call tool with valid structured output
-			CallToolResult response = mcpClient
-				.callTool(new McpSchema.CallToolRequest("calculator", Map.of("expression", "2 + 3")));
+			CallToolResult response = mcpClient.callTool(
+					McpSchema.CallToolRequest.builder("calculator").arguments(Map.of("expression", "2 + 3")).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response.isError()).isTrue();
 			assertThat(response.content()).isNotEmpty();
-			assertThat(response.content())
-				.containsExactly(new McpSchema.TextContent("Error calling tool: Simulated in-handler error"));
+			assertThat(response.content()).containsExactly(
+					McpSchema.TextContent.builder("Error calling tool: Simulated in-handler error").build());
 			assertThat(response.structuredContent()).isNull();
 		}
 		finally {
@@ -1634,8 +1647,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 				Map.of("result", Map.of("type", "number"), "operation", Map.of("type", "string")), "required",
 				List.of("result", "operation"));
 
-		Tool calculatorTool = Tool.builder()
-			.name("calculator")
+		Tool calculatorTool = Tool.builder("calculator")
 			.description("Performs mathematical calculations")
 			.outputSchema(outputSchema)
 			.build();
@@ -1662,8 +1674,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			assertThat(initResult).isNotNull();
 
 			// Call tool with invalid structured output
-			CallToolResult response = mcpClient
-				.callTool(new McpSchema.CallToolRequest("calculator", Map.of("expression", "2 + 3")));
+			CallToolResult response = mcpClient.callTool(
+					McpSchema.CallToolRequest.builder("calculator").arguments(Map.of("expression", "2 + 3")).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response.isError()).isTrue();
@@ -1688,8 +1700,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 		Map<String, Object> outputSchema = Map.of("type", "object", "properties",
 				Map.of("result", Map.of("type", "number")), "required", List.of("result"));
 
-		Tool calculatorTool = Tool.builder()
-			.name("calculator")
+		Tool calculatorTool = Tool.builder("calculator")
 			.description("Performs mathematical calculations")
 			.outputSchema(outputSchema)
 			.build();
@@ -1712,8 +1723,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			assertThat(initResult).isNotNull();
 
 			// Call tool that should return structured content but doesn't
-			CallToolResult response = mcpClient
-				.callTool(new McpSchema.CallToolRequest("calculator", Map.of("expression", "2 + 3")));
+			CallToolResult response = mcpClient.callTool(
+					McpSchema.CallToolRequest.builder("calculator").arguments(Map.of("expression", "2 + 3")).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response.isError()).isTrue();
@@ -1752,8 +1763,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 					Map.of("message", Map.of("type", "string"), "count", Map.of("type", "integer")), "required",
 					List.of("message", "count"));
 
-			Tool dynamicTool = Tool.builder()
-				.name("dynamic-tool")
+			Tool dynamicTool = Tool.builder("dynamic-tool")
 				.description("Dynamically added tool")
 				.outputSchema(outputSchema)
 				.build();
@@ -1785,7 +1795,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 
 			// Call dynamically added tool
 			CallToolResult response = mcpClient
-				.callTool(new McpSchema.CallToolRequest("dynamic-tool", Map.of("count", 3)));
+				.callTool(McpSchema.CallToolRequest.builder("dynamic-tool").arguments(Map.of("count", 3)).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response.isError()).isFalse();
@@ -1822,13 +1832,12 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 		var latch = new CountDownLatch(1);
 
 		McpServerFeatures.SyncResourceSpecification resourceSpec = new McpServerFeatures.SyncResourceSpecification(
-				McpSchema.Resource.builder()
-					.uri(resourceUri)
-					.name("Subscribable Resource")
-					.mimeType("text/plain")
-					.build(),
-				(exchange, req) -> new McpSchema.ReadResourceResult(
-						List.of(new McpSchema.TextResourceContents(resourceUri, "text/plain", "initial content"))));
+				McpSchema.Resource.builder(resourceUri, "Subscribable Resource").mimeType("text/plain").build(),
+				(exchange, req) -> McpSchema.ReadResourceResult
+					.builder(List.of(McpSchema.TextResourceContents.builder(resourceUri, "initial content")
+						.mimeType("text/plain")
+						.build()))
+					.build());
 
 		McpSyncServer mcpServer = prepareSyncServerBuilder().serverInfo("test-server", "1.0.0")
 			.capabilities(McpSchema.ServerCapabilities.builder().resources(true, false).build())
@@ -1842,7 +1851,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 
 			mcpClient.initialize();
 
-			mcpClient.subscribeResource(new McpSchema.SubscribeRequest(resourceUri));
+			mcpClient.subscribeResource(McpSchema.SubscribeRequest.builder(resourceUri).build());
 
 			mcpServer.notifyResourcesUpdated(new McpSchema.ResourcesUpdatedNotification(resourceUri));
 
@@ -1866,13 +1875,10 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 		var notificationCount = new java.util.concurrent.atomic.AtomicInteger(0);
 
 		McpServerFeatures.SyncResourceSpecification resourceSpec = new McpServerFeatures.SyncResourceSpecification(
-				McpSchema.Resource.builder()
-					.uri(resourceUri)
-					.name("Subscribable Resource")
-					.mimeType("text/plain")
-					.build(),
-				(exchange, req) -> new McpSchema.ReadResourceResult(
-						List.of(new McpSchema.TextResourceContents(resourceUri, "text/plain", "content"))));
+				McpSchema.Resource.builder(resourceUri, "Subscribable Resource").mimeType("text/plain").build(),
+				(exchange, req) -> McpSchema.ReadResourceResult.builder(List
+					.of(McpSchema.TextResourceContents.builder(resourceUri, "content").mimeType("text/plain").build()))
+					.build());
 
 		McpSyncServer mcpServer = prepareSyncServerBuilder().serverInfo("test-server", "1.0.0")
 			.capabilities(McpSchema.ServerCapabilities.builder().resources(true, false).build())
@@ -1884,8 +1890,8 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 
 			mcpClient.initialize();
 
-			mcpClient.subscribeResource(new McpSchema.SubscribeRequest(resourceUri));
-			mcpClient.unsubscribeResource(new McpSchema.UnsubscribeRequest(resourceUri));
+			mcpClient.subscribeResource(McpSchema.SubscribeRequest.builder(resourceUri).build());
+			mcpClient.unsubscribeResource(McpSchema.UnsubscribeRequest.builder(resourceUri).build());
 
 			mcpServer.notifyResourcesUpdated(new McpSchema.ResourcesUpdatedNotification(resourceUri));
 

--- a/mcp-test/src/main/java/io/modelcontextprotocol/AbstractStatelessIntegrationTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/AbstractStatelessIntegrationTests.java
@@ -62,7 +62,8 @@ public abstract class AbstractStatelessIntegrationTests {
 
 		try (
 				// Create client without sampling capabilities
-				var client = clientBuilder.clientInfo(new McpSchema.Implementation("Sample " + "client", "0.0.0"))
+				var client = clientBuilder
+					.clientInfo(McpSchema.Implementation.builder("Sample " + "client", "0.0.0").build())
 					.requestTimeout(Duration.ofSeconds(1000))
 					.build()) {
 
@@ -84,12 +85,12 @@ public abstract class AbstractStatelessIntegrationTests {
 		var clientBuilder = clientBuilders.get(clientType);
 
 		var callResponse = McpSchema.CallToolResult.builder()
-			.content(List.of(new McpSchema.TextContent("CALL RESPONSE")))
+			.content(List.of(McpSchema.TextContent.builder("CALL RESPONSE").build()))
 			.isError(false)
 			.build();
 		McpStatelessServerFeatures.SyncToolSpecification tool1 = McpStatelessServerFeatures.SyncToolSpecification
 			.builder()
-			.tool(Tool.builder().name("tool1").description("tool1 description").inputSchema(EMPTY_JSON_SCHEMA).build())
+			.tool(Tool.builder("tool1", EMPTY_JSON_SCHEMA).description("tool1 description").build())
 			.callHandler((ctx, request) -> {
 
 				try {
@@ -121,7 +122,8 @@ public abstract class AbstractStatelessIntegrationTests {
 
 			assertThat(mcpClient.listTools().tools()).contains(tool1.tool());
 
-			CallToolResult response = mcpClient.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
+			CallToolResult response = mcpClient
+				.callTool(McpSchema.CallToolRequest.builder("tool1").arguments(Map.of()).build());
 
 			assertThat(response).isNotNull().isEqualTo(callResponse);
 		}
@@ -139,11 +141,7 @@ public abstract class AbstractStatelessIntegrationTests {
 		McpStatelessSyncServer mcpServer = prepareSyncServerBuilder()
 			.capabilities(ServerCapabilities.builder().tools(true).build())
 			.tools(McpStatelessServerFeatures.SyncToolSpecification.builder()
-				.tool(Tool.builder()
-					.name("tool1")
-					.description("tool1 description")
-					.inputSchema(EMPTY_JSON_SCHEMA)
-					.build())
+				.tool(Tool.builder("tool1", EMPTY_JSON_SCHEMA).description("tool1 description").build())
 				.callHandler((context, request) -> {
 					// We trigger a timeout on blocking read, raising an exception
 					Mono.never().block(Duration.ofSeconds(1));
@@ -159,8 +157,8 @@ public abstract class AbstractStatelessIntegrationTests {
 			// We expect the tool call to fail immediately with the exception raised by
 			// the offending tool
 			// instead of getting back a timeout.
-			assertThatExceptionOfType(McpError.class)
-				.isThrownBy(() -> mcpClient.callTool(new McpSchema.CallToolRequest("tool1", Map.of())))
+			assertThatExceptionOfType(McpError.class).isThrownBy(
+					() -> mcpClient.callTool(McpSchema.CallToolRequest.builder("tool1").arguments(Map.of()).build()))
 				.withMessageContaining("Timeout on blocking read");
 		}
 		finally {
@@ -175,12 +173,12 @@ public abstract class AbstractStatelessIntegrationTests {
 		var clientBuilder = clientBuilders.get(clientType);
 
 		var callResponse = McpSchema.CallToolResult.builder()
-			.content(List.of(new McpSchema.TextContent("CALL RESPONSE")))
+			.content(List.of(McpSchema.TextContent.builder("CALL RESPONSE").build()))
 			.isError(false)
 			.build();
 		McpStatelessServerFeatures.SyncToolSpecification tool1 = McpStatelessServerFeatures.SyncToolSpecification
 			.builder()
-			.tool(Tool.builder().name("tool1").description("tool1 description").inputSchema(EMPTY_JSON_SCHEMA).build())
+			.tool(Tool.builder("tool1", EMPTY_JSON_SCHEMA).description("tool1 description").build())
 			.callHandler((ctx, request) -> {
 				// perform a blocking call to a remote service
 				try {
@@ -238,11 +236,7 @@ public abstract class AbstractStatelessIntegrationTests {
 			// Add a new tool
 			McpStatelessServerFeatures.SyncToolSpecification tool2 = McpStatelessServerFeatures.SyncToolSpecification
 				.builder()
-				.tool(Tool.builder()
-					.name("tool2")
-					.description("tool2 description")
-					.inputSchema(EMPTY_JSON_SCHEMA)
-					.build())
+				.tool(Tool.builder("tool2", EMPTY_JSON_SCHEMA).description("tool2 description").build())
 				.callHandler((exchange, request) -> callResponse)
 				.build();
 
@@ -285,8 +279,7 @@ public abstract class AbstractStatelessIntegrationTests {
 						Map.of("type", "string"), "timestamp", Map.of("type", "string")),
 				"required", List.of("result", "operation"));
 
-		Tool calculatorTool = Tool.builder()
-			.name("calculator")
+		Tool calculatorTool = Tool.builder("calculator")
 			.description("Performs mathematical calculations")
 			.outputSchema(outputSchema)
 			.build();
@@ -320,8 +313,8 @@ public abstract class AbstractStatelessIntegrationTests {
 			// Note: outputSchema might be null in sync server, but validation still works
 
 			// Call tool with valid structured output
-			CallToolResult response = mcpClient
-				.callTool(new McpSchema.CallToolRequest("calculator", Map.of("expression", "2 + 3")));
+			CallToolResult response = mcpClient.callTool(
+					McpSchema.CallToolRequest.builder("calculator").arguments(Map.of("expression", "2 + 3")).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response.isError()).isFalse();
@@ -365,8 +358,7 @@ public abstract class AbstractStatelessIntegrationTests {
 					"age", Map.of("type", "number")),					
 				"required", List.of("name", "age"))); // @formatter:on
 
-		Tool calculatorTool = Tool.builder()
-			.name("getMembers")
+		Tool calculatorTool = Tool.builder("getMembers")
 			.description("Returns a list of members")
 			.outputSchema(outputSchema)
 			.build();
@@ -390,7 +382,8 @@ public abstract class AbstractStatelessIntegrationTests {
 			assertThat(mcpClient.initialize()).isNotNull();
 
 			// Call tool with valid structured output of type array
-			CallToolResult response = mcpClient.callTool(new McpSchema.CallToolRequest("getMembers", Map.of()));
+			CallToolResult response = mcpClient
+				.callTool(McpSchema.CallToolRequest.builder("getMembers").arguments(Map.of()).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response.isError()).isFalse();
@@ -420,8 +413,7 @@ public abstract class AbstractStatelessIntegrationTests {
 						Map.of("type", "string"), "timestamp", Map.of("type", "string")),
 				"required", List.of("result", "operation"));
 
-		Tool calculatorTool = Tool.builder()
-			.name("calculator")
+		Tool calculatorTool = Tool.builder("calculator")
 			.description("Performs mathematical calculations")
 			.outputSchema(outputSchema)
 			.build();
@@ -432,7 +424,7 @@ public abstract class AbstractStatelessIntegrationTests {
 			.tool(calculatorTool)
 			.callHandler((exchange, request) -> CallToolResult.builder()
 				.isError(true)
-				.content(List.of(new TextContent("Error calling tool: Simulated in-handler error")))
+				.content(List.of(TextContent.builder("Error calling tool: Simulated in-handler error").build()))
 				.build())
 			.build();
 
@@ -452,14 +444,14 @@ public abstract class AbstractStatelessIntegrationTests {
 			// Note: outputSchema might be null in sync server, but validation still works
 
 			// Call tool with valid structured output
-			CallToolResult response = mcpClient
-				.callTool(new McpSchema.CallToolRequest("calculator", Map.of("expression", "2 + 3")));
+			CallToolResult response = mcpClient.callTool(
+					McpSchema.CallToolRequest.builder("calculator").arguments(Map.of("expression", "2 + 3")).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response.isError()).isTrue();
 			assertThat(response.content()).isNotEmpty();
-			assertThat(response.content())
-				.containsExactly(new McpSchema.TextContent("Error calling tool: Simulated in-handler error"));
+			assertThat(response.content()).containsExactly(
+					McpSchema.TextContent.builder("Error calling tool: Simulated in-handler error").build());
 			assertThat(response.structuredContent()).isNull();
 		}
 		finally {
@@ -478,8 +470,7 @@ public abstract class AbstractStatelessIntegrationTests {
 				Map.of("result", Map.of("type", "number"), "operation", Map.of("type", "string")), "required",
 				List.of("result", "operation"));
 
-		Tool calculatorTool = Tool.builder()
-			.name("calculator")
+		Tool calculatorTool = Tool.builder("calculator")
 			.description("Performs mathematical calculations")
 			.outputSchema(outputSchema)
 			.build();
@@ -507,8 +498,8 @@ public abstract class AbstractStatelessIntegrationTests {
 			assertThat(initResult).isNotNull();
 
 			// Call tool with invalid structured output
-			CallToolResult response = mcpClient
-				.callTool(new McpSchema.CallToolRequest("calculator", Map.of("expression", "2 + 3")));
+			CallToolResult response = mcpClient.callTool(
+					McpSchema.CallToolRequest.builder("calculator").arguments(Map.of("expression", "2 + 3")).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response.isError()).isTrue();
@@ -533,8 +524,7 @@ public abstract class AbstractStatelessIntegrationTests {
 		Map<String, Object> outputSchema = Map.of("type", "object", "properties",
 				Map.of("result", Map.of("type", "number")), "required", List.of("result"));
 
-		Tool calculatorTool = Tool.builder()
-			.name("calculator")
+		Tool calculatorTool = Tool.builder("calculator")
 			.description("Performs mathematical calculations")
 			.outputSchema(outputSchema)
 			.build();
@@ -557,8 +547,8 @@ public abstract class AbstractStatelessIntegrationTests {
 			assertThat(initResult).isNotNull();
 
 			// Call tool that should return structured content but doesn't
-			CallToolResult response = mcpClient
-				.callTool(new McpSchema.CallToolRequest("calculator", Map.of("expression", "2 + 3")));
+			CallToolResult response = mcpClient.callTool(
+					McpSchema.CallToolRequest.builder("calculator").arguments(Map.of("expression", "2 + 3")).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response.isError()).isTrue();
@@ -597,8 +587,7 @@ public abstract class AbstractStatelessIntegrationTests {
 					Map.of("message", Map.of("type", "string"), "count", Map.of("type", "integer")), "required",
 					List.of("message", "count"));
 
-			Tool dynamicTool = Tool.builder()
-				.name("dynamic-tool")
+			Tool dynamicTool = Tool.builder("dynamic-tool")
 				.description("Dynamically added tool")
 				.outputSchema(outputSchema)
 				.build();
@@ -630,7 +619,7 @@ public abstract class AbstractStatelessIntegrationTests {
 
 			// Call dynamically added tool
 			CallToolResult response = mcpClient
-				.callTool(new McpSchema.CallToolRequest("dynamic-tool", Map.of("count", 3)));
+				.callTool(McpSchema.CallToolRequest.builder("dynamic-tool").arguments(Map.of("count", 3)).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response.isError()).isFalse();

--- a/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientResiliencyTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientResiliencyTests.java
@@ -205,7 +205,9 @@ public abstract class AbstractMcpAsyncClientResiliencyTests {
 
 			String name = tools.get().get(0).name();
 			// Assuming this is the echo tool
-			McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(name, Map.of("message", "hello"));
+			McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder(name)
+				.arguments(Map.of("message", "hello"))
+				.build();
 			StepVerifier.create(mcpAsyncClient.callTool(request)).expectError().verify();
 
 			reconnect();

--- a/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientTests.java
@@ -85,8 +85,10 @@ public abstract class AbstractMcpAsyncClientTests {
 			McpClient.AsyncSpec builder = McpClient.async(transport)
 				.requestTimeout(getRequestTimeout())
 				.initializationTimeout(getInitializationTimeout())
-				.sampling(req -> Mono.just(new CreateMessageResult(McpSchema.Role.USER,
-						new McpSchema.TextContent("Oh, hi!"), "modelId", CreateMessageResult.StopReason.END_TURN)))
+				.sampling(req -> Mono.just(CreateMessageResult
+					.builder(McpSchema.Role.USER, McpSchema.TextContent.builder("Oh, hi!").build(), "modelId")
+					.stopReason(CreateMessageResult.StopReason.END_TURN)
+					.build()))
 				.capabilities(ClientCapabilities.builder().roots(true).sampling().build());
 			builder = customizer.apply(builder);
 			client.set(builder.build());
@@ -176,11 +178,7 @@ public abstract class AbstractMcpAsyncClientTests {
 					assertThat(result.tools()).isNotNull();
 					// Verify that the returned list is immutable
 					assertThatThrownBy(() -> result.tools()
-						.add(Tool.builder()
-							.name("test")
-							.title("test")
-							.inputSchema(JSON_MAPPER, "{\"type\":\"object\"}")
-							.build()))
+						.add(Tool.builder("test", JSON_MAPPER, "{\"type\":\"object\"}").title("test").build()))
 						.isInstanceOf(UnsupportedOperationException.class);
 				})
 				.verifyComplete();
@@ -203,14 +201,18 @@ public abstract class AbstractMcpAsyncClientTests {
 
 	@Test
 	void testCallToolWithoutInitialization() {
-		CallToolRequest callToolRequest = new CallToolRequest("echo", Map.of("message", ECHO_TEST_MESSAGE));
+		CallToolRequest callToolRequest = CallToolRequest.builder("echo")
+			.arguments(Map.of("message", ECHO_TEST_MESSAGE))
+			.build();
 		verifyCallSucceedsWithImplicitInitialization(client -> client.callTool(callToolRequest), "calling tools");
 	}
 
 	@Test
 	void testCallTool() {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
-			CallToolRequest callToolRequest = new CallToolRequest("echo", Map.of("message", ECHO_TEST_MESSAGE));
+			CallToolRequest callToolRequest = CallToolRequest.builder("echo")
+				.arguments(Map.of("message", ECHO_TEST_MESSAGE))
+				.build();
 
 			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.callTool(callToolRequest)))
 				.consumeNextWith(callToolResult -> {
@@ -226,8 +228,9 @@ public abstract class AbstractMcpAsyncClientTests {
 	@Test
 	void testCallToolWithInvalidTool() {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
-			CallToolRequest invalidRequest = new CallToolRequest("nonexistent_tool",
-					Map.of("message", ECHO_TEST_MESSAGE));
+			CallToolRequest invalidRequest = CallToolRequest.builder("nonexistent_tool")
+				.arguments(Map.of("message", ECHO_TEST_MESSAGE))
+				.build();
 
 			StepVerifier.create(mcpAsyncClient.initialize().then(mcpAsyncClient.callTool(invalidRequest)))
 				.consumeErrorWith(
@@ -243,8 +246,9 @@ public abstract class AbstractMcpAsyncClientTests {
 
 		withClient(transport, mcpAsyncClient -> {
 			StepVerifier.create(mcpAsyncClient.initialize()
-				.then(mcpAsyncClient.callTool(new McpSchema.CallToolRequest("annotatedMessage",
-						Map.of("messageType", messageType, "includeImage", true)))))
+				.then(mcpAsyncClient.callTool(McpSchema.CallToolRequest.builder("annotatedMessage")
+					.arguments(Map.of("messageType", messageType, "includeImage", true))
+					.build())))
 				.consumeNextWith(result -> {
 					assertThat(result).isNotNull();
 					assertThat(result.isError()).isNotEqualTo(true);
@@ -345,8 +349,7 @@ public abstract class AbstractMcpAsyncClientTests {
 				.consumeNextWith(result -> {
 					assertThat(result.resources()).isNotNull();
 					// Verify that the returned list is immutable
-					assertThatThrownBy(
-							() -> result.resources().add(Resource.builder().uri("test://uri").name("test").build()))
+					assertThatThrownBy(() -> result.resources().add(Resource.builder("test://uri", "test").build()))
 						.isInstanceOf(UnsupportedOperationException.class);
 				})
 				.verifyComplete();
@@ -411,7 +414,8 @@ public abstract class AbstractMcpAsyncClientTests {
 				.consumeNextWith(result -> {
 					assertThat(result.prompts()).isNotNull();
 					// Verify that the returned list is immutable
-					assertThatThrownBy(() -> result.prompts().add(new Prompt("test", "test", "test", null)))
+					assertThatThrownBy(() -> result.prompts()
+						.add(Prompt.builder("test").title("test").description("test").build()))
 						.isInstanceOf(UnsupportedOperationException.class);
 				})
 				.verifyComplete();
@@ -420,7 +424,7 @@ public abstract class AbstractMcpAsyncClientTests {
 
 	@Test
 	void testGetPromptWithoutInitialization() {
-		GetPromptRequest request = new GetPromptRequest("simple_prompt", Map.of());
+		GetPromptRequest request = GetPromptRequest.builder("simple_prompt").arguments(Map.of()).build();
 		verifyCallSucceedsWithImplicitInitialization(client -> client.getPrompt(request), "getting " + "prompts");
 	}
 
@@ -429,7 +433,8 @@ public abstract class AbstractMcpAsyncClientTests {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
 			StepVerifier
 				.create(mcpAsyncClient.initialize()
-					.then(mcpAsyncClient.getPrompt(new GetPromptRequest("simple_prompt", Map.of()))))
+					.then(mcpAsyncClient
+						.getPrompt(GetPromptRequest.builder("simple_prompt").arguments(Map.of()).build())))
 				.consumeNextWith(prompt -> {
 					assertThat(prompt).isNotNull().satisfies(result -> {
 						assertThat(result.messages()).isNotEmpty();
@@ -456,8 +461,8 @@ public abstract class AbstractMcpAsyncClientTests {
 
 	@Test
 	void testInitializeWithRootsListProviders() {
-		withClient(createMcpTransport(), builder -> builder.roots(new Root("file:///test/path", "test-root")),
-				client -> {
+		withClient(createMcpTransport(),
+				builder -> builder.roots(Root.builder("file:///test/path").name("test-root").build()), client -> {
 					StepVerifier.create(client.initialize().then(client.closeGracefully())).verifyComplete();
 				});
 	}
@@ -465,7 +470,7 @@ public abstract class AbstractMcpAsyncClientTests {
 	@Test
 	void testAddRoot() {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
-			Root newRoot = new Root("file:///new/test/path", "new-test-root");
+			Root newRoot = Root.builder("file:///new/test/path").name("new-test-root").build();
 			StepVerifier.create(mcpAsyncClient.addRoot(newRoot)).verifyComplete();
 		});
 	}
@@ -483,7 +488,7 @@ public abstract class AbstractMcpAsyncClientTests {
 	@Test
 	void testRemoveRoot() {
 		withClient(createMcpTransport(), mcpAsyncClient -> {
-			Root root = new Root("file:///test/path/to/remove", "root-to-remove");
+			Root root = Root.builder("file:///test/path/to/remove").name("root-to-remove").build();
 			StepVerifier.create(mcpAsyncClient.addRoot(root)).verifyComplete();
 
 			StepVerifier.create(mcpAsyncClient.removeRoot(root.uri())).verifyComplete();
@@ -603,7 +608,7 @@ public abstract class AbstractMcpAsyncClientTests {
 					assertThat(result.resourceTemplates()).isNotNull();
 					// Verify that the returned list is immutable
 					assertThatThrownBy(() -> result.resourceTemplates()
-						.add(new McpSchema.ResourceTemplate("test://template", "test", "test", null, null, null)))
+						.add(McpSchema.ResourceTemplate.builder("test://template", "test").title("test").build()))
 						.isInstanceOf(UnsupportedOperationException.class);
 				})
 				.verifyComplete();
@@ -618,8 +623,8 @@ public abstract class AbstractMcpAsyncClientTests {
 					return Mono.empty();
 				}
 				Resource firstResource = resources.resources().get(0);
-				return mcpAsyncClient.subscribeResource(new SubscribeRequest(firstResource.uri()))
-					.then(mcpAsyncClient.unsubscribeResource(new UnsubscribeRequest(firstResource.uri())));
+				return mcpAsyncClient.subscribeResource(SubscribeRequest.builder(firstResource.uri()).build())
+					.then(mcpAsyncClient.unsubscribeResource(UnsubscribeRequest.builder(firstResource.uri()).build()));
 			})).verifyComplete();
 		});
 	}
@@ -646,9 +651,8 @@ public abstract class AbstractMcpAsyncClientTests {
 	@Test
 	void testInitializeWithSamplingCapability() {
 		ClientCapabilities capabilities = ClientCapabilities.builder().sampling().build();
-		CreateMessageResult createMessageResult = CreateMessageResult.builder()
-			.message("test")
-			.model("test-model")
+		CreateMessageResult createMessageResult = CreateMessageResult
+			.builder(McpSchema.Role.ASSISTANT, "test", "test-model")
 			.build();
 		withClient(createMcpTransport(),
 				builder -> builder.capabilities(capabilities).sampling(request -> Mono.just(createMessageResult)),
@@ -660,8 +664,7 @@ public abstract class AbstractMcpAsyncClientTests {
 	@Test
 	void testInitializeWithElicitationCapability() {
 		ClientCapabilities capabilities = ClientCapabilities.builder().elicitation().build();
-		ElicitResult elicitResult = ElicitResult.builder()
-			.message(ElicitResult.Action.ACCEPT)
+		ElicitResult elicitResult = ElicitResult.builder(ElicitResult.Action.ACCEPT)
 			.content(Map.of("foo", "bar"))
 			.build();
 		withClient(createMcpTransport(),
@@ -680,10 +683,10 @@ public abstract class AbstractMcpAsyncClientTests {
 			.build();
 
 		Function<CreateMessageRequest, Mono<CreateMessageResult>> samplingHandler = request -> Mono
-			.just(CreateMessageResult.builder().message("test").model("test-model").build());
+			.just(CreateMessageResult.builder(McpSchema.Role.ASSISTANT, "test", "test-model").build());
 
 		Function<ElicitRequest, Mono<ElicitResult>> elicitationHandler = request -> Mono
-			.just(ElicitResult.builder().message(ElicitResult.Action.ACCEPT).content(Map.of("foo", "bar")).build());
+			.just(ElicitResult.builder(ElicitResult.Action.ACCEPT).content(Map.of("foo", "bar")).build());
 
 		withClient(createMcpTransport(),
 				builder -> builder.capabilities(capabilities).sampling(samplingHandler).elicitation(elicitationHandler),
@@ -757,15 +760,16 @@ public abstract class AbstractMcpAsyncClientTests {
 				receivedMessage.set(messageText.text());
 				receivedMaxTokens.set(request.maxTokens());
 
-				return Mono
-					.just(new McpSchema.CreateMessageResult(McpSchema.Role.USER, new McpSchema.TextContent(response),
-							"modelId", McpSchema.CreateMessageResult.StopReason.END_TURN));
+				return Mono.just(McpSchema.CreateMessageResult
+					.builder(McpSchema.Role.USER, McpSchema.TextContent.builder(response).build(), "modelId")
+					.stopReason(McpSchema.CreateMessageResult.StopReason.END_TURN)
+					.build());
 			}), client -> {
 				StepVerifier.create(client.initialize()).expectNextMatches(Objects::nonNull).verifyComplete();
 
-				StepVerifier.create(client.callTool(
-						new McpSchema.CallToolRequest("sampleLLM", Map.of("prompt", message, "maxTokens", maxTokens))))
-					.consumeNextWith(result -> {
+				StepVerifier.create(client.callTool(McpSchema.CallToolRequest.builder("sampleLLM")
+					.arguments(Map.of("prompt", message, "maxTokens", maxTokens))
+					.build())).consumeNextWith(result -> {
 						// Verify tool response to ensure our sampling response was passed
 						// through
 						assertThat(result.content()).hasAtLeastOneElementOfType(McpSchema.TextContent.class);
@@ -780,8 +784,7 @@ public abstract class AbstractMcpAsyncClientTests {
 						assertThat(receivedPrompt.get()).isNotEmpty();
 						assertThat(receivedMessage.get()).endsWith(message); // Prefixed
 						assertThat(receivedMaxTokens.get()).isEqualTo(maxTokens);
-					})
-					.verifyComplete();
+					}).verifyComplete();
 			});
 	}
 

--- a/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpSyncClientTests.java
@@ -186,14 +186,16 @@ public abstract class AbstractMcpSyncClientTests {
 	@Test
 	void testCallToolsWithoutInitialization() {
 		verifyCallSucceedsWithImplicitInitialization(
-				client -> client.callTool(new CallToolRequest("add", Map.of("a", 3, "b", 4))), "calling tools");
+				client -> client.callTool(CallToolRequest.builder("add").arguments(Map.of("a", 3, "b", 4)).build()),
+				"calling tools");
 	}
 
 	@Test
 	void testCallTools() {
 		withClient(createMcpTransport(), mcpSyncClient -> {
 			mcpSyncClient.initialize();
-			CallToolResult toolResult = mcpSyncClient.callTool(new CallToolRequest("add", Map.of("a", 3, "b", 4)));
+			CallToolResult toolResult = mcpSyncClient
+				.callTool(CallToolRequest.builder("add").arguments(Map.of("a", 3, "b", 4)).build());
 
 			assertThat(toolResult).isNotNull().satisfies(result -> {
 
@@ -223,7 +225,9 @@ public abstract class AbstractMcpSyncClientTests {
 
 	@Test
 	void testCallToolWithoutInitialization() {
-		CallToolRequest callToolRequest = new CallToolRequest("echo", Map.of("message", TEST_MESSAGE));
+		CallToolRequest callToolRequest = CallToolRequest.builder("echo")
+			.arguments(Map.of("message", TEST_MESSAGE))
+			.build();
 		verifyCallSucceedsWithImplicitInitialization(client -> client.callTool(callToolRequest), "calling tools");
 	}
 
@@ -231,7 +235,9 @@ public abstract class AbstractMcpSyncClientTests {
 	void testCallTool() {
 		withClient(createMcpTransport(), mcpSyncClient -> {
 			mcpSyncClient.initialize();
-			CallToolRequest callToolRequest = new CallToolRequest("echo", Map.of("message", TEST_MESSAGE));
+			CallToolRequest callToolRequest = CallToolRequest.builder("echo")
+				.arguments(Map.of("message", TEST_MESSAGE))
+				.build();
 
 			CallToolResult callToolResult = mcpSyncClient.callTool(callToolRequest);
 
@@ -245,7 +251,9 @@ public abstract class AbstractMcpSyncClientTests {
 	@Test
 	void testCallToolWithInvalidTool() {
 		withClient(createMcpTransport(), mcpSyncClient -> {
-			CallToolRequest invalidRequest = new CallToolRequest("nonexistent_tool", Map.of("message", TEST_MESSAGE));
+			CallToolRequest invalidRequest = CallToolRequest.builder("nonexistent_tool")
+				.arguments(Map.of("message", TEST_MESSAGE))
+				.build();
 
 			assertThatThrownBy(() -> mcpSyncClient.callTool(invalidRequest)).isInstanceOf(Exception.class);
 		});
@@ -259,8 +267,9 @@ public abstract class AbstractMcpSyncClientTests {
 		withClient(transport, client -> {
 			client.initialize();
 
-			McpSchema.CallToolResult result = client.callTool(new McpSchema.CallToolRequest("annotatedMessage",
-					Map.of("messageType", messageType, "includeImage", true)));
+			McpSchema.CallToolResult result = client.callTool(McpSchema.CallToolRequest.builder("annotatedMessage")
+				.arguments(Map.of("messageType", messageType, "includeImage", true))
+				.build());
 
 			assertThat(result).isNotNull();
 			assertThat(result.isError()).isNotEqualTo(true);
@@ -370,7 +379,8 @@ public abstract class AbstractMcpSyncClientTests {
 
 	@Test
 	void testInitializeWithRootsListProviders() {
-		withClient(createMcpTransport(), builder -> builder.roots(new Root("file:///test/path", "test-root")),
+		withClient(createMcpTransport(),
+				builder -> builder.roots(Root.builder("file:///test/path").name("test-root").build()),
 				mcpSyncClient -> {
 
 					assertThatCode(() -> {
@@ -383,7 +393,7 @@ public abstract class AbstractMcpSyncClientTests {
 	@Test
 	void testAddRoot() {
 		withClient(createMcpTransport(), mcpSyncClient -> {
-			Root newRoot = new Root("file:///new/test/path", "new-test-root");
+			Root newRoot = Root.builder("file:///new/test/path").name("new-test-root").build();
 			assertThatCode(() -> mcpSyncClient.addRoot(newRoot)).doesNotThrowAnyException();
 		});
 	}
@@ -398,7 +408,7 @@ public abstract class AbstractMcpSyncClientTests {
 	@Test
 	void testRemoveRoot() {
 		withClient(createMcpTransport(), mcpSyncClient -> {
-			Root root = new Root("file:///test/path/to/remove", "root-to-remove");
+			Root root = Root.builder("file:///test/path/to/remove").name("root-to-remove").build();
 			assertThatCode(() -> {
 				mcpSyncClient.addRoot(root);
 				mcpSyncClient.removeRoot(root.uri());
@@ -533,11 +543,13 @@ public abstract class AbstractMcpSyncClientTests {
 				Resource firstResource = resources.resources().get(0);
 
 				// Test subscribe
-				assertThatCode(() -> mcpSyncClient.subscribeResource(new SubscribeRequest(firstResource.uri())))
+				assertThatCode(
+						() -> mcpSyncClient.subscribeResource(SubscribeRequest.builder(firstResource.uri()).build()))
 					.doesNotThrowAnyException();
 
 				// Test unsubscribe
-				assertThatCode(() -> mcpSyncClient.unsubscribeResource(new UnsubscribeRequest(firstResource.uri())))
+				assertThatCode(() -> mcpSyncClient
+					.unsubscribeResource(UnsubscribeRequest.builder(firstResource.uri()).build()))
 					.doesNotThrowAnyException();
 			}
 		});
@@ -623,13 +635,16 @@ public abstract class AbstractMcpSyncClientTests {
 				receivedMessage.set(messageText.text());
 				receivedMaxTokens.set(request.maxTokens());
 
-				return new McpSchema.CreateMessageResult(McpSchema.Role.USER, new McpSchema.TextContent(response),
-						"modelId", McpSchema.CreateMessageResult.StopReason.END_TURN);
+				return McpSchema.CreateMessageResult
+					.builder(McpSchema.Role.USER, McpSchema.TextContent.builder(response).build(), "modelId")
+					.stopReason(McpSchema.CreateMessageResult.StopReason.END_TURN)
+					.build();
 			}), client -> {
 				client.initialize();
 
-				McpSchema.CallToolResult result = client.callTool(
-						new McpSchema.CallToolRequest("sampleLLM", Map.of("prompt", message, "maxTokens", maxTokens)));
+				McpSchema.CallToolResult result = client.callTool(McpSchema.CallToolRequest.builder("sampleLLM")
+					.arguments(Map.of("prompt", message, "maxTokens", maxTokens))
+					.build());
 
 				// Verify tool response to ensure our sampling response was passed through
 				assertThat(result.content()).hasAtLeastOneElementOfType(McpSchema.TextContent.class);

--- a/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpAsyncServerTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpAsyncServerTests.java
@@ -99,11 +99,7 @@ public abstract class AbstractMcpAsyncServerTests {
 	// ---------------------------------------
 	@Test
 	void testAddToolCall() {
-		Tool newTool = McpSchema.Tool.builder()
-			.name("new-tool")
-			.title("New test tool")
-			.inputSchema(EMPTY_JSON_SCHEMA)
-			.build();
+		Tool newTool = McpSchema.Tool.builder("new-tool", EMPTY_JSON_SCHEMA).title("New test tool").build();
 
 		var mcpAsyncServer = prepareAsyncServerBuilder().serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
@@ -120,11 +116,7 @@ public abstract class AbstractMcpAsyncServerTests {
 
 	@Test
 	void testAddDuplicateToolCall() {
-		Tool duplicateTool = McpSchema.Tool.builder()
-			.name(TEST_TOOL_NAME)
-			.title("Duplicate tool")
-			.inputSchema(EMPTY_JSON_SCHEMA)
-			.build();
+		Tool duplicateTool = McpSchema.Tool.builder(TEST_TOOL_NAME, EMPTY_JSON_SCHEMA).title("Duplicate tool").build();
 
 		var mcpAsyncServer = prepareAsyncServerBuilder().serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
@@ -144,10 +136,8 @@ public abstract class AbstractMcpAsyncServerTests {
 
 	@Test
 	void testDuplicateToolCallDuringBuilding() {
-		Tool duplicateTool = McpSchema.Tool.builder()
-			.name("duplicate-build-toolcall")
+		Tool duplicateTool = McpSchema.Tool.builder("duplicate-build-toolcall", EMPTY_JSON_SCHEMA)
 			.title("Duplicate toolcall during building")
-			.inputSchema(EMPTY_JSON_SCHEMA)
 			.build();
 
 		assertThatThrownBy(() -> prepareAsyncServerBuilder().serverInfo("test-server", "1.0.0")
@@ -164,10 +154,8 @@ public abstract class AbstractMcpAsyncServerTests {
 
 	@Test
 	void testDuplicateToolsInBatchListRegistration() {
-		Tool duplicateTool = McpSchema.Tool.builder()
-			.name("batch-list-tool")
+		Tool duplicateTool = McpSchema.Tool.builder("batch-list-tool", EMPTY_JSON_SCHEMA)
 			.title("Duplicate tool in batch list")
-			.inputSchema(EMPTY_JSON_SCHEMA)
 			.build();
 
 		List<McpServerFeatures.AsyncToolSpecification> specs = List.of(
@@ -192,10 +180,8 @@ public abstract class AbstractMcpAsyncServerTests {
 
 	@Test
 	void testDuplicateToolsInBatchVarargsRegistration() {
-		Tool duplicateTool = McpSchema.Tool.builder()
-			.name("batch-varargs-tool")
+		Tool duplicateTool = McpSchema.Tool.builder("batch-varargs-tool", EMPTY_JSON_SCHEMA)
 			.title("Duplicate tool in batch varargs")
-			.inputSchema(EMPTY_JSON_SCHEMA)
 			.build();
 
 		assertThatThrownBy(() -> prepareAsyncServerBuilder().serverInfo("test-server", "1.0.0")
@@ -217,11 +203,7 @@ public abstract class AbstractMcpAsyncServerTests {
 
 	@Test
 	void testRemoveTool() {
-		Tool too = McpSchema.Tool.builder()
-			.name(TEST_TOOL_NAME)
-			.title("Duplicate tool")
-			.inputSchema(EMPTY_JSON_SCHEMA)
-			.build();
+		Tool too = McpSchema.Tool.builder(TEST_TOOL_NAME, EMPTY_JSON_SCHEMA).title("Duplicate tool").build();
 
 		var mcpAsyncServer = prepareAsyncServerBuilder().serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
@@ -248,11 +230,7 @@ public abstract class AbstractMcpAsyncServerTests {
 
 	@Test
 	void testNotifyToolsListChanged() {
-		Tool too = McpSchema.Tool.builder()
-			.name(TEST_TOOL_NAME)
-			.title("Duplicate tool")
-			.inputSchema(EMPTY_JSON_SCHEMA)
-			.build();
+		Tool too = McpSchema.Tool.builder(TEST_TOOL_NAME, EMPTY_JSON_SCHEMA).title("Duplicate tool").build();
 
 		var mcpAsyncServer = prepareAsyncServerBuilder().serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
@@ -296,15 +274,13 @@ public abstract class AbstractMcpAsyncServerTests {
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
 			.build();
 
-		Resource resource = Resource.builder()
-			.uri(TEST_RESOURCE_URI)
-			.name("Test Resource")
+		Resource resource = Resource.builder(TEST_RESOURCE_URI, "Test Resource")
 			.title("Test Resource")
 			.mimeType("text/plain")
 			.description("Test resource description")
 			.build();
 		McpServerFeatures.AsyncResourceSpecification specification = new McpServerFeatures.AsyncResourceSpecification(
-				resource, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
+				resource, (exchange, req) -> Mono.just(ReadResourceResult.builder(List.of()).build()));
 
 		StepVerifier.create(mcpAsyncServer.addResource(specification)).verifyComplete();
 
@@ -330,15 +306,13 @@ public abstract class AbstractMcpAsyncServerTests {
 		// Create a server without resource capabilities
 		McpAsyncServer serverWithoutResources = prepareAsyncServerBuilder().serverInfo("test-server", "1.0.0").build();
 
-		Resource resource = Resource.builder()
-			.uri(TEST_RESOURCE_URI)
-			.name("Test Resource")
+		Resource resource = Resource.builder(TEST_RESOURCE_URI, "Test Resource")
 			.title("Test Resource")
 			.mimeType("text/plain")
 			.description("Test resource description")
 			.build();
 		McpServerFeatures.AsyncResourceSpecification specification = new McpServerFeatures.AsyncResourceSpecification(
-				resource, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
+				resource, (exchange, req) -> Mono.just(ReadResourceResult.builder(List.of()).build()));
 
 		StepVerifier.create(serverWithoutResources.addResource(specification)).verifyErrorSatisfies(error -> {
 			assertThat(error).isInstanceOf(IllegalStateException.class)
@@ -363,15 +337,13 @@ public abstract class AbstractMcpAsyncServerTests {
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
 			.build();
 
-		Resource resource = Resource.builder()
-			.uri(TEST_RESOURCE_URI)
-			.name("Test Resource")
+		Resource resource = Resource.builder(TEST_RESOURCE_URI, "Test Resource")
 			.title("Test Resource")
 			.mimeType("text/plain")
 			.description("Test resource description")
 			.build();
 		McpServerFeatures.AsyncResourceSpecification specification = new McpServerFeatures.AsyncResourceSpecification(
-				resource, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
+				resource, (exchange, req) -> Mono.just(ReadResourceResult.builder(List.of()).build()));
 
 		StepVerifier
 			.create(mcpAsyncServer.addResource(specification).then(mcpAsyncServer.listResources().collectList()))
@@ -387,15 +359,13 @@ public abstract class AbstractMcpAsyncServerTests {
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
 			.build();
 
-		Resource resource = Resource.builder()
-			.uri(TEST_RESOURCE_URI)
-			.name("Test Resource")
+		Resource resource = Resource.builder(TEST_RESOURCE_URI, "Test Resource")
 			.title("Test Resource")
 			.mimeType("text/plain")
 			.description("Test resource description")
 			.build();
 		McpServerFeatures.AsyncResourceSpecification specification = new McpServerFeatures.AsyncResourceSpecification(
-				resource, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
+				resource, (exchange, req) -> Mono.just(ReadResourceResult.builder(List.of()).build()));
 
 		StepVerifier
 			.create(mcpAsyncServer.addResource(specification).then(mcpAsyncServer.removeResource(TEST_RESOURCE_URI)))
@@ -427,15 +397,14 @@ public abstract class AbstractMcpAsyncServerTests {
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
 			.build();
 
-		McpSchema.ResourceTemplate template = McpSchema.ResourceTemplate.builder()
-			.uriTemplate("test://template/{id}")
-			.name("test-template")
+		McpSchema.ResourceTemplate template = McpSchema.ResourceTemplate
+			.builder("test://template/{id}", "test-template")
 			.description("Test resource template")
 			.mimeType("text/plain")
 			.build();
 
 		McpServerFeatures.AsyncResourceTemplateSpecification specification = new McpServerFeatures.AsyncResourceTemplateSpecification(
-				template, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
+				template, (exchange, req) -> Mono.just(ReadResourceResult.builder(List.of()).build()));
 
 		StepVerifier.create(mcpAsyncServer.addResourceTemplate(specification)).verifyComplete();
 
@@ -447,15 +416,14 @@ public abstract class AbstractMcpAsyncServerTests {
 		// Create a server without resource capabilities
 		McpAsyncServer serverWithoutResources = prepareAsyncServerBuilder().serverInfo("test-server", "1.0.0").build();
 
-		McpSchema.ResourceTemplate template = McpSchema.ResourceTemplate.builder()
-			.uriTemplate("test://template/{id}")
-			.name("test-template")
+		McpSchema.ResourceTemplate template = McpSchema.ResourceTemplate
+			.builder("test://template/{id}", "test-template")
 			.description("Test resource template")
 			.mimeType("text/plain")
 			.build();
 
 		McpServerFeatures.AsyncResourceTemplateSpecification specification = new McpServerFeatures.AsyncResourceTemplateSpecification(
-				template, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
+				template, (exchange, req) -> Mono.just(ReadResourceResult.builder(List.of()).build()));
 
 		StepVerifier.create(serverWithoutResources.addResourceTemplate(specification)).verifyErrorSatisfies(error -> {
 			assertThat(error).isInstanceOf(IllegalStateException.class)
@@ -465,15 +433,14 @@ public abstract class AbstractMcpAsyncServerTests {
 
 	@Test
 	void testRemoveResourceTemplate() {
-		McpSchema.ResourceTemplate template = McpSchema.ResourceTemplate.builder()
-			.uriTemplate("test://template/{id}")
-			.name("test-template")
+		McpSchema.ResourceTemplate template = McpSchema.ResourceTemplate
+			.builder("test://template/{id}", "test-template")
 			.description("Test resource template")
 			.mimeType("text/plain")
 			.build();
 
 		McpServerFeatures.AsyncResourceTemplateSpecification specification = new McpServerFeatures.AsyncResourceTemplateSpecification(
-				template, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
+				template, (exchange, req) -> Mono.just(ReadResourceResult.builder(List.of()).build()));
 
 		var mcpAsyncServer = prepareAsyncServerBuilder().serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
@@ -510,15 +477,14 @@ public abstract class AbstractMcpAsyncServerTests {
 
 	@Test
 	void testListResourceTemplates() {
-		McpSchema.ResourceTemplate template = McpSchema.ResourceTemplate.builder()
-			.uriTemplate("test://template/{id}")
-			.name("test-template")
+		McpSchema.ResourceTemplate template = McpSchema.ResourceTemplate
+			.builder("test://template/{id}", "test-template")
 			.description("Test resource template")
 			.mimeType("text/plain")
 			.build();
 
 		McpServerFeatures.AsyncResourceTemplateSpecification specification = new McpServerFeatures.AsyncResourceTemplateSpecification(
-				template, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
+				template, (exchange, req) -> Mono.just(ReadResourceResult.builder(List.of()).build()));
 
 		var mcpAsyncServer = prepareAsyncServerBuilder().serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
@@ -568,10 +534,22 @@ public abstract class AbstractMcpAsyncServerTests {
 		// Create a server without prompt capabilities
 		McpAsyncServer serverWithoutPrompts = prepareAsyncServerBuilder().serverInfo("test-server", "1.0.0").build();
 
-		Prompt prompt = new Prompt(TEST_PROMPT_NAME, "Test Prompt", "Test Prompt", List.of());
+		Prompt prompt = Prompt.builder(TEST_PROMPT_NAME)
+			.title("Test Prompt")
+			.description("Test Prompt")
+			.arguments(List.of())
+			.build();
 		McpServerFeatures.AsyncPromptSpecification specification = new McpServerFeatures.AsyncPromptSpecification(
-				prompt, (exchange, req) -> Mono.just(new GetPromptResult("Test prompt description", List
-					.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content"))))));
+				prompt,
+				(exchange, req) -> Mono.just(
+						GetPromptResult
+							.builder(
+									List.of(PromptMessage
+										.builder(McpSchema.Role.ASSISTANT,
+												McpSchema.TextContent.builder("Test content").build())
+										.build()))
+							.description("Test prompt description")
+							.build()));
 
 		StepVerifier.create(serverWithoutPrompts.addPrompt(specification)).verifyErrorSatisfies(error -> {
 			assertThat(error).isInstanceOf(IllegalStateException.class)
@@ -594,10 +572,22 @@ public abstract class AbstractMcpAsyncServerTests {
 	void testRemovePrompt() {
 		String TEST_PROMPT_NAME_TO_REMOVE = "TEST_PROMPT_NAME678";
 
-		Prompt prompt = new Prompt(TEST_PROMPT_NAME_TO_REMOVE, "Test Prompt", "Test Prompt", List.of());
+		Prompt prompt = Prompt.builder(TEST_PROMPT_NAME_TO_REMOVE)
+			.title("Test Prompt")
+			.description("Test Prompt")
+			.arguments(List.of())
+			.build();
 		McpServerFeatures.AsyncPromptSpecification specification = new McpServerFeatures.AsyncPromptSpecification(
-				prompt, (exchange, req) -> Mono.just(new GetPromptResult("Test prompt description", List
-					.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content"))))));
+				prompt,
+				(exchange, req) -> Mono.just(
+						GetPromptResult
+							.builder(
+									List.of(PromptMessage
+										.builder(McpSchema.Role.ASSISTANT,
+												McpSchema.TextContent.builder("Test content").build())
+										.build()))
+							.description("Test prompt description")
+							.build()));
 
 		var mcpAsyncServer = prepareAsyncServerBuilder().serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().prompts(true).build())

--- a/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/server/AbstractMcpSyncServerTests.java
@@ -107,11 +107,7 @@ public abstract class AbstractMcpSyncServerTests {
 			.capabilities(ServerCapabilities.builder().tools(true).build())
 			.build();
 
-		Tool newTool = McpSchema.Tool.builder()
-			.name("new-tool")
-			.title("New test tool")
-			.inputSchema(EMPTY_JSON_SCHEMA)
-			.build();
+		Tool newTool = McpSchema.Tool.builder("new-tool", EMPTY_JSON_SCHEMA).title("New test tool").build();
 
 		assertThatCode(() -> mcpSyncServer.addTool(McpServerFeatures.SyncToolSpecification.builder()
 			.tool(newTool)
@@ -123,11 +119,7 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testAddDuplicateToolCall() {
-		Tool duplicateTool = McpSchema.Tool.builder()
-			.name(TEST_TOOL_NAME)
-			.title("Duplicate tool")
-			.inputSchema(EMPTY_JSON_SCHEMA)
-			.build();
+		Tool duplicateTool = McpSchema.Tool.builder(TEST_TOOL_NAME, EMPTY_JSON_SCHEMA).title("Duplicate tool").build();
 
 		var mcpSyncServer = prepareSyncServerBuilder().serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
@@ -145,10 +137,8 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testDuplicateToolCallDuringBuilding() {
-		Tool duplicateTool = McpSchema.Tool.builder()
-			.name("duplicate-build-toolcall")
+		Tool duplicateTool = McpSchema.Tool.builder("duplicate-build-toolcall", EMPTY_JSON_SCHEMA)
 			.title("Duplicate toolcall during building")
-			.inputSchema(EMPTY_JSON_SCHEMA)
 			.build();
 
 		assertThatThrownBy(() -> prepareSyncServerBuilder().serverInfo("test-server", "1.0.0")
@@ -163,10 +153,8 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testDuplicateToolsInBatchListRegistration() {
-		Tool duplicateTool = McpSchema.Tool.builder()
-			.name("batch-list-tool")
+		Tool duplicateTool = McpSchema.Tool.builder("batch-list-tool", EMPTY_JSON_SCHEMA)
 			.title("Duplicate tool in batch list")
-			.inputSchema(EMPTY_JSON_SCHEMA)
 			.build();
 		List<McpServerFeatures.SyncToolSpecification> specs = List.of(
 				McpServerFeatures.SyncToolSpecification.builder()
@@ -190,10 +178,8 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testDuplicateToolsInBatchVarargsRegistration() {
-		Tool duplicateTool = McpSchema.Tool.builder()
-			.name("batch-varargs-tool")
+		Tool duplicateTool = McpSchema.Tool.builder("batch-varargs-tool", EMPTY_JSON_SCHEMA)
 			.title("Duplicate tool in batch varargs")
-			.inputSchema(EMPTY_JSON_SCHEMA)
 			.build();
 
 		assertThatThrownBy(() -> prepareSyncServerBuilder().serverInfo("test-server", "1.0.0")
@@ -214,11 +200,7 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testRemoveTool() {
-		Tool tool = McpSchema.Tool.builder()
-			.name(TEST_TOOL_NAME)
-			.title("Test tool")
-			.inputSchema(EMPTY_JSON_SCHEMA)
-			.build();
+		Tool tool = McpSchema.Tool.builder(TEST_TOOL_NAME, EMPTY_JSON_SCHEMA).title("Test tool").build();
 
 		var mcpSyncServer = prepareSyncServerBuilder().serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
@@ -280,15 +262,13 @@ public abstract class AbstractMcpSyncServerTests {
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
 			.build();
 
-		Resource resource = Resource.builder()
-			.uri(TEST_RESOURCE_URI)
-			.name("Test Resource")
+		Resource resource = Resource.builder(TEST_RESOURCE_URI, "Test Resource")
 			.title("Test Resource")
 			.mimeType("text/plain")
 			.description("Test resource description")
 			.build();
 		McpServerFeatures.SyncResourceSpecification specification = new McpServerFeatures.SyncResourceSpecification(
-				resource, (exchange, req) -> new ReadResourceResult(List.of()));
+				resource, (exchange, req) -> ReadResourceResult.builder(List.of()).build());
 
 		assertThatCode(() -> mcpSyncServer.addResource(specification)).doesNotThrowAnyException();
 
@@ -312,15 +292,13 @@ public abstract class AbstractMcpSyncServerTests {
 	void testAddResourceWithoutCapability() {
 		var serverWithoutResources = prepareSyncServerBuilder().serverInfo("test-server", "1.0.0").build();
 
-		Resource resource = Resource.builder()
-			.uri(TEST_RESOURCE_URI)
-			.name("Test Resource")
+		Resource resource = Resource.builder(TEST_RESOURCE_URI, "Test Resource")
 			.title("Test Resource")
 			.mimeType("text/plain")
 			.description("Test resource description")
 			.build();
 		McpServerFeatures.SyncResourceSpecification specification = new McpServerFeatures.SyncResourceSpecification(
-				resource, (exchange, req) -> new ReadResourceResult(List.of()));
+				resource, (exchange, req) -> ReadResourceResult.builder(List.of()).build());
 
 		assertThatThrownBy(() -> serverWithoutResources.addResource(specification))
 			.isInstanceOf(IllegalStateException.class)
@@ -342,15 +320,13 @@ public abstract class AbstractMcpSyncServerTests {
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
 			.build();
 
-		Resource resource = Resource.builder()
-			.uri(TEST_RESOURCE_URI)
-			.name("Test Resource")
+		Resource resource = Resource.builder(TEST_RESOURCE_URI, "Test Resource")
 			.title("Test Resource")
 			.mimeType("text/plain")
 			.description("Test resource description")
 			.build();
 		McpServerFeatures.SyncResourceSpecification specification = new McpServerFeatures.SyncResourceSpecification(
-				resource, (exchange, req) -> new ReadResourceResult(List.of()));
+				resource, (exchange, req) -> ReadResourceResult.builder(List.of()).build());
 
 		mcpSyncServer.addResource(specification);
 		List<McpSchema.Resource> resources = mcpSyncServer.listResources();
@@ -367,15 +343,13 @@ public abstract class AbstractMcpSyncServerTests {
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
 			.build();
 
-		Resource resource = Resource.builder()
-			.uri(TEST_RESOURCE_URI)
-			.name("Test Resource")
+		Resource resource = Resource.builder(TEST_RESOURCE_URI, "Test Resource")
 			.title("Test Resource")
 			.mimeType("text/plain")
 			.description("Test resource description")
 			.build();
 		McpServerFeatures.SyncResourceSpecification specification = new McpServerFeatures.SyncResourceSpecification(
-				resource, (exchange, req) -> new ReadResourceResult(List.of()));
+				resource, (exchange, req) -> ReadResourceResult.builder(List.of()).build());
 
 		mcpSyncServer.addResource(specification);
 		assertThatCode(() -> mcpSyncServer.removeResource(TEST_RESOURCE_URI)).doesNotThrowAnyException();
@@ -406,15 +380,14 @@ public abstract class AbstractMcpSyncServerTests {
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
 			.build();
 
-		McpSchema.ResourceTemplate template = McpSchema.ResourceTemplate.builder()
-			.uriTemplate("test://template/{id}")
-			.name("test-template")
+		McpSchema.ResourceTemplate template = McpSchema.ResourceTemplate
+			.builder("test://template/{id}", "test-template")
 			.description("Test resource template")
 			.mimeType("text/plain")
 			.build();
 
 		McpServerFeatures.SyncResourceTemplateSpecification specification = new McpServerFeatures.SyncResourceTemplateSpecification(
-				template, (exchange, req) -> new ReadResourceResult(List.of()));
+				template, (exchange, req) -> ReadResourceResult.builder(List.of()).build());
 
 		assertThatCode(() -> mcpSyncServer.addResourceTemplate(specification)).doesNotThrowAnyException();
 
@@ -426,15 +399,14 @@ public abstract class AbstractMcpSyncServerTests {
 		// Create a server without resource capabilities
 		var serverWithoutResources = prepareSyncServerBuilder().serverInfo("test-server", "1.0.0").build();
 
-		McpSchema.ResourceTemplate template = McpSchema.ResourceTemplate.builder()
-			.uriTemplate("test://template/{id}")
-			.name("test-template")
+		McpSchema.ResourceTemplate template = McpSchema.ResourceTemplate
+			.builder("test://template/{id}", "test-template")
 			.description("Test resource template")
 			.mimeType("text/plain")
 			.build();
 
 		McpServerFeatures.SyncResourceTemplateSpecification specification = new McpServerFeatures.SyncResourceTemplateSpecification(
-				template, (exchange, req) -> new ReadResourceResult(List.of()));
+				template, (exchange, req) -> ReadResourceResult.builder(List.of()).build());
 
 		assertThatThrownBy(() -> serverWithoutResources.addResourceTemplate(specification))
 			.isInstanceOf(IllegalStateException.class)
@@ -443,15 +415,14 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testRemoveResourceTemplate() {
-		McpSchema.ResourceTemplate template = McpSchema.ResourceTemplate.builder()
-			.uriTemplate("test://template/{id}")
-			.name("test-template")
+		McpSchema.ResourceTemplate template = McpSchema.ResourceTemplate
+			.builder("test://template/{id}", "test-template")
 			.description("Test resource template")
 			.mimeType("text/plain")
 			.build();
 
 		McpServerFeatures.SyncResourceTemplateSpecification specification = new McpServerFeatures.SyncResourceTemplateSpecification(
-				template, (exchange, req) -> new ReadResourceResult(List.of()));
+				template, (exchange, req) -> ReadResourceResult.builder(List.of()).build());
 
 		var mcpSyncServer = prepareSyncServerBuilder().serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
@@ -487,15 +458,14 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testListResourceTemplates() {
-		McpSchema.ResourceTemplate template = McpSchema.ResourceTemplate.builder()
-			.uriTemplate("test://template/{id}")
-			.name("test-template")
+		McpSchema.ResourceTemplate template = McpSchema.ResourceTemplate
+			.builder("test://template/{id}", "test-template")
 			.description("Test resource template")
 			.mimeType("text/plain")
 			.build();
 
 		McpServerFeatures.SyncResourceTemplateSpecification specification = new McpServerFeatures.SyncResourceTemplateSpecification(
-				template, (exchange, req) -> new ReadResourceResult(List.of()));
+				template, (exchange, req) -> ReadResourceResult.builder(List.of()).build());
 
 		var mcpSyncServer = prepareSyncServerBuilder().serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
@@ -537,10 +507,21 @@ public abstract class AbstractMcpSyncServerTests {
 	void testAddPromptWithoutCapability() {
 		var serverWithoutPrompts = prepareSyncServerBuilder().serverInfo("test-server", "1.0.0").build();
 
-		Prompt prompt = new Prompt(TEST_PROMPT_NAME, "Test Prompt", "Test Prompt", List.of());
+		Prompt prompt = Prompt.builder(TEST_PROMPT_NAME)
+			.title("Test Prompt")
+			.description("Test Prompt")
+			.arguments(List.of())
+			.build();
 		McpServerFeatures.SyncPromptSpecification specification = new McpServerFeatures.SyncPromptSpecification(prompt,
-				(exchange, req) -> new GetPromptResult("Test prompt description", List
-					.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content")))));
+				(exchange,
+						req) -> GetPromptResult
+							.builder(
+									List.of(PromptMessage
+										.builder(McpSchema.Role.ASSISTANT,
+												McpSchema.TextContent.builder("Test content").build())
+										.build()))
+							.description("Test prompt description")
+							.build());
 
 		assertThatThrownBy(() -> serverWithoutPrompts.addPrompt(specification))
 			.isInstanceOf(IllegalStateException.class)
@@ -558,10 +539,21 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testRemovePrompt() {
-		Prompt prompt = new Prompt(TEST_PROMPT_NAME, "Test Prompt", "Test Prompt", List.of());
+		Prompt prompt = Prompt.builder(TEST_PROMPT_NAME)
+			.title("Test Prompt")
+			.description("Test Prompt")
+			.arguments(List.of())
+			.build();
 		McpServerFeatures.SyncPromptSpecification specification = new McpServerFeatures.SyncPromptSpecification(prompt,
-				(exchange, req) -> new GetPromptResult("Test prompt description", List
-					.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content")))));
+				(exchange,
+						req) -> GetPromptResult
+							.builder(
+									List.of(PromptMessage
+										.builder(McpSchema.Role.ASSISTANT,
+												McpSchema.TextContent.builder("Test content").build())
+										.build()))
+							.description("Test prompt description")
+							.build());
 
 		var mcpSyncServer = prepareSyncServerBuilder().serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().prompts(true).build())

--- a/mcp-test/src/test/java/io/modelcontextprotocol/client/McpAsyncClientResponseHandlerTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/client/McpAsyncClientResponseHandlerTests.java
@@ -30,7 +30,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class McpAsyncClientResponseHandlerTests {
 
-	private static final McpSchema.Implementation SERVER_INFO = new McpSchema.Implementation("test-server", "1.0.0");
+	private static final McpSchema.Implementation SERVER_INFO = McpSchema.Implementation.builder("test-server", "1.0.0")
+		.build();
 
 	private static final McpSchema.ServerCapabilities SERVER_CAPABILITIES = McpSchema.ServerCapabilities.builder()
 		.tools(true)
@@ -43,13 +44,14 @@ class McpAsyncClientResponseHandlerTests {
 
 	private static MockMcpClientTransport initializationEnabledTransport(
 			McpSchema.ServerCapabilities mockServerCapabilities, McpSchema.Implementation mockServerInfo) {
-		McpSchema.InitializeResult mockInitResult = new McpSchema.InitializeResult(ProtocolVersions.MCP_2025_11_25,
-				mockServerCapabilities, mockServerInfo, "Test instructions");
+		McpSchema.InitializeResult mockInitResult = McpSchema.InitializeResult
+			.builder(ProtocolVersions.MCP_2025_11_25, mockServerCapabilities, mockServerInfo)
+			.instructions("Test instructions")
+			.build();
 
 		return new MockMcpClientTransport((t, message) -> {
 			if (message instanceof McpSchema.JSONRPCRequest r && METHOD_INITIALIZE.equals(r.method())) {
-				McpSchema.JSONRPCResponse initResponse = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION,
-						r.id(), mockInitResult, null);
+				McpSchema.JSONRPCResponse initResponse = McpSchema.JSONRPCResponse.result(r.id(), mockInitResult);
 				t.simulateIncomingMessage(initResponse);
 			}
 		}).withProtocolVersion(ProtocolVersions.MCP_2025_11_25);
@@ -57,7 +59,7 @@ class McpAsyncClientResponseHandlerTests {
 
 	@Test
 	void testSuccessfulInitialization() {
-		McpSchema.Implementation serverInfo = new McpSchema.Implementation("mcp-test-server", "0.0.1");
+		McpSchema.Implementation serverInfo = McpSchema.Implementation.builder("mcp-test-server", "0.0.1").build();
 		McpSchema.ServerCapabilities serverCapabilities = McpSchema.ServerCapabilities.builder()
 			.tools(false)
 			.resources(true, true) // Enable both resources and resource templates
@@ -111,37 +113,37 @@ class McpAsyncClientResponseHandlerTests {
 
 		// Create a mock tools list that the server will return
 		Map<String, Object> inputSchema = Map.of("type", "object", "properties", Map.of(), "required", List.of());
-		McpSchema.Tool mockTool = McpSchema.Tool.builder()
-			.name("test-tool-1")
+		McpSchema.Tool mockTool = McpSchema.Tool
+			.builder("test-tool-1", JSON_MAPPER, JSON_MAPPER.writeValueAsString(inputSchema))
 			.description("Test Tool 1 Description")
-			.inputSchema(JSON_MAPPER, JSON_MAPPER.writeValueAsString(inputSchema))
 			.build();
 
 		// Create page 1 response with nextPageToken
 		String nextPageToken = "page2Token";
-		McpSchema.ListToolsResult mockToolsResult1 = new McpSchema.ListToolsResult(List.of(mockTool), nextPageToken);
+		McpSchema.ListToolsResult mockToolsResult1 = McpSchema.ListToolsResult.builder(List.of(mockTool))
+			.nextCursor(nextPageToken)
+			.build();
 
 		// Simulate server sending tools/list_changed notification
-		McpSchema.JSONRPCNotification notification = new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION,
-				McpSchema.METHOD_NOTIFICATION_TOOLS_LIST_CHANGED, null);
+		McpSchema.JSONRPCNotification notification = new McpSchema.JSONRPCNotification(
+				McpSchema.METHOD_NOTIFICATION_TOOLS_LIST_CHANGED);
 		transport.simulateIncomingMessage(notification);
 
 		// Simulate server response to first tools/list request
 		McpSchema.JSONRPCRequest toolsListRequest1 = transport.getLastSentMessageAsRequest();
 		assertThat(toolsListRequest1.method()).isEqualTo(McpSchema.METHOD_TOOLS_LIST);
 
-		McpSchema.JSONRPCResponse toolsListResponse1 = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION,
-				toolsListRequest1.id(), mockToolsResult1, null);
+		McpSchema.JSONRPCResponse toolsListResponse1 = McpSchema.JSONRPCResponse.result(toolsListRequest1.id(),
+				mockToolsResult1);
 		transport.simulateIncomingMessage(toolsListResponse1);
 
 		// Create mock tools for page 2
-		McpSchema.Tool mockTool2 = McpSchema.Tool.builder()
-			.name("test-tool-2")
+		McpSchema.Tool mockTool2 = McpSchema.Tool
+			.builder("test-tool-2", JSON_MAPPER, JSON_MAPPER.writeValueAsString(inputSchema))
 			.description("Test Tool 2 Description")
-			.inputSchema(JSON_MAPPER, JSON_MAPPER.writeValueAsString(inputSchema))
 			.build();
 		// Create page 2 response with no nextPageToken (last page)
-		McpSchema.ListToolsResult mockToolsResult2 = new McpSchema.ListToolsResult(List.of(mockTool2), null);
+		McpSchema.ListToolsResult mockToolsResult2 = McpSchema.ListToolsResult.builder(List.of(mockTool2)).build();
 
 		// Simulate server response to second tools/list request with page token
 		McpSchema.JSONRPCRequest toolsListRequest2 = transport.getLastSentMessageAsRequest();
@@ -152,8 +154,8 @@ class McpAsyncClientResponseHandlerTests {
 		assertThat(params).isNotNull();
 		assertThat(params.cursor()).isEqualTo(nextPageToken);
 
-		McpSchema.JSONRPCResponse toolsListResponse2 = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION,
-				toolsListRequest2.id(), mockToolsResult2, null);
+		McpSchema.JSONRPCResponse toolsListResponse2 = McpSchema.JSONRPCResponse.result(toolsListRequest2.id(),
+				mockToolsResult2);
 		transport.simulateIncomingMessage(toolsListResponse2);
 
 		// Verify the consumer received all expected tools from both pages
@@ -171,14 +173,13 @@ class McpAsyncClientResponseHandlerTests {
 		MockMcpClientTransport transport = initializationEnabledTransport();
 
 		McpAsyncClient asyncMcpClient = McpClient.async(transport)
-			.roots(new Root("file:///test/path", "test-root"))
+			.roots(Root.builder("file:///test/path").name("test-root").build())
 			.build();
 
 		assertThat(asyncMcpClient.initialize().block()).isNotNull();
 
 		// Simulate incoming request
-		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION,
-				McpSchema.METHOD_ROOTS_LIST, "test-id", null);
+		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.METHOD_ROOTS_LIST, "test-id");
 		transport.simulateIncomingMessage(request);
 
 		// Verify response
@@ -187,8 +188,9 @@ class McpAsyncClientResponseHandlerTests {
 
 		McpSchema.JSONRPCResponse response = (McpSchema.JSONRPCResponse) sentMessage;
 		assertThat(response.id()).isEqualTo("test-id");
-		assertThat(response.result())
-			.isEqualTo(new McpSchema.ListRootsResult(List.of(new Root("file:///test/path", "test-root"))));
+		assertThat(response.result()).isEqualTo(McpSchema.ListRootsResult
+			.builder(List.of(McpSchema.Root.builder("file:///test/path").name("test-root").build()))
+			.build());
 		assertThat(response.error()).isNull();
 
 		asyncMcpClient.closeGracefully();
@@ -213,26 +215,24 @@ class McpAsyncClientResponseHandlerTests {
 		assertThat(asyncMcpClient.initialize().block()).isNotNull();
 
 		// Create a mock resources list that the server will return
-		McpSchema.Resource mockResource = McpSchema.Resource.builder()
-			.uri("test://resource")
-			.name("Test Resource")
+		McpSchema.Resource mockResource = McpSchema.Resource.builder("test://resource", "Test Resource")
 			.description("A test resource")
 			.mimeType("text/plain")
 			.build();
-		McpSchema.ListResourcesResult mockResourcesResult = new McpSchema.ListResourcesResult(List.of(mockResource),
-				null);
+		McpSchema.ListResourcesResult mockResourcesResult = McpSchema.ListResourcesResult.builder(List.of(mockResource))
+			.build();
 
 		// Simulate server sending resources/list_changed notification
-		McpSchema.JSONRPCNotification notification = new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION,
-				McpSchema.METHOD_NOTIFICATION_RESOURCES_LIST_CHANGED, null);
+		McpSchema.JSONRPCNotification notification = new McpSchema.JSONRPCNotification(
+				McpSchema.METHOD_NOTIFICATION_RESOURCES_LIST_CHANGED);
 		transport.simulateIncomingMessage(notification);
 
 		// Simulate server response to resources/list request
 		McpSchema.JSONRPCRequest resourcesListRequest = transport.getLastSentMessageAsRequest();
 		assertThat(resourcesListRequest.method()).isEqualTo(McpSchema.METHOD_RESOURCES_LIST);
 
-		McpSchema.JSONRPCResponse resourcesListResponse = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION,
-				resourcesListRequest.id(), mockResourcesResult, null);
+		McpSchema.JSONRPCResponse resourcesListResponse = McpSchema.JSONRPCResponse.result(resourcesListRequest.id(),
+				mockResourcesResult);
 		transport.simulateIncomingMessage(resourcesListResponse);
 
 		// Verify the consumer received the expected resources
@@ -261,21 +261,29 @@ class McpAsyncClientResponseHandlerTests {
 		assertThat(asyncMcpClient.initialize().block()).isNotNull();
 
 		// Create a mock prompts list that the server will return
-		McpSchema.Prompt mockPrompt = new McpSchema.Prompt("test-prompt", "Test Prompt", "Test Prompt Description",
-				List.of(new McpSchema.PromptArgument("arg1", "Test argument", "Test argument", true)));
-		McpSchema.ListPromptsResult mockPromptsResult = new McpSchema.ListPromptsResult(List.of(mockPrompt), null);
+		McpSchema.Prompt mockPrompt = McpSchema.Prompt.builder("test-prompt")
+			.title("Test Prompt")
+			.description("Test Prompt Description")
+			.arguments(List.of(McpSchema.PromptArgument.builder("arg1")
+				.title("Test argument")
+				.description("Test argument")
+				.required(true)
+				.build()))
+			.build();
+		McpSchema.ListPromptsResult mockPromptsResult = McpSchema.ListPromptsResult.builder(List.of(mockPrompt))
+			.build();
 
 		// Simulate server sending prompts/list_changed notification
-		McpSchema.JSONRPCNotification notification = new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION,
-				McpSchema.METHOD_NOTIFICATION_PROMPTS_LIST_CHANGED, null);
+		McpSchema.JSONRPCNotification notification = new McpSchema.JSONRPCNotification(
+				McpSchema.METHOD_NOTIFICATION_PROMPTS_LIST_CHANGED);
 		transport.simulateIncomingMessage(notification);
 
 		// Simulate server response to prompts/list request
 		McpSchema.JSONRPCRequest promptsListRequest = transport.getLastSentMessageAsRequest();
 		assertThat(promptsListRequest.method()).isEqualTo(McpSchema.METHOD_PROMPT_LIST);
 
-		McpSchema.JSONRPCResponse promptsListResponse = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION,
-				promptsListRequest.id(), mockPromptsResult, null);
+		McpSchema.JSONRPCResponse promptsListResponse = McpSchema.JSONRPCResponse.result(promptsListRequest.id(),
+				mockPromptsResult);
 		transport.simulateIncomingMessage(promptsListResponse);
 
 		// Verify the consumer received the expected prompts
@@ -295,8 +303,9 @@ class McpAsyncClientResponseHandlerTests {
 		// Create a test sampling handler that echoes back the input
 		Function<McpSchema.CreateMessageRequest, Mono<McpSchema.CreateMessageResult>> samplingHandler = request -> {
 			var content = request.messages().get(0).content();
-			return Mono.just(new McpSchema.CreateMessageResult(McpSchema.Role.ASSISTANT, content, "test-model",
-					McpSchema.CreateMessageResult.StopReason.END_TURN));
+			return Mono.just(McpSchema.CreateMessageResult.builder(McpSchema.Role.ASSISTANT, content, "test-model")
+				.stopReason(McpSchema.CreateMessageResult.StopReason.END_TURN)
+				.build());
 		};
 
 		// Create client with sampling capability and handler
@@ -308,18 +317,18 @@ class McpAsyncClientResponseHandlerTests {
 		assertThat(asyncMcpClient.initialize().block()).isNotNull();
 
 		// Create a mock create message request
-		var messageRequest = new McpSchema.CreateMessageRequest(
-				List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER, new McpSchema.TextContent("Test message"))),
-				null, // modelPreferences
-				"Test system prompt", McpSchema.CreateMessageRequest.ContextInclusionStrategy.NONE, 0.7, // temperature
-				100, // maxTokens
-				null, // stopSequences
-				null // metadata
-		);
+		var messageRequest = McpSchema.CreateMessageRequest
+			.builder(List.of(McpSchema.SamplingMessage
+				.builder(McpSchema.Role.USER, McpSchema.TextContent.builder("Test message").build())
+				.build()), 100)
+			.systemPrompt("Test system prompt")
+			.includeContext(McpSchema.CreateMessageRequest.ContextInclusionStrategy.NONE)
+			.temperature(0.7)
+			.build();
 
 		// Simulate incoming request
-		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION,
-				McpSchema.METHOD_SAMPLING_CREATE_MESSAGE, "test-id", messageRequest);
+		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.METHOD_SAMPLING_CREATE_MESSAGE,
+				"test-id", messageRequest);
 		transport.simulateIncomingMessage(request);
 
 		// Verify response
@@ -354,13 +363,13 @@ class McpAsyncClientResponseHandlerTests {
 		assertThat(asyncMcpClient.initialize().block()).isNotNull();
 
 		// Create a mock create message request
-		var messageRequest = new McpSchema.CreateMessageRequest(
-				List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER, new McpSchema.TextContent("Test message"))),
-				null, null, null, null, 0, null, null);
+		var messageRequest = McpSchema.CreateMessageRequest.builder(List.of(McpSchema.SamplingMessage
+			.builder(McpSchema.Role.USER, McpSchema.TextContent.builder("Test message").build())
+			.build()), 0).build();
 
 		// Simulate incoming request
-		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION,
-				McpSchema.METHOD_SAMPLING_CREATE_MESSAGE, "test-id", messageRequest);
+		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.METHOD_SAMPLING_CREATE_MESSAGE,
+				"test-id", messageRequest);
 		transport.simulateIncomingMessage(request);
 
 		// Verify error response
@@ -402,8 +411,7 @@ class McpAsyncClientResponseHandlerTests {
 			assertThat(properties).isNotNull();
 			assertThat(((Map<String, Object>) properties).get("message")).isInstanceOf(Map.class);
 
-			return Mono.just(McpSchema.ElicitResult.builder()
-				.message(McpSchema.ElicitResult.Action.ACCEPT)
+			return Mono.just(McpSchema.ElicitResult.builder(McpSchema.ElicitResult.Action.ACCEPT)
 				.content(Map.of("message", request.message()))
 				.build());
 		};
@@ -417,14 +425,14 @@ class McpAsyncClientResponseHandlerTests {
 		assertThat(asyncMcpClient.initialize().block()).isNotNull();
 
 		// Create a mock elicitation
-		var elicitRequest = McpSchema.ElicitRequest.builder()
-			.message("Test message")
-			.requestedSchema(Map.of("type", "object", "properties", Map.of("message", Map.of("type", "string"))))
+		var elicitRequest = McpSchema.ElicitRequest
+			.builder("Test message",
+					Map.of("type", "object", "properties", Map.of("message", Map.of("type", "string"))))
 			.build();
 
 		// Simulate incoming request
-		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION,
-				McpSchema.METHOD_ELICITATION_CREATE, "test-id", elicitRequest);
+		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.METHOD_ELICITATION_CREATE, "test-id",
+				elicitRequest);
 		transport.simulateIncomingMessage(request);
 
 		// Verify response
@@ -451,7 +459,7 @@ class McpAsyncClientResponseHandlerTests {
 
 		// Create a test elicitation handler to decline the request
 		Function<McpSchema.ElicitRequest, Mono<McpSchema.ElicitResult>> elicitationHandler = request -> Mono
-			.just(McpSchema.ElicitResult.builder().message(action).build());
+			.just(McpSchema.ElicitResult.builder(action).build());
 
 		// Create client with elicitation capability and handler
 		McpAsyncClient asyncMcpClient = McpClient.async(transport)
@@ -462,14 +470,14 @@ class McpAsyncClientResponseHandlerTests {
 		assertThat(asyncMcpClient.initialize().block()).isNotNull();
 
 		// Create a mock elicitation
-		var elicitRequest = McpSchema.ElicitRequest.builder()
-			.message("Test message")
-			.requestedSchema(Map.of("type", "object", "properties", Map.of("message", Map.of("type", "string"))))
+		var elicitRequest = McpSchema.ElicitRequest
+			.builder("Test message",
+					Map.of("type", "object", "properties", Map.of("message", Map.of("type", "string"))))
 			.build();
 
 		// Simulate incoming request
-		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION,
-				McpSchema.METHOD_ELICITATION_CREATE, "test-id", elicitRequest);
+		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.METHOD_ELICITATION_CREATE, "test-id",
+				elicitRequest);
 		transport.simulateIncomingMessage(request);
 
 		// Verify response
@@ -502,13 +510,15 @@ class McpAsyncClientResponseHandlerTests {
 		assertThat(asyncMcpClient.initialize().block()).isNotNull();
 
 		// Create a mock elicitation
-		var elicitRequest = new McpSchema.ElicitRequest("test",
-				Map.of("type", "object", "properties", Map.of("test", Map.of("type", "boolean", "defaultValue", true,
-						"description", "test-description", "title", "test-title"))));
+		var elicitRequest = McpSchema.ElicitRequest
+			.builder("test",
+					Map.of("type", "object", "properties", Map.of("test", Map.of("type", "boolean", "defaultValue",
+							true, "description", "test-description", "title", "test-title"))))
+			.build();
 
 		// Simulate incoming request
-		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION,
-				McpSchema.METHOD_ELICITATION_CREATE, "test-id", elicitRequest);
+		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.METHOD_ELICITATION_CREATE, "test-id",
+				elicitRequest);
 		transport.simulateIncomingMessage(request);
 
 		// Verify error response
@@ -544,8 +554,7 @@ class McpAsyncClientResponseHandlerTests {
 		assertThat(asyncMcpClient.initialize().block()).isNotNull();
 
 		// Simulate incoming ping request from server
-		McpSchema.JSONRPCRequest pingRequest = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION,
-				McpSchema.METHOD_PING, "ping-id", null);
+		McpSchema.JSONRPCRequest pingRequest = new McpSchema.JSONRPCRequest(McpSchema.METHOD_PING, "ping-id");
 		transport.simulateIncomingMessage(pingRequest);
 
 		// Verify response

--- a/mcp-test/src/test/java/io/modelcontextprotocol/client/McpAsyncClientTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/client/McpAsyncClientTests.java
@@ -26,15 +26,18 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 class McpAsyncClientTests {
 
-	public static final McpSchema.Implementation MOCK_SERVER_INFO = new McpSchema.Implementation("test-server",
-			"1.0.0");
+	public static final McpSchema.Implementation MOCK_SERVER_INFO = McpSchema.Implementation
+		.builder("test-server", "1.0.0")
+		.build();
 
 	public static final McpSchema.ServerCapabilities MOCK_SERVER_CAPABILITIES = McpSchema.ServerCapabilities.builder()
 		.tools(true)
 		.build();
 
-	public static final McpSchema.InitializeResult MOCK_INIT_RESULT = new McpSchema.InitializeResult(
-			ProtocolVersions.MCP_2024_11_05, MOCK_SERVER_CAPABILITIES, MOCK_SERVER_INFO, "Test instructions");
+	public static final McpSchema.InitializeResult MOCK_INIT_RESULT = McpSchema.InitializeResult
+		.builder(ProtocolVersions.MCP_2024_11_05, MOCK_SERVER_CAPABILITIES, MOCK_SERVER_INFO)
+		.instructions("Test instructions")
+		.build();
 
 	private static final String CONTEXT_KEY = "context.key";
 
@@ -44,10 +47,8 @@ class McpAsyncClientTests {
 		Map<String, Object> inputSchemaMap = Map.of("type", "object", "properties",
 				Map.of("expression", Map.of("type", "string")), "required", List.of("expression"));
 
-		McpSchema.Tool.Builder toolBuilder = McpSchema.Tool.builder()
-			.name("calculator")
-			.description("Performs mathematical calculations")
-			.inputSchema(inputSchemaMap);
+		McpSchema.Tool.Builder toolBuilder = McpSchema.Tool.builder("calculator", inputSchemaMap)
+			.description("Performs mathematical calculations");
 
 		if (hasOutputSchema) {
 			Map<String, Object> outputSchema = Map.of("type", "object", "properties",
@@ -57,7 +58,7 @@ class McpAsyncClientTests {
 		}
 
 		McpSchema.Tool calculatorTool = toolBuilder.build();
-		McpSchema.ListToolsResult mockToolsResult = new McpSchema.ListToolsResult(List.of(calculatorTool), null);
+		McpSchema.ListToolsResult mockToolsResult = McpSchema.ListToolsResult.builder(List.of(calculatorTool)).build();
 
 		// Create call tool result - valid or invalid based on parameter
 		Map<String, Object> structuredContent = invalidOutput ? Map.of("result", "5", "operation", "add")
@@ -91,16 +92,13 @@ class McpAsyncClientTests {
 
 				McpSchema.JSONRPCResponse response;
 				if (McpSchema.METHOD_INITIALIZE.equals(request.method())) {
-					response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), MOCK_INIT_RESULT,
-							null);
+					response = McpSchema.JSONRPCResponse.result(request.id(), MOCK_INIT_RESULT);
 				}
 				else if (McpSchema.METHOD_TOOLS_LIST.equals(request.method())) {
-					response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), mockToolsResult,
-							null);
+					response = McpSchema.JSONRPCResponse.result(request.id(), mockToolsResult);
 				}
 				else if (McpSchema.METHOD_TOOLS_CALL.equals(request.method())) {
-					response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(),
-							mockCallToolResult, null);
+					response = McpSchema.JSONRPCResponse.result(request.id(), mockCallToolResult);
 				}
 				else {
 					return Mono.empty();
@@ -155,8 +153,8 @@ class McpAsyncClientTests {
 				if (!(message instanceof McpSchema.JSONRPCRequest)) {
 					return Mono.empty();
 				}
-				McpSchema.JSONRPCResponse initResponse = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION,
-						((McpSchema.JSONRPCRequest) message).id(), MOCK_INIT_RESULT, null);
+				McpSchema.JSONRPCResponse initResponse = McpSchema.JSONRPCResponse
+					.result(((McpSchema.JSONRPCRequest) message).id(), MOCK_INIT_RESULT);
 				return handler.apply(Mono.just(initResponse)).then();
 			}
 
@@ -185,7 +183,9 @@ class McpAsyncClientTests {
 
 		StepVerifier.create(client.initialize()).expectNextMatches(Objects::nonNull).verifyComplete();
 
-		StepVerifier.create(client.callTool(new McpSchema.CallToolRequest("calculator", Map.of("expression", "2 + 3"))))
+		StepVerifier
+			.create(client.callTool(
+					McpSchema.CallToolRequest.builder("calculator").arguments(Map.of("expression", "2 + 3")).build()))
 			.expectNextMatches(response -> {
 				assertThat(response).isNotNull();
 				assertThat(response.isError()).isFalse();
@@ -207,7 +207,9 @@ class McpAsyncClientTests {
 
 		StepVerifier.create(client.initialize()).expectNextMatches(Objects::nonNull).verifyComplete();
 
-		StepVerifier.create(client.callTool(new McpSchema.CallToolRequest("calculator", Map.of("expression", "2 + 3"))))
+		StepVerifier
+			.create(client.callTool(
+					McpSchema.CallToolRequest.builder("calculator").arguments(Map.of("expression", "2 + 3")).build()))
 			.expectNextMatches(response -> {
 				assertThat(response).isNotNull();
 				assertThat(response.isError()).isFalse();
@@ -229,7 +231,9 @@ class McpAsyncClientTests {
 
 		StepVerifier.create(client.initialize()).expectNextMatches(Objects::nonNull).verifyComplete();
 
-		StepVerifier.create(client.callTool(new McpSchema.CallToolRequest("calculator", Map.of("expression", "2 + 3"))))
+		StepVerifier
+			.create(client.callTool(
+					McpSchema.CallToolRequest.builder("calculator").arguments(Map.of("expression", "2 + 3")).build()))
 			.expectErrorMatches(ex -> ex instanceof IllegalArgumentException
 					&& ex.getMessage().contains("Tool call result validation failed"))
 			.verify();
@@ -326,50 +330,50 @@ class McpAsyncClientTests {
 					.tools(false)
 					.build();
 
-				McpSchema.InitializeResult initResult = new McpSchema.InitializeResult(ProtocolVersions.MCP_2024_11_05,
-						caps, MOCK_SERVER_INFO, null);
+				McpSchema.InitializeResult initResult = McpSchema.InitializeResult
+					.builder(ProtocolVersions.MCP_2024_11_05, caps, MOCK_SERVER_INFO)
+					.build();
 
-				response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), initResult, null);
+				response = McpSchema.JSONRPCResponse.result(request.id(), initResult);
 			}
 			else if (McpSchema.METHOD_PROMPT_LIST.equals(request.method())) {
 				capturedRequest = JSON_MAPPER.convertValue(request.params(), McpSchema.PaginatedRequest.class);
 
-				McpSchema.Prompt mockPrompt = new McpSchema.Prompt("test-prompt", "A test prompt", List.of());
-				McpSchema.ListPromptsResult mockPromptResult = new McpSchema.ListPromptsResult(List.of(mockPrompt),
-						null);
-				response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), mockPromptResult,
-						null);
+				McpSchema.Prompt mockPrompt = McpSchema.Prompt.builder("test-prompt")
+					.description("A test prompt")
+					.arguments(List.of())
+					.build();
+				McpSchema.ListPromptsResult mockPromptResult = McpSchema.ListPromptsResult.builder(List.of(mockPrompt))
+					.build();
+				response = McpSchema.JSONRPCResponse.result(request.id(), mockPromptResult);
 			}
 			else if (McpSchema.METHOD_RESOURCES_TEMPLATES_LIST.equals(request.method())) {
 				capturedRequest = JSON_MAPPER.convertValue(request.params(), McpSchema.PaginatedRequest.class);
 
-				McpSchema.ResourceTemplate mockTemplate = new McpSchema.ResourceTemplate("file:///{name}", "template",
-						null, null, null);
-				McpSchema.ListResourceTemplatesResult mockResourceTemplateResult = new McpSchema.ListResourceTemplatesResult(
-						List.of(mockTemplate), null);
-				response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(),
-						mockResourceTemplateResult, null);
+				McpSchema.ResourceTemplate mockTemplate = McpSchema.ResourceTemplate
+					.builder("file:///{name}", "template")
+					.build();
+				McpSchema.ListResourceTemplatesResult mockResourceTemplateResult = McpSchema.ListResourceTemplatesResult
+					.builder(List.of(mockTemplate))
+					.build();
+				response = McpSchema.JSONRPCResponse.result(request.id(), mockResourceTemplateResult);
 			}
 			else if (McpSchema.METHOD_RESOURCES_LIST.equals(request.method())) {
 				capturedRequest = JSON_MAPPER.convertValue(request.params(), McpSchema.PaginatedRequest.class);
 
-				McpSchema.Resource mockResource = McpSchema.Resource.builder()
-					.uri("file:///test.txt")
-					.name("test.txt")
+				McpSchema.Resource mockResource = McpSchema.Resource.builder("file:///test.txt", "test.txt").build();
+				McpSchema.ListResourcesResult mockResourceResult = McpSchema.ListResourcesResult
+					.builder(List.of(mockResource))
 					.build();
-				McpSchema.ListResourcesResult mockResourceResult = new McpSchema.ListResourcesResult(
-						List.of(mockResource), null);
 
-				response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), mockResourceResult,
-						null);
+				response = McpSchema.JSONRPCResponse.result(request.id(), mockResourceResult);
 			}
 			else if (McpSchema.METHOD_TOOLS_LIST.equals(request.method())) {
 				capturedRequest = JSON_MAPPER.convertValue(request.params(), McpSchema.PaginatedRequest.class);
 
-				McpSchema.Tool addTool = McpSchema.Tool.builder().name("add").description("calculate add").build();
-				McpSchema.ListToolsResult mockToolsResult = new McpSchema.ListToolsResult(List.of(addTool), null);
-				response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), mockToolsResult,
-						null);
+				McpSchema.Tool addTool = McpSchema.Tool.builder("add").description("calculate add").build();
+				McpSchema.ListToolsResult mockToolsResult = McpSchema.ListToolsResult.builder(List.of(addTool)).build();
+				response = McpSchema.JSONRPCResponse.result(request.id(), mockToolsResult);
 			}
 			else {
 				return Mono.empty();

--- a/mcp-test/src/test/java/io/modelcontextprotocol/client/McpClientProtocolVersionTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/client/McpClientProtocolVersionTests.java
@@ -25,7 +25,8 @@ class McpClientProtocolVersionTests {
 
 	private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(300);
 
-	private static final McpSchema.Implementation CLIENT_INFO = new McpSchema.Implementation("test-client", "1.0.0");
+	private static final McpSchema.Implementation CLIENT_INFO = McpSchema.Implementation.builder("test-client", "1.0.0")
+		.build();
 
 	@Test
 	void shouldUseLatestVersionByDefault() {
@@ -46,10 +47,11 @@ class McpClientProtocolVersionTests {
 				McpSchema.InitializeRequest initRequest = (McpSchema.InitializeRequest) request.params();
 				assertThat(initRequest.protocolVersion()).isEqualTo(transport.protocolVersions().get(0));
 
-				transport.simulateIncomingMessage(new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(),
-						new McpSchema.InitializeResult(protocolVersion, ServerCapabilities.builder().build(),
-								new McpSchema.Implementation("test-server", "1.0.0"), null),
-						null));
+				transport.simulateIncomingMessage(McpSchema.JSONRPCResponse.result(request.id(),
+						McpSchema.InitializeResult
+							.builder(protocolVersion, ServerCapabilities.builder().build(),
+									McpSchema.Implementation.builder("test-server", "1.0.0").build())
+							.build()));
 			}).assertNext(result -> {
 				assertThat(result.protocolVersion()).isEqualTo(protocolVersion);
 			}).verifyComplete();
@@ -80,10 +82,11 @@ class McpClientProtocolVersionTests {
 				McpSchema.InitializeRequest initRequest = (McpSchema.InitializeRequest) request.params();
 				assertThat(initRequest.protocolVersion()).isIn(List.of(oldVersion, ProtocolVersions.MCP_2025_11_25));
 
-				transport.simulateIncomingMessage(new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(),
-						new McpSchema.InitializeResult(oldVersion, ServerCapabilities.builder().build(),
-								new McpSchema.Implementation("test-server", "1.0.0"), null),
-						null));
+				transport.simulateIncomingMessage(McpSchema.JSONRPCResponse.result(request.id(),
+						McpSchema.InitializeResult
+							.builder(oldVersion, ServerCapabilities.builder().build(),
+									McpSchema.Implementation.builder("test-server", "1.0.0").build())
+							.build()));
 			}).assertNext(result -> {
 				assertThat(result.protocolVersion()).isEqualTo(oldVersion);
 			}).verifyComplete();
@@ -109,10 +112,11 @@ class McpClientProtocolVersionTests {
 				McpSchema.JSONRPCRequest request = transport.getLastSentMessageAsRequest();
 				assertThat(request.params()).isInstanceOf(McpSchema.InitializeRequest.class);
 
-				transport.simulateIncomingMessage(new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(),
-						new McpSchema.InitializeResult(unsupportedVersion, ServerCapabilities.builder().build(),
-								new McpSchema.Implementation("test-server", "1.0.0"), null),
-						null));
+				transport.simulateIncomingMessage(McpSchema.JSONRPCResponse.result(request.id(),
+						McpSchema.InitializeResult
+							.builder(unsupportedVersion, ServerCapabilities.builder().build(),
+									McpSchema.Implementation.builder("test-server", "1.0.0").build())
+							.build()));
 			}).expectError(RuntimeException.class).verify();
 		}
 		finally {
@@ -142,10 +146,11 @@ class McpClientProtocolVersionTests {
 				McpSchema.InitializeRequest initRequest = (McpSchema.InitializeRequest) request.params();
 				assertThat(initRequest.protocolVersion()).isEqualTo(latestVersion);
 
-				transport.simulateIncomingMessage(new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(),
-						new McpSchema.InitializeResult(latestVersion, ServerCapabilities.builder().build(),
-								new McpSchema.Implementation("test-server", "1.0.0"), null),
-						null));
+				transport.simulateIncomingMessage(McpSchema.JSONRPCResponse.result(request.id(),
+						McpSchema.InitializeResult
+							.builder(latestVersion, ServerCapabilities.builder().build(),
+									McpSchema.Implementation.builder("test-server", "1.0.0").build())
+							.build()));
 			}).assertNext(result -> {
 				assertThat(result.protocolVersion()).isEqualTo(latestVersion);
 			}).verifyComplete();

--- a/mcp-test/src/test/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransportTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransportTests.java
@@ -14,6 +14,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.modelcontextprotocol.client.transport.customizer.McpAsyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.common.McpTransportContext;
@@ -125,8 +127,7 @@ class HttpClientSseClientTransportTests {
 
 	@Test
 	void testErrorOnBogusMessage() {
-		// bogus message
-		JSONRPCRequest bogusMessage = new JSONRPCRequest(null, null, "test-id", Map.of("key", "value"));
+		var bogusMessage = new BogusJsonRpcMessage("test-id", Map.of("key", "value"));
 
 		StepVerifier.create(transport.sendMessage(bogusMessage))
 			.verifyErrorMessage(
@@ -136,8 +137,7 @@ class HttpClientSseClientTransportTests {
 	@Test
 	void testMessageProcessing() {
 		// Create a test message
-		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method", "test-id",
-				Map.of("key", "value"));
+		JSONRPCRequest testMessage = new McpSchema.JSONRPCRequest("test-method", "test-id", Map.of("key", "value"));
 
 		// Simulate receiving the message
 		transport.simulateMessageEvent("""
@@ -167,8 +167,7 @@ class HttpClientSseClientTransportTests {
 				""");
 
 		// Create and send a request message
-		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method", "test-id",
-				Map.of("key", "value"));
+		JSONRPCRequest testMessage = new McpSchema.JSONRPCRequest("test-method", "test-id", Map.of("key", "value"));
 
 		// Verify message handling
 		StepVerifier.create(transport.sendMessage(testMessage)).verifyComplete();
@@ -191,8 +190,7 @@ class HttpClientSseClientTransportTests {
 				""");
 
 		// Create and send a request message
-		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method", "test-id",
-				Map.of("key", "value"));
+		JSONRPCRequest testMessage = new McpSchema.JSONRPCRequest("test-method", "test-id", Map.of("key", "value"));
 
 		// Verify message handling
 		StepVerifier.create(transport.sendMessage(testMessage)).verifyComplete();
@@ -221,8 +219,7 @@ class HttpClientSseClientTransportTests {
 		StepVerifier.create(transport.closeGracefully()).verifyComplete();
 
 		// Create a test message
-		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method", "test-id",
-				Map.of("key", "value"));
+		JSONRPCRequest testMessage = new McpSchema.JSONRPCRequest("test-method", "test-id", Map.of("key", "value"));
 
 		// Verify message is not processed after shutdown
 		StepVerifier.create(transport.sendMessage(testMessage)).verifyComplete();
@@ -266,11 +263,9 @@ class HttpClientSseClientTransportTests {
 				""");
 
 		// Create and send corresponding messages
-		JSONRPCRequest message1 = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "method1", "id1",
-				Map.of("key", "value1"));
+		JSONRPCRequest message1 = new McpSchema.JSONRPCRequest("method1", "id1", Map.of("key", "value1"));
 
-		JSONRPCRequest message2 = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "method2", "id2",
-				Map.of("key", "value2"));
+		JSONRPCRequest message2 = new McpSchema.JSONRPCRequest("method2", "id2", Map.of("key", "value2"));
 
 		// Verify both messages are processed
 		StepVerifier.create(transport.sendMessage(message1).then(transport.sendMessage(message2))).verifyComplete();
@@ -354,8 +349,7 @@ class HttpClientSseClientTransportTests {
 		clearInvocations(mockCustomizer);
 
 		// Send test message
-		var testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method", "test-id",
-				Map.of("key", "value"));
+		var testMessage = new McpSchema.JSONRPCRequest("test-method", "test-id", Map.of("key", "value"));
 
 		// Subscribe to messages and verify
 		StepVerifier
@@ -397,8 +391,7 @@ class HttpClientSseClientTransportTests {
 		clearInvocations(mockCustomizer);
 
 		// Send test message
-		var testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method", "test-id",
-				Map.of("key", "value"));
+		var testMessage = new McpSchema.JSONRPCRequest("test-method", "test-id", Map.of("key", "value"));
 
 		// Subscribe to messages and verify
 		StepVerifier
@@ -415,6 +408,32 @@ class HttpClientSseClientTransportTests {
 
 		// Clean up
 		customizedTransport.closeGracefully().block();
+	}
+
+	/**
+	 * A minimal {@link McpSchema.JSONRPCMessage} that serializes only the supplied
+	 * fields, intentionally omitting {@code jsonrpc} and {@code method} to produce a
+	 * bogus wire payload for error-handling tests.
+	 */
+	private static class BogusJsonRpcMessage implements McpSchema.JSONRPCMessage {
+
+		@JsonProperty("id")
+		private final String id;
+
+		@JsonProperty("params")
+		private final Map<String, Object> params;
+
+		BogusJsonRpcMessage(String id, Map<String, Object> params) {
+			this.id = id;
+			this.params = params;
+		}
+
+		@Override
+		@JsonIgnore
+		public String jsonrpc() {
+			return null;
+		}
+
 	}
 
 }

--- a/mcp-test/src/test/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransportTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransportTests.java
@@ -415,7 +415,7 @@ class HttpClientSseClientTransportTests {
 	void testMessageEndpointValidation() throws InvalidSseMessageEndpointException {
 		var uriCaptor = ArgumentCaptor.forClass(URI.class);
 		verify(sseMessageEndpointValidator).validate(uriCaptor.capture(), matches("/message\\?sessionId=[a-z0-9-]+"));
-		assertThat(uriCaptor.getValue().toString()).matches("http://localhost:\\d+/sse");
+		assertThat(uriCaptor.getValue().toString()).matches(host + "/sse");
 	}
 
 	@Test

--- a/mcp-test/src/test/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransportEmptyJsonResponseTest.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransportEmptyJsonResponseTest.java
@@ -76,11 +76,11 @@ public class HttpClientStreamableHttpTransportEmptyJsonResponseTest {
 			.httpRequestCustomizer(mockRequestCustomizer)
 			.build();
 
-		var initializeRequest = new McpSchema.InitializeRequest(ProtocolVersions.MCP_2025_03_26,
-				McpSchema.ClientCapabilities.builder().roots(true).build(),
-				new McpSchema.Implementation("MCP Client", "0.3.1"));
-		var testMessage = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, McpSchema.METHOD_INITIALIZE,
-				"test-id", initializeRequest);
+		var initializeRequest = McpSchema.InitializeRequest
+			.builder(ProtocolVersions.MCP_2025_03_26, McpSchema.ClientCapabilities.builder().roots(true).build(),
+					McpSchema.Implementation.builder("MCP Client", "0.3.1").build())
+			.build();
+		var testMessage = new McpSchema.JSONRPCRequest(McpSchema.METHOD_INITIALIZE, "test-id", initializeRequest);
 
 		StepVerifier.create(transport.sendMessage(testMessage)).verifyComplete();
 

--- a/mcp-test/src/test/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransportErrorHandlingTest.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransportErrorHandlingTest.java
@@ -770,11 +770,11 @@ public class HttpClientStreamableHttpTransportErrorHandlingTest {
 	}
 
 	private McpSchema.JSONRPCRequest createTestRequestMessage() {
-		var initializeRequest = new McpSchema.InitializeRequest(ProtocolVersions.MCP_2025_03_26,
-				McpSchema.ClientCapabilities.builder().roots(true).build(),
-				new McpSchema.Implementation("Test Client", "1.0.0"));
-		return new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, McpSchema.METHOD_INITIALIZE, "test-id",
-				initializeRequest);
+		var initializeRequest = McpSchema.InitializeRequest
+			.builder(ProtocolVersions.MCP_2025_03_26, McpSchema.ClientCapabilities.builder().roots(true).build(),
+					McpSchema.Implementation.builder("Test Client", "1.0.0").build())
+			.build();
+		return new McpSchema.JSONRPCRequest(McpSchema.METHOD_INITIALIZE, "test-id", initializeRequest);
 	}
 
 }

--- a/mcp-test/src/test/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransportTest.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransportTest.java
@@ -79,11 +79,11 @@ class HttpClientStreamableHttpTransportTest {
 
 		withTransport(transport, (t) -> {
 			// Send test message
-			var initializeRequest = new McpSchema.InitializeRequest(ProtocolVersions.MCP_2025_11_25,
-					McpSchema.ClientCapabilities.builder().roots(true).build(),
-					new McpSchema.Implementation("MCP Client", "0.3.1"));
-			var testMessage = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, McpSchema.METHOD_INITIALIZE,
-					"test-id", initializeRequest);
+			var initializeRequest = McpSchema.InitializeRequest
+				.builder(ProtocolVersions.MCP_2025_11_25, McpSchema.ClientCapabilities.builder().roots(true).build(),
+						McpSchema.Implementation.builder("MCP Client", "0.3.1").build())
+				.build();
+			var testMessage = new McpSchema.JSONRPCRequest(McpSchema.METHOD_INITIALIZE, "test-id", initializeRequest);
 
 			StepVerifier
 				.create(t.sendMessage(testMessage).contextWrite(ctx -> ctx.put(McpTransportContext.KEY, context)))
@@ -109,11 +109,11 @@ class HttpClientStreamableHttpTransportTest {
 
 		withTransport(transport, (t) -> {
 			// Send test message
-			var initializeRequest = new McpSchema.InitializeRequest(ProtocolVersions.MCP_2025_11_25,
-					McpSchema.ClientCapabilities.builder().roots(true).build(),
-					new McpSchema.Implementation("MCP Client", "0.3.1"));
-			var testMessage = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, McpSchema.METHOD_INITIALIZE,
-					"test-id", initializeRequest);
+			var initializeRequest = McpSchema.InitializeRequest
+				.builder(ProtocolVersions.MCP_2025_11_25, McpSchema.ClientCapabilities.builder().roots(true).build(),
+						McpSchema.Implementation.builder("MCP Client", "0.3.1").build())
+				.build();
+			var testMessage = new McpSchema.JSONRPCRequest(McpSchema.METHOD_INITIALIZE, "test-id", initializeRequest);
 
 			StepVerifier
 				.create(t.sendMessage(testMessage).contextWrite(ctx -> ctx.put(McpTransportContext.KEY, context)))
@@ -132,11 +132,11 @@ class HttpClientStreamableHttpTransportTest {
 
 		StepVerifier.create(transport.closeGracefully()).verifyComplete();
 
-		var initializeRequest = new McpSchema.InitializeRequest(ProtocolVersions.MCP_2025_11_25,
-				McpSchema.ClientCapabilities.builder().roots(true).build(),
-				new McpSchema.Implementation("MCP Client", "0.3.1"));
-		var testMessage = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, McpSchema.METHOD_INITIALIZE,
-				"test-id", initializeRequest);
+		var initializeRequest = McpSchema.InitializeRequest
+			.builder(ProtocolVersions.MCP_2025_11_25, McpSchema.ClientCapabilities.builder().roots(true).build(),
+					McpSchema.Implementation.builder("MCP Client", "0.3.1").build())
+			.build();
+		var testMessage = new McpSchema.JSONRPCRequest(McpSchema.METHOD_INITIALIZE, "test-id", initializeRequest);
 
 		StepVerifier.create(transport.sendMessage(testMessage))
 			.expectErrorMessage("MCP session has been closed")
@@ -147,11 +147,11 @@ class HttpClientStreamableHttpTransportTest {
 	void testCloseInitialized() {
 		var transport = HttpClientStreamableHttpTransport.builder(host).build();
 
-		var initializeRequest = new McpSchema.InitializeRequest(ProtocolVersions.MCP_2025_11_25,
-				McpSchema.ClientCapabilities.builder().roots(true).build(),
-				new McpSchema.Implementation("MCP Client", "0.3.1"));
-		var testMessage = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, McpSchema.METHOD_INITIALIZE,
-				"test-id", initializeRequest);
+		var initializeRequest = McpSchema.InitializeRequest
+			.builder(ProtocolVersions.MCP_2025_11_25, McpSchema.ClientCapabilities.builder().roots(true).build(),
+					McpSchema.Implementation.builder("MCP Client", "0.3.1").build())
+			.build();
+		var testMessage = new McpSchema.JSONRPCRequest(McpSchema.METHOD_INITIALIZE, "test-id", initializeRequest);
 
 		StepVerifier.create(transport.sendMessage(testMessage)).verifyComplete();
 		StepVerifier.create(transport.closeGracefully()).verifyComplete();

--- a/mcp-test/src/test/java/io/modelcontextprotocol/common/AsyncServerMcpTransportContextIntegrationTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/common/AsyncServerMcpTransportContextIntegrationTests.java
@@ -125,8 +125,7 @@ public class AsyncServerMcpTransportContextIntegrationTests {
 			.build())
 		.build();
 
-	private final McpSchema.Tool tool = McpSchema.Tool.builder()
-		.name("test-tool")
+	private final McpSchema.Tool tool = McpSchema.Tool.builder("test-tool")
 		.description("return the value of the x-test header from call tool request")
 		.build();
 
@@ -178,7 +177,8 @@ public class AsyncServerMcpTransportContextIntegrationTests {
 
 		// Test tool call with context
 		StepVerifier
-			.create(asyncStreamableClient.callTool(new McpSchema.CallToolRequest("test-tool", Map.of()))
+			.create(asyncStreamableClient
+				.callTool(McpSchema.CallToolRequest.builder("test-tool").arguments(Map.of()).build())
 				.contextWrite(ctx -> ctx.put(McpTransportContext.KEY,
 						McpTransportContext.create(Map.of("client-side-header-value", "some important value")))))
 			.assertNext(response -> {
@@ -212,7 +212,8 @@ public class AsyncServerMcpTransportContextIntegrationTests {
 
 		// Test tool call with context
 		StepVerifier
-			.create(asyncStreamableClient.callTool(new McpSchema.CallToolRequest("test-tool", Map.of()))
+			.create(asyncStreamableClient
+				.callTool(McpSchema.CallToolRequest.builder("test-tool").arguments(Map.of()).build())
 				.contextWrite(ctx -> ctx.put(McpTransportContext.KEY,
 						McpTransportContext.create(Map.of("client-side-header-value", "some important value")))))
 			.assertNext(response -> {
@@ -246,7 +247,7 @@ public class AsyncServerMcpTransportContextIntegrationTests {
 
 		// Test tool call with context
 		StepVerifier
-			.create(asyncSseClient.callTool(new McpSchema.CallToolRequest("test-tool", Map.of()))
+			.create(asyncSseClient.callTool(McpSchema.CallToolRequest.builder("test-tool").arguments(Map.of()).build())
 				.contextWrite(ctx -> ctx.put(McpTransportContext.KEY,
 						McpTransportContext.create(Map.of("client-side-header-value", "some important value")))))
 			.assertNext(response -> {

--- a/mcp-test/src/test/java/io/modelcontextprotocol/common/HttpClientStreamableHttpVersionNegotiationIntegrationTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/common/HttpClientStreamableHttpVersionNegotiationIntegrationTests.java
@@ -41,8 +41,7 @@ class HttpClientStreamableHttpVersionNegotiationIntegrationTests {
 				req -> McpTransportContext.create(Map.of("protocol-version", req.getHeader("MCP-protocol-version"))))
 		.build();
 
-	private final McpSchema.Tool toolSpec = McpSchema.Tool.builder()
-		.name("test-tool")
+	private final McpSchema.Tool toolSpec = McpSchema.Tool.builder("test-tool")
 		.description("return the protocol version used")
 		.build();
 
@@ -70,7 +69,8 @@ class HttpClientStreamableHttpVersionNegotiationIntegrationTests {
 			.build();
 
 		client.initialize();
-		McpSchema.CallToolResult response = client.callTool(new McpSchema.CallToolRequest("test-tool", Map.of()));
+		McpSchema.CallToolResult response = client
+			.callTool(McpSchema.CallToolRequest.builder("test-tool").arguments(Map.of()).build());
 
 		var calls = requestRecordingFilter.getCalls();
 
@@ -100,7 +100,8 @@ class HttpClientStreamableHttpVersionNegotiationIntegrationTests {
 		var client = McpClient.sync(transport).build();
 
 		client.initialize();
-		McpSchema.CallToolResult response = client.callTool(new McpSchema.CallToolRequest("test-tool", Map.of()));
+		McpSchema.CallToolResult response = client
+			.callTool(McpSchema.CallToolRequest.builder("test-tool").arguments(Map.of()).build());
 
 		var calls = requestRecordingFilter.getCalls();
 		// Initialize tells the server the Client's latest supported version

--- a/mcp-test/src/test/java/io/modelcontextprotocol/common/SyncServerMcpTransportContextIntegrationTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/common/SyncServerMcpTransportContextIntegrationTests.java
@@ -116,8 +116,7 @@ public class SyncServerMcpTransportContextIntegrationTests {
 		.transportContextProvider(clientContextProvider)
 		.build();
 
-	private final McpSchema.Tool tool = McpSchema.Tool.builder()
-		.name("test-tool")
+	private final McpSchema.Tool tool = McpSchema.Tool.builder("test-tool")
 		.description("return the value of the x-test header from call tool request")
 		.build();
 
@@ -156,7 +155,7 @@ public class SyncServerMcpTransportContextIntegrationTests {
 
 		CLIENT_SIDE_HEADER_VALUE_HOLDER.set("some important value");
 		McpSchema.CallToolResult response = streamableClient
-			.callTool(new McpSchema.CallToolRequest("test-tool", Map.of()));
+			.callTool(McpSchema.CallToolRequest.builder("test-tool").arguments(Map.of()).build());
 
 		assertThat(response).isNotNull();
 		assertThat(response.content()).hasSize(1)
@@ -182,7 +181,7 @@ public class SyncServerMcpTransportContextIntegrationTests {
 
 		CLIENT_SIDE_HEADER_VALUE_HOLDER.set("some important value");
 		McpSchema.CallToolResult response = streamableClient
-			.callTool(new McpSchema.CallToolRequest("test-tool", Map.of()));
+			.callTool(McpSchema.CallToolRequest.builder("test-tool").arguments(Map.of()).build());
 
 		assertThat(response).isNotNull();
 		assertThat(response.content()).hasSize(1)
@@ -207,7 +206,8 @@ public class SyncServerMcpTransportContextIntegrationTests {
 		assertThat(initResult).isNotNull();
 
 		CLIENT_SIDE_HEADER_VALUE_HOLDER.set("some important value");
-		McpSchema.CallToolResult response = sseClient.callTool(new McpSchema.CallToolRequest("test-tool", Map.of()));
+		McpSchema.CallToolResult response = sseClient
+			.callTool(McpSchema.CallToolRequest.builder("test-tool").arguments(Map.of()).build());
 
 		assertThat(response).isNotNull();
 		assertThat(response.content()).hasSize(1)

--- a/mcp-test/src/test/java/io/modelcontextprotocol/server/HttpServletStatelessIntegrationTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/server/HttpServletStatelessIntegrationTests.java
@@ -116,11 +116,11 @@ class HttpServletStatelessIntegrationTests {
 		var clientBuilder = clientBuilders.get(clientType);
 
 		var callResponse = CallToolResult.builder()
-			.content(List.of(new McpSchema.TextContent("CALL RESPONSE")))
+			.content(List.of(McpSchema.TextContent.builder("CALL RESPONSE").build()))
 			.isError(false)
 			.build();
 		McpStatelessServerFeatures.SyncToolSpecification tool1 = new McpStatelessServerFeatures.SyncToolSpecification(
-				Tool.builder().name("tool1").title("tool1 description").inputSchema(EMPTY_JSON_SCHEMA).build(),
+				Tool.builder("tool1", EMPTY_JSON_SCHEMA).title("tool1 description").build(),
 				(transportContext, request) -> {
 					// perform a blocking call to a remote service
 					String response = RestClient.create()
@@ -144,7 +144,8 @@ class HttpServletStatelessIntegrationTests {
 
 			assertThat(mcpClient.listTools().tools()).contains(tool1.tool());
 
-			CallToolResult response = mcpClient.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
+			CallToolResult response = mcpClient
+				.callTool(McpSchema.CallToolRequest.builder("tool1").arguments(Map.of()).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response).isEqualTo(callResponse);
@@ -193,12 +194,17 @@ class HttpServletStatelessIntegrationTests {
 
 		var mcpServer = McpServer.sync(mcpStatelessServerTransport)
 			.capabilities(ServerCapabilities.builder().completions().build())
-			.prompts(new McpStatelessServerFeatures.SyncPromptSpecification(
-					new Prompt("code_review", "Code review", "this is code review prompt",
-							List.of(new PromptArgument("language", "Language", "string", false))),
-					(transportContext, getPromptRequest) -> null))
+			.prompts(new McpStatelessServerFeatures.SyncPromptSpecification(Prompt.builder("code_review")
+				.title("Code review")
+				.description("this is code review prompt")
+				.arguments(List.of(PromptArgument.builder("language")
+					.title("Language")
+					.description("string")
+					.required(false)
+					.build()))
+				.build(), (transportContext, getPromptRequest) -> null))
 			.completions(new McpStatelessServerFeatures.SyncCompletionSpecification(
-					new PromptReference(PromptReference.TYPE, "code_review", "Code review"), completionHandler))
+					PromptReference.builder("code_review").title("Code review").build(), completionHandler))
 			.build();
 
 		try (var mcpClient = clientBuilder.build()) {
@@ -206,9 +212,10 @@ class HttpServletStatelessIntegrationTests {
 			InitializeResult initResult = mcpClient.initialize();
 			assertThat(initResult).isNotNull();
 
-			CompleteRequest request = new CompleteRequest(
-					new PromptReference(PromptReference.TYPE, "code_review", "Code review"),
-					new CompleteRequest.CompleteArgument("language", "py"));
+			CompleteRequest request = CompleteRequest
+				.builder(PromptReference.builder("code_review").title("Code review").build(),
+						new CompleteRequest.CompleteArgument("language", "py"))
+				.build();
 
 			CompleteResult result = mcpClient.completeCompletion(request);
 
@@ -237,8 +244,7 @@ class HttpServletStatelessIntegrationTests {
 						Map.of("type", "string"), "timestamp", Map.of("type", "string")),
 				"required", List.of("result", "operation"));
 
-		Tool calculatorTool = Tool.builder()
-			.name("calculator")
+		Tool calculatorTool = Tool.builder("calculator")
 			.description("Performs mathematical calculations")
 			.outputSchema(outputSchema)
 			.build();
@@ -270,8 +276,8 @@ class HttpServletStatelessIntegrationTests {
 			// Note: outputSchema might be null in sync server, but validation still works
 
 			// Call tool with valid structured output
-			CallToolResult response = mcpClient
-				.callTool(new McpSchema.CallToolRequest("calculator", Map.of("expression", "2 + 3")));
+			CallToolResult response = mcpClient.callTool(
+					McpSchema.CallToolRequest.builder("calculator").arguments(Map.of("expression", "2 + 3")).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response.isError()).isFalse();
@@ -312,8 +318,7 @@ class HttpServletStatelessIntegrationTests {
 					"age", Map.of("type", "number")),					
 				"required", List.of("name", "age"))); // @formatter:on
 
-		Tool calculatorTool = Tool.builder()
-			.name("getMembers")
+		Tool calculatorTool = Tool.builder("getMembers")
 			.description("Returns a list of members")
 			.outputSchema(outputSchema)
 			.build();
@@ -338,7 +343,8 @@ class HttpServletStatelessIntegrationTests {
 			assertThat(mcpClient.initialize()).isNotNull();
 
 			// Call tool with valid structured output of type array
-			CallToolResult response = mcpClient.callTool(new McpSchema.CallToolRequest("getMembers", Map.of()));
+			CallToolResult response = mcpClient
+				.callTool(McpSchema.CallToolRequest.builder("getMembers").arguments(Map.of()).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response.isError()).isFalse();
@@ -368,8 +374,7 @@ class HttpServletStatelessIntegrationTests {
 						Map.of("type", "string"), "timestamp", Map.of("type", "string")),
 				"required", List.of("result", "operation"));
 
-		Tool calculatorTool = Tool.builder()
-			.name("calculator")
+		Tool calculatorTool = Tool.builder("calculator")
 			.description("Performs mathematical calculations")
 			.outputSchema(outputSchema)
 			.build();
@@ -380,7 +385,7 @@ class HttpServletStatelessIntegrationTests {
 			.tool(calculatorTool)
 			.callHandler((exchange, request) -> CallToolResult.builder()
 				.isError(true)
-				.content(List.of(new TextContent("Error calling tool: Simulated in-handler error")))
+				.content(List.of(TextContent.builder("Error calling tool: Simulated in-handler error").build()))
 				.build())
 			.build();
 
@@ -401,14 +406,14 @@ class HttpServletStatelessIntegrationTests {
 			// Note: outputSchema might be null in sync server, but validation still works
 
 			// Call tool with valid structured output
-			CallToolResult response = mcpClient
-				.callTool(new McpSchema.CallToolRequest("calculator", Map.of("expression", "2 + 3")));
+			CallToolResult response = mcpClient.callTool(
+					McpSchema.CallToolRequest.builder("calculator").arguments(Map.of("expression", "2 + 3")).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response.isError()).isTrue();
 			assertThat(response.content()).isNotEmpty();
-			assertThat(response.content())
-				.containsExactly(new McpSchema.TextContent("Error calling tool: Simulated in-handler error"));
+			assertThat(response.content()).containsExactly(
+					McpSchema.TextContent.builder("Error calling tool: Simulated in-handler error").build());
 			assertThat(response.structuredContent()).isNull();
 		}
 		finally {
@@ -426,8 +431,7 @@ class HttpServletStatelessIntegrationTests {
 				Map.of("result", Map.of("type", "number"), "operation", Map.of("type", "string")), "required",
 				List.of("result", "operation"));
 
-		Tool calculatorTool = Tool.builder()
-			.name("calculator")
+		Tool calculatorTool = Tool.builder("calculator")
 			.description("Performs mathematical calculations")
 			.outputSchema(outputSchema)
 			.build();
@@ -453,8 +457,8 @@ class HttpServletStatelessIntegrationTests {
 			assertThat(initResult).isNotNull();
 
 			// Call tool with invalid structured output
-			CallToolResult response = mcpClient
-				.callTool(new McpSchema.CallToolRequest("calculator", Map.of("expression", "2 + 3")));
+			CallToolResult response = mcpClient.callTool(
+					McpSchema.CallToolRequest.builder("calculator").arguments(Map.of("expression", "2 + 3")).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response.isError()).isTrue();
@@ -478,8 +482,7 @@ class HttpServletStatelessIntegrationTests {
 		Map<String, Object> outputSchema = Map.of("type", "object", "properties",
 				Map.of("result", Map.of("type", "number")), "required", List.of("result"));
 
-		Tool calculatorTool = Tool.builder()
-			.name("calculator")
+		Tool calculatorTool = Tool.builder("calculator")
 			.description("Performs mathematical calculations")
 			.outputSchema(outputSchema)
 			.build();
@@ -502,8 +505,8 @@ class HttpServletStatelessIntegrationTests {
 			assertThat(initResult).isNotNull();
 
 			// Call tool that should return structured content but doesn't
-			CallToolResult response = mcpClient
-				.callTool(new McpSchema.CallToolRequest("calculator", Map.of("expression", "2 + 3")));
+			CallToolResult response = mcpClient.callTool(
+					McpSchema.CallToolRequest.builder("calculator").arguments(Map.of("expression", "2 + 3")).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response.isError()).isTrue();
@@ -542,8 +545,7 @@ class HttpServletStatelessIntegrationTests {
 					Map.of("message", Map.of("type", "string"), "count", Map.of("type", "integer")), "required",
 					List.of("message", "count"));
 
-			Tool dynamicTool = Tool.builder()
-				.name("dynamic-tool")
+			Tool dynamicTool = Tool.builder("dynamic-tool")
 				.description("Dynamically added tool")
 				.outputSchema(outputSchema)
 				.build();
@@ -573,7 +575,7 @@ class HttpServletStatelessIntegrationTests {
 
 			// Call dynamically added tool
 			CallToolResult response = mcpClient
-				.callTool(new McpSchema.CallToolRequest("dynamic-tool", Map.of("count", 3)));
+				.callTool(McpSchema.CallToolRequest.builder("dynamic-tool").arguments(Map.of("count", 3)).build());
 
 			assertThat(response).isNotNull();
 			assertThat(response.isError()).isFalse();
@@ -601,7 +603,7 @@ class HttpServletStatelessIntegrationTests {
 			.capabilities(ServerCapabilities.builder().tools(true).build())
 			.build();
 
-		Tool testTool = Tool.builder().name("test").description("test").build();
+		Tool testTool = Tool.builder("test").description("test").build();
 
 		McpStatelessServerFeatures.SyncToolSpecification toolSpec = new McpStatelessServerFeatures.SyncToolSpecification(
 				testTool, (transportContext, request) -> {
@@ -610,9 +612,11 @@ class HttpServletStatelessIntegrationTests {
 
 		mcpServer.addTool(toolSpec);
 
-		McpSchema.CallToolRequest callToolRequest = new McpSchema.CallToolRequest("test", Map.of());
-		McpSchema.JSONRPCRequest jsonrpcRequest = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION,
-				McpSchema.METHOD_TOOLS_CALL, "test", callToolRequest);
+		McpSchema.CallToolRequest callToolRequest = McpSchema.CallToolRequest.builder("test")
+			.arguments(Map.of())
+			.build();
+		McpSchema.JSONRPCRequest jsonrpcRequest = new McpSchema.JSONRPCRequest(McpSchema.METHOD_TOOLS_CALL, "test",
+				callToolRequest);
 
 		MockHttpServletRequest request = new MockHttpServletRequest("POST", CUSTOM_MESSAGE_ENDPOINT);
 		MockHttpServletResponse response = new MockHttpServletResponse();

--- a/mcp-test/src/test/java/io/modelcontextprotocol/server/McpCompletionTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/server/McpCompletionTests.java
@@ -98,11 +98,9 @@ class McpCompletionTests {
 			return new CompleteResult(new CompleteResult.CompleteCompletion(List.of("test-completion"), 1, false));
 		};
 
-		ResourceReference resourceRef = new ResourceReference(ResourceReference.TYPE, "test://resource/{param}");
+		ResourceReference resourceRef = new ResourceReference("test://resource/{param}");
 
-		var resource = Resource.builder()
-			.uri("test://resource/{param}")
-			.name("Test Resource")
+		var resource = Resource.builder("test://resource/{param}", "Test Resource")
 			.description("A resource for testing")
 			.mimeType("text/plain")
 			.size(123L)
@@ -111,19 +109,21 @@ class McpCompletionTests {
 		var mcpServer = McpServer.sync(mcpServerTransportProvider)
 			.capabilities(ServerCapabilities.builder().completions().build())
 			.resources(new McpServerFeatures.SyncResourceSpecification(resource,
-					(exchange, req) -> new ReadResourceResult(List.of())))
+					(exchange, req) -> ReadResourceResult.builder(List.of()).build()))
 			.completions(new McpServerFeatures.SyncCompletionSpecification(resourceRef, completionHandler))
 			.build();
 
-		try (var mcpClient = clientBuilder.clientInfo(new McpSchema.Implementation("Sample " + "client", "0.0.0"))
+		try (var mcpClient = clientBuilder
+			.clientInfo(McpSchema.Implementation.builder("Sample " + "client", "0.0.0").build())
 			.build();) {
 			InitializeResult initResult = mcpClient.initialize();
 			assertThat(initResult).isNotNull();
 
 			// Test with context
-			CompleteRequest request = new CompleteRequest(resourceRef,
-					new CompleteRequest.CompleteArgument("param", "test"), null,
-					new CompleteRequest.CompleteContext(Map.of("previous", "value")));
+			CompleteRequest request = CompleteRequest
+				.builder(resourceRef, new CompleteRequest.CompleteArgument("param", "test"))
+				.context(new CompleteRequest.CompleteContext(Map.of("previous", "value")))
+				.build();
 
 			CompleteResult result = mcpClient.completeCompletion(request);
 
@@ -145,25 +145,29 @@ class McpCompletionTests {
 					new CompleteResult.CompleteCompletion(List.of("no-context-completion"), 1, false));
 		};
 
-		McpSchema.Prompt prompt = new Prompt("test-prompt", "this is a test prompt",
-				List.of(new PromptArgument("arg", "string", false)));
+		McpSchema.Prompt prompt = Prompt.builder("test-prompt")
+			.description("this is a test prompt")
+			.arguments(List.of(PromptArgument.builder("arg").description("string").required(false).build()))
+			.build();
 
 		var mcpServer = McpServer.sync(mcpServerTransportProvider)
 			.capabilities(ServerCapabilities.builder().completions().build())
 			.prompts(new McpServerFeatures.SyncPromptSpecification(prompt,
 					(mcpSyncServerExchange, getPromptRequest) -> null))
-			.completions(new McpServerFeatures.SyncCompletionSpecification(
-					new PromptReference(PromptReference.TYPE, "test-prompt"), completionHandler))
+			.completions(new McpServerFeatures.SyncCompletionSpecification(new PromptReference("test-prompt"),
+					completionHandler))
 			.build();
 
-		try (var mcpClient = clientBuilder.clientInfo(new McpSchema.Implementation("Sample " + "client", "0.0.0"))
+		try (var mcpClient = clientBuilder
+			.clientInfo(McpSchema.Implementation.builder("Sample " + "client", "0.0.0").build())
 			.build();) {
 			InitializeResult initResult = mcpClient.initialize();
 			assertThat(initResult).isNotNull();
 
 			// Test without context
-			CompleteRequest request = new CompleteRequest(new PromptReference(PromptReference.TYPE, "test-prompt"),
-					new CompleteRequest.CompleteArgument("arg", "val"));
+			CompleteRequest request = CompleteRequest
+				.builder(new PromptReference("test-prompt"), new CompleteRequest.CompleteArgument("arg", "val"))
+				.build();
 
 			CompleteResult result = mcpClient.completeCompletion(request);
 
@@ -205,9 +209,7 @@ class McpCompletionTests {
 			return new CompleteResult(new CompleteResult.CompleteCompletion(List.of(), 0, false));
 		};
 
-		McpSchema.Resource resource = Resource.builder()
-			.uri("db://{database}/{table}")
-			.name("Database Table")
+		McpSchema.Resource resource = Resource.builder("db://{database}/{table}", "Database Table")
 			.description("Resource representing a table in a database")
 			.mimeType("application/json")
 			.size(456L)
@@ -216,38 +218,42 @@ class McpCompletionTests {
 		var mcpServer = McpServer.sync(mcpServerTransportProvider)
 			.capabilities(ServerCapabilities.builder().completions().build())
 			.resources(new McpServerFeatures.SyncResourceSpecification(resource,
-					(exchange, req) -> new ReadResourceResult(List.of())))
+					(exchange, req) -> ReadResourceResult.builder(List.of()).build()))
 			.completions(new McpServerFeatures.SyncCompletionSpecification(
-					new ResourceReference(ResourceReference.TYPE, "db://{database}/{table}"), completionHandler))
+					new ResourceReference("db://{database}/{table}"), completionHandler))
 			.build();
 
-		try (var mcpClient = clientBuilder.clientInfo(new McpSchema.Implementation("Sample " + "client", "0.0.0"))
+		try (var mcpClient = clientBuilder
+			.clientInfo(McpSchema.Implementation.builder("Sample " + "client", "0.0.0").build())
 			.build();) {
 			InitializeResult initResult = mcpClient.initialize();
 			assertThat(initResult).isNotNull();
 
 			// First, complete database
-			CompleteRequest dbRequest = new CompleteRequest(
-					new ResourceReference(ResourceReference.TYPE, "db://{database}/{table}"),
-					new CompleteRequest.CompleteArgument("database", ""));
+			CompleteRequest dbRequest = CompleteRequest
+				.builder(new ResourceReference("db://{database}/{table}"),
+						new CompleteRequest.CompleteArgument("database", ""))
+				.build();
 
 			CompleteResult dbResult = mcpClient.completeCompletion(dbRequest);
 			assertThat(dbResult.completion().values()).contains("users_db", "products_db");
 
 			// Then complete table with database context
-			CompleteRequest tableRequest = new CompleteRequest(
-					new ResourceReference(ResourceReference.TYPE, "db://{database}/{table}"),
-					new CompleteRequest.CompleteArgument("table", ""),
-					new CompleteRequest.CompleteContext(Map.of("database", "users_db")));
+			CompleteRequest tableRequest = CompleteRequest
+				.builder(new ResourceReference("db://{database}/{table}"),
+						new CompleteRequest.CompleteArgument("table", ""))
+				.context(new CompleteRequest.CompleteContext(Map.of("database", "users_db")))
+				.build();
 
 			CompleteResult tableResult = mcpClient.completeCompletion(tableRequest);
 			assertThat(tableResult.completion().values()).containsExactly("users", "sessions", "permissions");
 
 			// Different database gives different tables
-			CompleteRequest tableRequest2 = new CompleteRequest(
-					new ResourceReference(ResourceReference.TYPE, "db://{database}/{table}"),
-					new CompleteRequest.CompleteArgument("table", ""),
-					new CompleteRequest.CompleteContext(Map.of("database", "products_db")));
+			CompleteRequest tableRequest2 = CompleteRequest
+				.builder(new ResourceReference("db://{database}/{table}"),
+						new CompleteRequest.CompleteArgument("table", ""))
+				.context(new CompleteRequest.CompleteContext(Map.of("database", "products_db")))
+				.build();
 
 			CompleteResult tableResult2 = mcpClient.completeCompletion(tableRequest2);
 			assertThat(tableResult2.completion().values()).containsExactly("products", "categories", "inventory");
@@ -282,9 +288,7 @@ class McpCompletionTests {
 			return new CompleteResult(new CompleteResult.CompleteCompletion(List.of(), 0, false));
 		};
 
-		McpSchema.Resource resource = Resource.builder()
-			.uri("db://{database}/{table}")
-			.name("Database Table")
+		McpSchema.Resource resource = Resource.builder("db://{database}/{table}", "Database Table")
 			.description("Resource representing a table in a database")
 			.mimeType("application/json")
 			.size(456L)
@@ -293,30 +297,33 @@ class McpCompletionTests {
 		var mcpServer = McpServer.sync(mcpServerTransportProvider)
 			.capabilities(ServerCapabilities.builder().completions().build())
 			.resources(new McpServerFeatures.SyncResourceSpecification(resource,
-					(exchange, req) -> new ReadResourceResult(List.of())))
+					(exchange, req) -> ReadResourceResult.builder(List.of()).build()))
 			.completions(new McpServerFeatures.SyncCompletionSpecification(
-					new ResourceReference(ResourceReference.TYPE, "db://{database}/{table}"), completionHandler))
+					new ResourceReference("db://{database}/{table}"), completionHandler))
 			.build();
 
-		try (var mcpClient = clientBuilder.clientInfo(new McpSchema.Implementation("Sample" + "client", "0.0.0"))
+		try (var mcpClient = clientBuilder
+			.clientInfo(McpSchema.Implementation.builder("Sample" + "client", "0.0.0").build())
 			.build();) {
 			InitializeResult initResult = mcpClient.initialize();
 			assertThat(initResult).isNotNull();
 
 			// Try to complete table without database context - should raise error
-			CompleteRequest requestWithoutContext = new CompleteRequest(
-					new ResourceReference(ResourceReference.TYPE, "db://{database}/{table}"),
-					new CompleteRequest.CompleteArgument("table", ""));
+			CompleteRequest requestWithoutContext = CompleteRequest
+				.builder(new ResourceReference("db://{database}/{table}"),
+						new CompleteRequest.CompleteArgument("table", ""))
+				.build();
 
 			assertThatExceptionOfType(McpError.class)
 				.isThrownBy(() -> mcpClient.completeCompletion(requestWithoutContext))
 				.withMessageContaining("Please select a database first");
 
 			// Now complete with proper context - should work normally
-			CompleteRequest requestWithContext = new CompleteRequest(
-					new ResourceReference(ResourceReference.TYPE, "db://{database}/{table}"),
-					new CompleteRequest.CompleteArgument("table", ""),
-					new CompleteRequest.CompleteContext(Map.of("database", "test_db")));
+			CompleteRequest requestWithContext = CompleteRequest
+				.builder(new ResourceReference("db://{database}/{table}"),
+						new CompleteRequest.CompleteArgument("table", ""))
+				.context(new CompleteRequest.CompleteContext(Map.of("database", "test_db")))
+				.build();
 
 			CompleteResult resultWithContext = mcpClient.completeCompletion(requestWithContext);
 			assertThat(resultWithContext.completion().values()).containsExactly("users", "orders", "products");
@@ -330,24 +337,26 @@ class McpCompletionTests {
 		BiFunction<McpSyncServerExchange, CompleteRequest, CompleteResult> completionHandler = (exchange,
 				request) -> new CompleteResult(new CompleteResult.CompleteCompletion(List.of("test"), 1, false));
 
-		McpSchema.Prompt prompt = new Prompt("test-prompt", "this is a test prompt", null);
+		McpSchema.Prompt prompt = Prompt.builder("test-prompt").description("this is a test prompt").build();
 
 		var mcpServer = McpServer.sync(mcpServerTransportProvider)
 			.capabilities(ServerCapabilities.builder().completions().build())
 			.prompts(new McpServerFeatures.SyncPromptSpecification(prompt,
 					(mcpSyncServerExchange, getPromptRequest) -> null))
-			.completions(new McpServerFeatures.SyncCompletionSpecification(
-					new PromptReference(PromptReference.TYPE, "test-prompt"), completionHandler))
+			.completions(new McpServerFeatures.SyncCompletionSpecification(new PromptReference("test-prompt"),
+					completionHandler))
 			.build();
 
-		try (var mcpClient = clientBuilder.clientInfo(new McpSchema.Implementation("Sample " + "client", "0.0.0"))
+		try (var mcpClient = clientBuilder
+			.clientInfo(McpSchema.Implementation.builder("Sample " + "client", "0.0.0").build())
 			.build()) {
 			InitializeResult initResult = mcpClient.initialize();
 			assertThat(initResult).isNotNull();
 
 			// try completing an argument knowing that the prompt is not parameterized
-			CompleteRequest request = new CompleteRequest(new PromptReference(PromptReference.TYPE, "test-prompt"),
-					new CompleteRequest.CompleteArgument("arg", "val"));
+			CompleteRequest request = CompleteRequest
+				.builder(new PromptReference("test-prompt"), new CompleteRequest.CompleteArgument("arg", "val"))
+				.build();
 
 			CompleteResult completeResult = mcpClient.completeCompletion(request);
 			assertThat(completeResult.completion().values()).isEmpty();

--- a/mcp-test/src/test/java/io/modelcontextprotocol/server/McpServerProtocolVersionTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/server/McpServerProtocolVersionTests.java
@@ -20,13 +20,17 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class McpServerProtocolVersionTests {
 
-	private static final McpSchema.Implementation SERVER_INFO = new McpSchema.Implementation("test-server", "1.0.0");
+	private static final McpSchema.Implementation SERVER_INFO = McpSchema.Implementation.builder("test-server", "1.0.0")
+		.build();
 
-	private static final McpSchema.Implementation CLIENT_INFO = new McpSchema.Implementation("test-client", "1.0.0");
+	private static final McpSchema.Implementation CLIENT_INFO = McpSchema.Implementation.builder("test-client", "1.0.0")
+		.build();
 
 	private McpSchema.JSONRPCRequest jsonRpcInitializeRequest(String requestId, String protocolVersion) {
-		return new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, McpSchema.METHOD_INITIALIZE, requestId,
-				new McpSchema.InitializeRequest(protocolVersion, null, CLIENT_INFO));
+		return new McpSchema.JSONRPCRequest(McpSchema.METHOD_INITIALIZE, requestId,
+				McpSchema.InitializeRequest
+					.builder(protocolVersion, McpSchema.ClientCapabilities.builder().build(), CLIENT_INFO)
+					.build());
 	}
 
 	@Test

--- a/mcp-test/src/test/java/io/modelcontextprotocol/server/ResourceSubscriptionTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/server/ResourceSubscriptionTests.java
@@ -24,9 +24,11 @@ class ResourceSubscriptionTests {
 
 	private static final String RESOURCE_URI = "test://resource/1";
 
-	private static final McpSchema.Implementation SERVER_INFO = new McpSchema.Implementation("test-server", "1.0.0");
+	private static final McpSchema.Implementation SERVER_INFO = McpSchema.Implementation.builder("test-server", "1.0.0")
+		.build();
 
-	private static final McpSchema.Implementation CLIENT_INFO = new McpSchema.Implementation("test-client", "1.0.0");
+	private static final McpSchema.Implementation CLIENT_INFO = McpSchema.Implementation.builder("test-client", "1.0.0")
+		.build();
 
 	private static McpAsyncServer buildServer(MockMcpServerTransportProvider transportProvider) {
 		return McpServer.async(transportProvider)
@@ -36,24 +38,25 @@ class ResourceSubscriptionTests {
 	}
 
 	private static McpSchema.JSONRPCRequest initRequest() {
-		return new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, McpSchema.METHOD_INITIALIZE,
-				UUID.randomUUID().toString(),
-				new McpSchema.InitializeRequest(ProtocolVersions.MCP_2025_11_25, null, CLIENT_INFO));
+		return new McpSchema.JSONRPCRequest(McpSchema.METHOD_INITIALIZE, UUID.randomUUID().toString(),
+				McpSchema.InitializeRequest
+					.builder(ProtocolVersions.MCP_2025_11_25, McpSchema.ClientCapabilities.builder().build(),
+							CLIENT_INFO)
+					.build());
 	}
 
 	private static McpSchema.JSONRPCNotification initializedNotification() {
-		return new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION, McpSchema.METHOD_NOTIFICATION_INITIALIZED,
-				null);
+		return new McpSchema.JSONRPCNotification(McpSchema.METHOD_NOTIFICATION_INITIALIZED);
 	}
 
 	private static McpSchema.JSONRPCRequest subscribeRequest(String uri) {
-		return new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, McpSchema.METHOD_RESOURCES_SUBSCRIBE,
-				UUID.randomUUID().toString(), new McpSchema.SubscribeRequest(uri));
+		return new McpSchema.JSONRPCRequest(McpSchema.METHOD_RESOURCES_SUBSCRIBE, UUID.randomUUID().toString(),
+				McpSchema.SubscribeRequest.builder(uri).build());
 	}
 
 	private static McpSchema.JSONRPCRequest unsubscribeRequest(String uri) {
-		return new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, McpSchema.METHOD_RESOURCES_UNSUBSCRIBE,
-				UUID.randomUUID().toString(), new McpSchema.UnsubscribeRequest(uri));
+		return new McpSchema.JSONRPCRequest(McpSchema.METHOD_RESOURCES_UNSUBSCRIBE, UUID.randomUUID().toString(),
+				McpSchema.UnsubscribeRequest.builder(uri).build());
 	}
 
 	@Test

--- a/mcp-test/src/test/java/io/modelcontextprotocol/server/ResourceTemplateManagementTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/server/ResourceTemplateManagementTests.java
@@ -62,15 +62,13 @@ public class ResourceTemplateManagementTests {
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
 			.build();
 
-		ResourceTemplate template = ResourceTemplate.builder()
-			.uriTemplate(TEST_TEMPLATE_URI)
-			.name(TEST_TEMPLATE_NAME)
+		ResourceTemplate template = ResourceTemplate.builder(TEST_TEMPLATE_URI, TEST_TEMPLATE_NAME)
 			.description("Test resource template")
 			.mimeType("text/plain")
 			.build();
 
 		McpServerFeatures.AsyncResourceTemplateSpecification specification = new McpServerFeatures.AsyncResourceTemplateSpecification(
-				template, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
+				template, (exchange, req) -> Mono.just(ReadResourceResult.builder(List.of()).build()));
 
 		StepVerifier.create(mcpAsyncServer.addResourceTemplate(specification)).verifyComplete();
 	}
@@ -82,15 +80,13 @@ public class ResourceTemplateManagementTests {
 			.serverInfo("test-server", "1.0.0")
 			.build();
 
-		ResourceTemplate template = ResourceTemplate.builder()
-			.uriTemplate(TEST_TEMPLATE_URI)
-			.name(TEST_TEMPLATE_NAME)
+		ResourceTemplate template = ResourceTemplate.builder(TEST_TEMPLATE_URI, TEST_TEMPLATE_NAME)
 			.description("Test resource template")
 			.mimeType("text/plain")
 			.build();
 
 		McpServerFeatures.AsyncResourceTemplateSpecification specification = new McpServerFeatures.AsyncResourceTemplateSpecification(
-				template, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
+				template, (exchange, req) -> Mono.just(ReadResourceResult.builder(List.of()).build()));
 
 		StepVerifier.create(serverWithoutResources.addResourceTemplate(specification)).verifyErrorSatisfies(error -> {
 			assertThat(error).isInstanceOf(IllegalStateException.class)
@@ -103,15 +99,13 @@ public class ResourceTemplateManagementTests {
 
 	@Test
 	void testRemoveResourceTemplate() {
-		ResourceTemplate template = ResourceTemplate.builder()
-			.uriTemplate(TEST_TEMPLATE_URI)
-			.name(TEST_TEMPLATE_NAME)
+		ResourceTemplate template = ResourceTemplate.builder(TEST_TEMPLATE_URI, TEST_TEMPLATE_NAME)
 			.description("Test resource template")
 			.mimeType("text/plain")
 			.build();
 
 		McpServerFeatures.AsyncResourceTemplateSpecification specification = new McpServerFeatures.AsyncResourceTemplateSpecification(
-				template, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
+				template, (exchange, req) -> Mono.just(ReadResourceResult.builder(List.of()).build()));
 
 		mcpAsyncServer = McpServer.async(mockTransportProvider)
 			.serverInfo("test-server", "1.0.0")
@@ -154,25 +148,21 @@ public class ResourceTemplateManagementTests {
 
 	@Test
 	void testReplaceExistingResourceTemplate() {
-		ResourceTemplate originalTemplate = ResourceTemplate.builder()
-			.uriTemplate(TEST_TEMPLATE_URI)
-			.name(TEST_TEMPLATE_NAME)
+		ResourceTemplate originalTemplate = ResourceTemplate.builder(TEST_TEMPLATE_URI, TEST_TEMPLATE_NAME)
 			.description("Original template")
 			.mimeType("text/plain")
 			.build();
 
-		ResourceTemplate updatedTemplate = ResourceTemplate.builder()
-			.uriTemplate(TEST_TEMPLATE_URI)
-			.name(TEST_TEMPLATE_NAME)
+		ResourceTemplate updatedTemplate = ResourceTemplate.builder(TEST_TEMPLATE_URI, TEST_TEMPLATE_NAME)
 			.description("Updated template")
 			.mimeType("application/json")
 			.build();
 
 		McpServerFeatures.AsyncResourceTemplateSpecification originalSpec = new McpServerFeatures.AsyncResourceTemplateSpecification(
-				originalTemplate, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
+				originalTemplate, (exchange, req) -> Mono.just(ReadResourceResult.builder(List.of()).build()));
 
 		McpServerFeatures.AsyncResourceTemplateSpecification updatedSpec = new McpServerFeatures.AsyncResourceTemplateSpecification(
-				updatedTemplate, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
+				updatedTemplate, (exchange, req) -> Mono.just(ReadResourceResult.builder(List.of()).build()));
 
 		mcpAsyncServer = McpServer.async(mockTransportProvider)
 			.serverInfo("test-server", "1.0.0")
@@ -190,15 +180,13 @@ public class ResourceTemplateManagementTests {
 
 	@Test
 	void testSyncAddResourceTemplate() {
-		ResourceTemplate template = ResourceTemplate.builder()
-			.uriTemplate(TEST_TEMPLATE_URI)
-			.name(TEST_TEMPLATE_NAME)
+		ResourceTemplate template = ResourceTemplate.builder(TEST_TEMPLATE_URI, TEST_TEMPLATE_NAME)
 			.description("Test resource template")
 			.mimeType("text/plain")
 			.build();
 
 		McpServerFeatures.SyncResourceTemplateSpecification specification = new McpServerFeatures.SyncResourceTemplateSpecification(
-				template, (exchange, req) -> new ReadResourceResult(List.of()));
+				template, (exchange, req) -> ReadResourceResult.builder(List.of()).build());
 
 		var mcpSyncServer = McpServer.sync(mockTransportProvider)
 			.serverInfo("test-server", "1.0.0")
@@ -212,15 +200,13 @@ public class ResourceTemplateManagementTests {
 
 	@Test
 	void testSyncRemoveResourceTemplate() {
-		ResourceTemplate template = ResourceTemplate.builder()
-			.uriTemplate(TEST_TEMPLATE_URI)
-			.name(TEST_TEMPLATE_NAME)
+		ResourceTemplate template = ResourceTemplate.builder(TEST_TEMPLATE_URI, TEST_TEMPLATE_NAME)
 			.description("Test resource template")
 			.mimeType("text/plain")
 			.build();
 
 		McpServerFeatures.SyncResourceTemplateSpecification specification = new McpServerFeatures.SyncResourceTemplateSpecification(
-				template, (exchange, req) -> new ReadResourceResult(List.of()));
+				template, (exchange, req) -> ReadResourceResult.builder(List.of()).build());
 
 		var mcpSyncServer = McpServer.sync(mockTransportProvider)
 			.serverInfo("test-server", "1.0.0")
@@ -239,25 +225,21 @@ public class ResourceTemplateManagementTests {
 
 	@Test
 	void testResourceTemplateMapBasedStorage() {
-		ResourceTemplate template1 = ResourceTemplate.builder()
-			.uriTemplate("test://template1/{id}")
-			.name("template1")
+		ResourceTemplate template1 = ResourceTemplate.builder("test://template1/{id}", "template1")
 			.description("First template")
 			.mimeType("text/plain")
 			.build();
 
-		ResourceTemplate template2 = ResourceTemplate.builder()
-			.uriTemplate("test://template2/{id}")
-			.name("template2")
+		ResourceTemplate template2 = ResourceTemplate.builder("test://template2/{id}", "template2")
 			.description("Second template")
 			.mimeType("application/json")
 			.build();
 
 		McpServerFeatures.AsyncResourceTemplateSpecification spec1 = new McpServerFeatures.AsyncResourceTemplateSpecification(
-				template1, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
+				template1, (exchange, req) -> Mono.just(ReadResourceResult.builder(List.of()).build()));
 
 		McpServerFeatures.AsyncResourceTemplateSpecification spec2 = new McpServerFeatures.AsyncResourceTemplateSpecification(
-				template2, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
+				template2, (exchange, req) -> Mono.just(ReadResourceResult.builder(List.of()).build()));
 
 		mcpAsyncServer = McpServer.async(mockTransportProvider)
 			.serverInfo("test-server", "1.0.0")
@@ -274,15 +256,13 @@ public class ResourceTemplateManagementTests {
 	@Test
 	void testResourceTemplateBuilderWithMap() {
 		// Test that the new Map-based builder methods work correctly
-		ResourceTemplate template = ResourceTemplate.builder()
-			.uriTemplate(TEST_TEMPLATE_URI)
-			.name(TEST_TEMPLATE_NAME)
+		ResourceTemplate template = ResourceTemplate.builder(TEST_TEMPLATE_URI, TEST_TEMPLATE_NAME)
 			.description("Test resource template")
 			.mimeType("text/plain")
 			.build();
 
 		McpServerFeatures.AsyncResourceTemplateSpecification specification = new McpServerFeatures.AsyncResourceTemplateSpecification(
-				template, (exchange, req) -> Mono.just(new ReadResourceResult(List.of())));
+				template, (exchange, req) -> Mono.just(ReadResourceResult.builder(List.of()).build()));
 
 		// Test varargs builder method
 		assertThatCode(() -> {

--- a/mcp-test/src/test/java/io/modelcontextprotocol/server/ToolInputValidationIntegrationTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/server/ToolInputValidationIntegrationTests.java
@@ -49,9 +49,11 @@ class ToolInputValidationIntegrationTests {
 
 	private static final String TOOL_NAME = "test-tool";
 
-	private static final McpSchema.JsonSchema INPUT_SCHEMA = new McpSchema.JsonSchema("object",
-			Map.of("name", Map.of("type", "string"), "age", Map.of("type", "integer", "minimum", 0)),
-			List.of("name", "age"), null, null, null);
+	private static final McpSchema.JsonSchema INPUT_SCHEMA = McpSchema.JsonSchema.builder()
+		.type("object")
+		.properties(Map.of("name", Map.of("type", "string"), "age", Map.of("type", "integer", "minimum", 0)))
+		.required(List.of("name", "age"))
+		.build();
 
 	private static final McpTransportContextExtractor<HttpServletRequest> TEST_CONTEXT_EXTRACTOR = (
 			r) -> McpTransportContext.create(Map.of("important", "value"));
@@ -123,34 +125,26 @@ class ToolInputValidationIntegrationTests {
 	}
 
 	private McpServerFeatures.SyncToolSpecification createSyncTool() {
-		Tool tool = Tool.builder()
-			.name(TOOL_NAME)
-			.description("Test tool with schema")
-			.inputSchema(INPUT_SCHEMA)
-			.build();
+		Tool tool = Tool.builder(TOOL_NAME).inputSchema(INPUT_SCHEMA).description("Test tool with schema").build();
 
 		return McpServerFeatures.SyncToolSpecification.builder().tool(tool).callHandler((exchange, request) -> {
 			String name = (String) request.arguments().get("name");
 			Integer age = ((Number) request.arguments().get("age")).intValue();
 			return CallToolResult.builder()
-				.content(List.of(new TextContent("Hello " + name + ", age " + age)))
+				.content(List.of(TextContent.builder("Hello " + name + ", age " + age).build()))
 				.isError(false)
 				.build();
 		}).build();
 	}
 
 	private McpServerFeatures.AsyncToolSpecification createAsyncTool() {
-		Tool tool = Tool.builder()
-			.name(TOOL_NAME)
-			.description("Test tool with schema")
-			.inputSchema(INPUT_SCHEMA)
-			.build();
+		Tool tool = Tool.builder(TOOL_NAME).inputSchema(INPUT_SCHEMA).description("Test tool with schema").build();
 
 		return McpServerFeatures.AsyncToolSpecification.builder().tool(tool).callHandler((exchange, request) -> {
 			String name = (String) request.arguments().get("name");
 			Integer age = ((Number) request.arguments().get("age")).intValue();
 			return Mono.just(CallToolResult.builder()
-				.content(List.of(new TextContent("Hello " + name + ", age " + age)))
+				.content(List.of(TextContent.builder("Hello " + name + ", age " + age).build()))
 				.isError(false)
 				.build());
 		}).build();
@@ -162,9 +156,10 @@ class ToolInputValidationIntegrationTests {
 			String expectedOutput) {
 		Object server = createServer(serverType, validationEnabled);
 
-		try (var client = clientBuilder.clientInfo(new McpSchema.Implementation("test-client", "1.0.0")).build()) {
+		try (var client = clientBuilder.clientInfo(McpSchema.Implementation.builder("test-client", "1.0.0").build())
+			.build()) {
 			client.initialize();
-			CallToolResult result = client.callTool(new CallToolRequest(TOOL_NAME, input));
+			CallToolResult result = client.callTool(CallToolRequest.builder(TOOL_NAME).arguments(input).build());
 
 			assertThat(result.isError()).isFalse();
 			assertThat(((TextContent) result.content().get(0)).text()).isEqualTo(expectedOutput);
@@ -180,9 +175,10 @@ class ToolInputValidationIntegrationTests {
 			String expectedErrorSubstring) {
 		Object server = createServerWithDefaultValidation(serverType);
 
-		try (var client = clientBuilder.clientInfo(new McpSchema.Implementation("test-client", "1.0.0")).build()) {
+		try (var client = clientBuilder.clientInfo(McpSchema.Implementation.builder("test-client", "1.0.0").build())
+			.build()) {
 			client.initialize();
-			CallToolResult result = client.callTool(new CallToolRequest(TOOL_NAME, input));
+			CallToolResult result = client.callTool(CallToolRequest.builder(TOOL_NAME).arguments(input).build());
 
 			assertThat(result.isError()).isTrue();
 			String errorMessage = ((TextContent) result.content().get(0)).text();
@@ -199,13 +195,14 @@ class ToolInputValidationIntegrationTests {
 			String ignored) {
 		Object server = createServer(serverType, false);
 
-		try (var client = clientBuilder.clientInfo(new McpSchema.Implementation("test-client", "1.0.0")).build()) {
+		try (var client = clientBuilder.clientInfo(McpSchema.Implementation.builder("test-client", "1.0.0").build())
+			.build()) {
 			client.initialize();
 			// Invalid input should pass through when validation is disabled
 			// The tool handler will fail, but that's expected - we're testing validation
 			// is skipped
 			try {
-				client.callTool(new CallToolRequest(TOOL_NAME, input));
+				client.callTool(CallToolRequest.builder(TOOL_NAME).arguments(input).build());
 			}
 			catch (Exception e) {
 				// Expected - tool handler fails on invalid input, but validation didn't

--- a/mcp-test/src/test/java/io/modelcontextprotocol/server/transport/HttpServletSseServerCustomContextPathTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/server/transport/HttpServletSseServerCustomContextPathTests.java
@@ -78,7 +78,7 @@ class HttpServletSseServerCustomContextPathTests {
 	void testCustomContextPath() {
 		var server = McpServer.async(mcpServerTransportProvider).serverInfo("test-server", "1.0.0").build();
 		try (//@formatter:off
-			var client = clientBuilder.clientInfo(new McpSchema.Implementation("Sample " + "client", "0.0.0")) .build()) { //@formatter:on
+			var client = clientBuilder.clientInfo(McpSchema.Implementation.builder("Sample " + "client", "0.0.0").build()) .build()) { //@formatter:on
 
 			assertThat(client.initialize()).isNotNull();
 		}

--- a/mcp-test/src/test/java/io/modelcontextprotocol/spec/CompleteReferenceJsonTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/spec/CompleteReferenceJsonTests.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.json.TypeRef;
 import org.junit.jupiter.api.Test;
-import tools.jackson.databind.exc.ValueInstantiationException;
 
 /**
  * Verifies that {@link McpSchema.CompleteReference} polymorphic dispatch works via direct
@@ -94,7 +93,7 @@ class CompleteReferenceJsonTests {
 		Object paramsMap = mapper.readValue(json, Object.class);
 
 		assertThatThrownBy(() -> mapper.convertValue(paramsMap, new TypeRef<McpSchema.CompleteRequest>() {
-		})).isInstanceOf(ValueInstantiationException.class).hasMessageContaining("ref must not be null");
+		})).hasMessageContaining("ref must not be null");
 
 	}
 

--- a/mcp-test/src/test/java/io/modelcontextprotocol/spec/CompleteReferenceJsonTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/spec/CompleteReferenceJsonTests.java
@@ -7,12 +7,14 @@ package io.modelcontextprotocol.spec;
 import static io.modelcontextprotocol.util.McpJsonMapperUtils.JSON_MAPPER;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 
 import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.json.TypeRef;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.exc.ValueInstantiationException;
 
 /**
  * Verifies that {@link McpSchema.CompleteReference} polymorphic dispatch works via direct
@@ -50,7 +52,7 @@ class CompleteReferenceJsonTests {
 		McpSchema.CompleteRequest req = mapper.readValue(json, McpSchema.CompleteRequest.class);
 
 		assertThat(req.ref()).isInstanceOf(McpSchema.PromptReference.class);
-		assertThat(req.ref().identifier()).isEqualTo("my-prompt");
+		assertThat(((McpSchema.PromptReference) req.ref()).name()).isEqualTo("my-prompt");
 		assertThat(req.argument().name()).isEqualTo("lang");
 		assertThat(req.argument().value()).isEqualTo("java");
 	}
@@ -64,7 +66,7 @@ class CompleteReferenceJsonTests {
 		McpSchema.CompleteRequest req = mapper.readValue(json, McpSchema.CompleteRequest.class);
 
 		assertThat(req.ref()).isInstanceOf(McpSchema.ResourceReference.class);
-		assertThat(req.ref().identifier()).isEqualTo("file:///src/Foo.java");
+		assertThat(((McpSchema.ResourceReference) req.ref()).uri()).isEqualTo("file:///src/Foo.java");
 	}
 
 	@Test
@@ -79,7 +81,21 @@ class CompleteReferenceJsonTests {
 		});
 
 		assertThat(req.ref()).isInstanceOf(McpSchema.PromptReference.class);
-		assertThat(req.ref().identifier()).isEqualTo("my-prompt");
+		assertThat(((McpSchema.PromptReference) req.ref()).name()).isEqualTo("my-prompt");
+	}
+
+	@Test
+	void completeRequestMissingRefFailsToInstantiate() throws IOException {
+		String json = """
+				{"argument":{"name":"lang","value":"java"}}
+				""";
+
+		// This is the real in-process path: params arrives as a Map from JSON-RPC
+		Object paramsMap = mapper.readValue(json, Object.class);
+
+		assertThatThrownBy(() -> mapper.convertValue(paramsMap, new TypeRef<McpSchema.CompleteRequest>() {
+		})).isInstanceOf(ValueInstantiationException.class).hasMessageContaining("ref must not be null");
+
 	}
 
 	@Test

--- a/mcp-test/src/test/java/io/modelcontextprotocol/spec/ContentJsonTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/spec/ContentJsonTests.java
@@ -24,7 +24,7 @@ class ContentJsonTests {
 
 	@Test
 	void textContentHasExactlyOneTypeProperty() throws IOException {
-		McpSchema.TextContent content = new McpSchema.TextContent("hello");
+		McpSchema.TextContent content = McpSchema.TextContent.builder("hello").build();
 		String json = mapper.writeValueAsString(content);
 
 		assertExactlyOneTypeProperty(json);
@@ -34,7 +34,7 @@ class ContentJsonTests {
 
 	@Test
 	void imageContentHasExactlyOneTypeProperty() throws IOException {
-		McpSchema.ImageContent content = new McpSchema.ImageContent(null, "base64data", "image/png");
+		McpSchema.ImageContent content = McpSchema.ImageContent.builder("base64data", "image/png").build();
 		String json = mapper.writeValueAsString(content);
 
 		assertExactlyOneTypeProperty(json);
@@ -43,7 +43,7 @@ class ContentJsonTests {
 
 	@Test
 	void audioContentHasExactlyOneTypeProperty() throws IOException {
-		McpSchema.AudioContent content = new McpSchema.AudioContent(null, "base64data", "audio/mp3");
+		McpSchema.AudioContent content = McpSchema.AudioContent.builder("base64data", "audio/mp3").build();
 		String json = mapper.writeValueAsString(content);
 
 		assertExactlyOneTypeProperty(json);
@@ -52,7 +52,7 @@ class ContentJsonTests {
 
 	@Test
 	void textContentRoundTrip() throws IOException {
-		McpSchema.TextContent original = new McpSchema.TextContent("round-trip");
+		McpSchema.TextContent original = McpSchema.TextContent.builder("round-trip").build();
 		String json = mapper.writeValueAsString(original);
 
 		McpSchema.Content decoded = mapper.readValue(json, McpSchema.Content.class);

--- a/mcp-test/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
@@ -34,7 +34,7 @@ public class McpSchemaTests {
 
 	@Test
 	void testTextContent() throws Exception {
-		McpSchema.TextContent test = new McpSchema.TextContent("XXX");
+		McpSchema.TextContent test = McpSchema.TextContent.builder("XXX").build();
 		String value = JSON_MAPPER.writeValueAsString(test);
 
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -73,7 +73,7 @@ public class McpSchemaTests {
 
 	@Test
 	void testImageContent() throws Exception {
-		McpSchema.ImageContent test = new McpSchema.ImageContent(null, "base64encodeddata", "image/png");
+		McpSchema.ImageContent test = McpSchema.ImageContent.builder("base64encodeddata", "image/png").build();
 		String value = JSON_MAPPER.writeValueAsString(test);
 
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -97,7 +97,7 @@ public class McpSchemaTests {
 
 	@Test
 	void testAudioContent() throws Exception {
-		McpSchema.AudioContent audioContent = new McpSchema.AudioContent(null, "base64encodeddata", "audio/wav");
+		McpSchema.AudioContent audioContent = McpSchema.AudioContent.builder("base64encodeddata", "audio/wav").build();
 		String value = JSON_MAPPER.writeValueAsString(audioContent);
 
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -121,11 +121,15 @@ public class McpSchemaTests {
 
 	@Test
 	void testCreateMessageRequestWithMeta() throws Exception {
-		McpSchema.TextContent content = new McpSchema.TextContent("User message");
-		McpSchema.SamplingMessage message = new McpSchema.SamplingMessage(McpSchema.Role.USER, content);
-		McpSchema.ModelHint hint = new McpSchema.ModelHint("gpt-4");
-		McpSchema.ModelPreferences preferences = new McpSchema.ModelPreferences(Collections.singletonList(hint), 0.3,
-				0.7, 0.9);
+		McpSchema.TextContent content = McpSchema.TextContent.builder("User message").build();
+		McpSchema.SamplingMessage message = McpSchema.SamplingMessage.builder(McpSchema.Role.USER, content).build();
+		McpSchema.ModelHint hint = McpSchema.ModelHint.of("gpt-4");
+		McpSchema.ModelPreferences preferences = McpSchema.ModelPreferences.builder()
+			.hints(Collections.singletonList(hint))
+			.costPriority(0.3)
+			.speedPriority(0.7)
+			.intelligencePriority(0.9)
+			.build();
 
 		Map<String, Object> metadata = new HashMap<>();
 		metadata.put("session", "test-session");
@@ -133,13 +137,12 @@ public class McpSchemaTests {
 		Map<String, Object> meta = new HashMap<>();
 		meta.put("progressToken", "create-message-token-456");
 
-		McpSchema.CreateMessageRequest request = McpSchema.CreateMessageRequest.builder()
-			.messages(Collections.singletonList(message))
+		McpSchema.CreateMessageRequest request = McpSchema.CreateMessageRequest
+			.builder(Collections.singletonList(message), 1000)
 			.modelPreferences(preferences)
 			.systemPrompt("You are a helpful assistant")
 			.includeContext(McpSchema.CreateMessageRequest.ContextInclusionStrategy.THIS_SERVER)
 			.temperature(0.7)
-			.maxTokens(1000)
 			.stopSequences(Arrays.asList("STOP", "END"))
 			.metadata(metadata)
 			.meta(meta)
@@ -158,10 +161,12 @@ public class McpSchemaTests {
 
 	@Test
 	void testEmbeddedResource() throws Exception {
-		McpSchema.TextResourceContents resourceContents = new McpSchema.TextResourceContents("resource://test",
-				"text/plain", "Sample resource content");
+		McpSchema.TextResourceContents resourceContents = McpSchema.TextResourceContents
+			.builder("resource://test", "Sample resource content")
+			.mimeType("text/plain")
+			.build();
 
-		McpSchema.EmbeddedResource test = new McpSchema.EmbeddedResource(null, resourceContents);
+		McpSchema.EmbeddedResource test = McpSchema.EmbeddedResource.builder(resourceContents).build();
 
 		String value = JSON_MAPPER.writeValueAsString(test);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -189,10 +194,12 @@ public class McpSchemaTests {
 
 	@Test
 	void testEmbeddedResourceWithBlobContents() throws Exception {
-		McpSchema.BlobResourceContents resourceContents = new McpSchema.BlobResourceContents("resource://test",
-				"application/octet-stream", "base64encodedblob");
+		McpSchema.BlobResourceContents resourceContents = McpSchema.BlobResourceContents
+			.builder("resource://test", "base64encodedblob")
+			.mimeType("application/octet-stream")
+			.build();
 
-		McpSchema.EmbeddedResource test = new McpSchema.EmbeddedResource(null, resourceContents);
+		McpSchema.EmbeddedResource test = McpSchema.EmbeddedResource.builder(resourceContents).build();
 
 		String value = JSON_MAPPER.writeValueAsString(test);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -221,9 +228,14 @@ public class McpSchemaTests {
 
 	@Test
 	void testResourceLink() throws Exception {
-		McpSchema.ResourceLink resourceLink = new McpSchema.ResourceLink("main.rs", "Main file",
-				"file:///project/src/main.rs", "Primary application entry point", "text/x-rust", null, null,
-				Map.of("metaKey", "metaValue"));
+		McpSchema.ResourceLink resourceLink = McpSchema.ResourceLink.builder()
+			.name("main.rs")
+			.title("Main file")
+			.uri("file:///project/src/main.rs")
+			.description("Primary application entry point")
+			.mimeType("text/x-rust")
+			.meta(Map.of("metaKey", "metaValue"))
+			.build();
 		String value = JSON_MAPPER.writeValueAsString(resourceLink);
 
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -256,8 +268,7 @@ public class McpSchemaTests {
 		Map<String, Object> params = new HashMap<>();
 		params.put("key", "value");
 
-		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, "method_name", 1,
-				params);
+		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest("method_name", 1, params);
 
 		String value = JSON_MAPPER.writeValueAsString(request);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -272,8 +283,7 @@ public class McpSchemaTests {
 		Map<String, Object> params = new HashMap<>();
 		params.put("key", "value");
 
-		McpSchema.JSONRPCNotification notification = new McpSchema.JSONRPCNotification(McpSchema.JSONRPC_VERSION,
-				"notification_method", params);
+		McpSchema.JSONRPCNotification notification = new McpSchema.JSONRPCNotification("notification_method", params);
 
 		String value = JSON_MAPPER.writeValueAsString(notification);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -288,7 +298,7 @@ public class McpSchemaTests {
 		Map<String, Object> result = new HashMap<>();
 		result.put("result_key", "result_value");
 
-		McpSchema.JSONRPCResponse response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, 1, result, null);
+		McpSchema.JSONRPCResponse response = McpSchema.JSONRPCResponse.result(1, result);
 
 		String value = JSON_MAPPER.writeValueAsString(response);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -301,9 +311,9 @@ public class McpSchemaTests {
 	@Test
 	void testJSONRPCResponseWithError() throws Exception {
 		McpSchema.JSONRPCResponse.JSONRPCError error = new McpSchema.JSONRPCResponse.JSONRPCError(
-				McpSchema.ErrorCodes.INVALID_REQUEST, "Invalid request", null);
+				McpSchema.ErrorCodes.INVALID_REQUEST, "Invalid request");
 
-		McpSchema.JSONRPCResponse response = new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, 1, null, error);
+		McpSchema.JSONRPCResponse response = McpSchema.JSONRPCResponse.error(1, error);
 
 		String value = JSON_MAPPER.writeValueAsString(response);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -322,11 +332,13 @@ public class McpSchemaTests {
 			.sampling()
 			.build();
 
-		McpSchema.Implementation clientInfo = new McpSchema.Implementation("test-client", "1.0.0");
+		McpSchema.Implementation clientInfo = McpSchema.Implementation.builder("test-client", "1.0.0").build();
 		Map<String, Object> meta = Map.of("metaKey", "metaValue");
 
-		McpSchema.InitializeRequest request = new McpSchema.InitializeRequest(ProtocolVersions.MCP_2024_11_05,
-				capabilities, clientInfo, meta);
+		McpSchema.InitializeRequest request = McpSchema.InitializeRequest
+			.builder(ProtocolVersions.MCP_2024_11_05, capabilities, clientInfo)
+			.meta(meta)
+			.build();
 
 		String value = JSON_MAPPER.writeValueAsString(request);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -346,10 +358,12 @@ public class McpSchemaTests {
 			.tools(true)
 			.build();
 
-		McpSchema.Implementation serverInfo = new McpSchema.Implementation("test-server", "1.0.0");
+		McpSchema.Implementation serverInfo = McpSchema.Implementation.builder("test-server", "1.0.0").build();
 
-		McpSchema.InitializeResult result = new McpSchema.InitializeResult(ProtocolVersions.MCP_2024_11_05,
-				capabilities, serverInfo, "Server initialized successfully");
+		McpSchema.InitializeResult result = McpSchema.InitializeResult
+			.builder(ProtocolVersions.MCP_2024_11_05, capabilities, serverInfo)
+			.instructions("Server initialized successfully")
+			.build();
 
 		String value = JSON_MAPPER.writeValueAsString(result);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -364,12 +378,12 @@ public class McpSchemaTests {
 
 	@Test
 	void testResource() throws Exception {
-		McpSchema.Annotations annotations = new McpSchema.Annotations(
-				Arrays.asList(McpSchema.Role.USER, McpSchema.Role.ASSISTANT), 0.8);
+		McpSchema.Annotations annotations = McpSchema.Annotations.builder()
+			.audience(Arrays.asList(McpSchema.Role.USER, McpSchema.Role.ASSISTANT))
+			.priority(0.8)
+			.build();
 
-		McpSchema.Resource resource = McpSchema.Resource.builder()
-			.uri("resource://test")
-			.name("Test Resource")
+		McpSchema.Resource resource = McpSchema.Resource.builder("resource://test", "Test Resource")
 			.description("A test resource")
 			.mimeType("text/plain")
 			.annotations(annotations)
@@ -386,12 +400,12 @@ public class McpSchemaTests {
 
 	@Test
 	void testResourceBuilder() throws Exception {
-		McpSchema.Annotations annotations = new McpSchema.Annotations(
-				Arrays.asList(McpSchema.Role.USER, McpSchema.Role.ASSISTANT), 0.8);
+		McpSchema.Annotations annotations = McpSchema.Annotations.builder()
+			.audience(Arrays.asList(McpSchema.Role.USER, McpSchema.Role.ASSISTANT))
+			.priority(0.8)
+			.build();
 
-		McpSchema.Resource resource = McpSchema.Resource.builder()
-			.uri("resource://test")
-			.name("Test Resource")
+		McpSchema.Resource resource = McpSchema.Resource.builder("resource://test", "Test Resource")
 			.description("A test resource")
 			.mimeType("text/plain")
 			.size(256L)
@@ -410,41 +424,32 @@ public class McpSchemaTests {
 
 	@Test
 	void testResourceBuilderUriRequired() {
-		McpSchema.Annotations annotations = new McpSchema.Annotations(
-				Arrays.asList(McpSchema.Role.USER, McpSchema.Role.ASSISTANT), 0.8);
-
-		McpSchema.Resource.Builder resourceBuilder = McpSchema.Resource.builder()
-			.name("Test Resource")
-			.description("A test resource")
-			.mimeType("text/plain")
-			.size(256L)
-			.annotations(annotations);
-
-		assertThatThrownBy(resourceBuilder::build).isInstanceOf(java.lang.IllegalArgumentException.class);
+		assertThatThrownBy(() -> McpSchema.Resource.builder(null, "Test Resource"))
+			.isInstanceOf(java.lang.IllegalArgumentException.class);
 	}
 
 	@Test
 	void testResourceBuilderNameRequired() {
-		McpSchema.Annotations annotations = new McpSchema.Annotations(
-				Arrays.asList(McpSchema.Role.USER, McpSchema.Role.ASSISTANT), 0.8);
-
-		McpSchema.Resource.Builder resourceBuilder = McpSchema.Resource.builder()
-			.uri("resource://test")
-			.description("A test resource")
-			.mimeType("text/plain")
-			.size(256L)
-			.annotations(annotations);
-
-		assertThatThrownBy(resourceBuilder::build).isInstanceOf(java.lang.IllegalArgumentException.class);
+		assertThatThrownBy(() -> McpSchema.Resource.builder("resource://test", null))
+			.isInstanceOf(java.lang.IllegalArgumentException.class);
 	}
 
 	@Test
 	void testResourceTemplate() throws Exception {
-		McpSchema.Annotations annotations = new McpSchema.Annotations(Arrays.asList(McpSchema.Role.USER), 0.5);
+		McpSchema.Annotations annotations = McpSchema.Annotations.builder()
+			.audience(Arrays.asList(McpSchema.Role.USER))
+			.priority(0.5)
+			.build();
 		Map<String, Object> meta = Map.of("metaKey", "metaValue");
 
-		McpSchema.ResourceTemplate template = new McpSchema.ResourceTemplate("resource://{param}/test", "Test Template",
-				"Test Template", "A test resource template", "text/plain", annotations, meta);
+		McpSchema.ResourceTemplate template = McpSchema.ResourceTemplate
+			.builder("resource://{param}/test", "Test Template")
+			.title("Test Template")
+			.description("A test resource template")
+			.mimeType("text/plain")
+			.annotations(annotations)
+			.meta(meta)
+			.build();
 
 		String value = JSON_MAPPER.writeValueAsString(template);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -457,24 +462,23 @@ public class McpSchemaTests {
 
 	@Test
 	void testListResourcesResult() throws Exception {
-		McpSchema.Resource resource1 = McpSchema.Resource.builder()
-			.uri("resource://test1")
-			.name("Test Resource 1")
+		McpSchema.Resource resource1 = McpSchema.Resource.builder("resource://test1", "Test Resource 1")
 			.description("First test resource")
 			.mimeType("text/plain")
 			.build();
 
-		McpSchema.Resource resource2 = McpSchema.Resource.builder()
-			.uri("resource://test2")
-			.name("Test Resource 2")
+		McpSchema.Resource resource2 = McpSchema.Resource.builder("resource://test2", "Test Resource 2")
 			.description("Second test resource")
 			.mimeType("application/json")
 			.build();
 
 		Map<String, Object> meta = Map.of("metaKey", "metaValue");
 
-		McpSchema.ListResourcesResult result = new McpSchema.ListResourcesResult(Arrays.asList(resource1, resource2),
-				"next-cursor", meta);
+		McpSchema.ListResourcesResult result = McpSchema.ListResourcesResult
+			.builder(Arrays.asList(resource1, resource2))
+			.nextCursor("next-cursor")
+			.meta(meta)
+			.build();
 
 		String value = JSON_MAPPER.writeValueAsString(result);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -487,14 +491,24 @@ public class McpSchemaTests {
 
 	@Test
 	void testListResourceTemplatesResult() throws Exception {
-		McpSchema.ResourceTemplate template1 = new McpSchema.ResourceTemplate("resource://{param}/test1",
-				"Test Template 1", "Test Template 1", "First test template", "text/plain", null);
+		McpSchema.ResourceTemplate template1 = McpSchema.ResourceTemplate
+			.builder("resource://{param}/test1", "Test Template 1")
+			.title("Test Template 1")
+			.description("First test template")
+			.mimeType("text/plain")
+			.build();
 
-		McpSchema.ResourceTemplate template2 = new McpSchema.ResourceTemplate("resource://{param}/test2",
-				"Test Template 2", "Test Template 2", "Second test template", "application/json", null);
+		McpSchema.ResourceTemplate template2 = McpSchema.ResourceTemplate
+			.builder("resource://{param}/test2", "Test Template 2")
+			.title("Test Template 2")
+			.description("Second test template")
+			.mimeType("application/json")
+			.build();
 
-		McpSchema.ListResourceTemplatesResult result = new McpSchema.ListResourceTemplatesResult(
-				Arrays.asList(template1, template2), "next-cursor");
+		McpSchema.ListResourceTemplatesResult result = McpSchema.ListResourceTemplatesResult
+			.builder(Arrays.asList(template1, template2))
+			.nextCursor("next-cursor")
+			.build();
 
 		String value = JSON_MAPPER.writeValueAsString(result);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -507,8 +521,9 @@ public class McpSchemaTests {
 
 	@Test
 	void testReadResourceRequest() throws Exception {
-		McpSchema.ReadResourceRequest request = new McpSchema.ReadResourceRequest("resource://test",
-				Map.of("metaKey", "metaValue"));
+		McpSchema.ReadResourceRequest request = McpSchema.ReadResourceRequest.builder("resource://test")
+			.meta(Map.of("metaKey", "metaValue"))
+			.build();
 
 		String value = JSON_MAPPER.writeValueAsString(request);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -523,7 +538,9 @@ public class McpSchemaTests {
 		Map<String, Object> meta = new HashMap<>();
 		meta.put("progressToken", "read-resource-token-123");
 
-		McpSchema.ReadResourceRequest request = new McpSchema.ReadResourceRequest("resource://test", meta);
+		McpSchema.ReadResourceRequest request = McpSchema.ReadResourceRequest.builder("resource://test")
+			.meta(meta)
+			.build();
 
 		String value = JSON_MAPPER.writeValueAsString(request);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -550,14 +567,19 @@ public class McpSchemaTests {
 
 	@Test
 	void testReadResourceResult() throws Exception {
-		McpSchema.TextResourceContents contents1 = new McpSchema.TextResourceContents("resource://test1", "text/plain",
-				"Sample text content");
+		McpSchema.TextResourceContents contents1 = McpSchema.TextResourceContents
+			.builder("resource://test1", "Sample text content")
+			.mimeType("text/plain")
+			.build();
 
-		McpSchema.BlobResourceContents contents2 = new McpSchema.BlobResourceContents("resource://test2",
-				"application/octet-stream", "base64encodedblob");
+		McpSchema.BlobResourceContents contents2 = McpSchema.BlobResourceContents
+			.builder("resource://test2", "base64encodedblob")
+			.mimeType("application/octet-stream")
+			.build();
 
-		McpSchema.ReadResourceResult result = new McpSchema.ReadResourceResult(Arrays.asList(contents1, contents2),
-				Map.of("metaKey", "metaValue"));
+		McpSchema.ReadResourceResult result = McpSchema.ReadResourceResult.builder(Arrays.asList(contents1, contents2))
+			.meta(Map.of("metaKey", "metaValue"))
+			.build();
 
 		String value = JSON_MAPPER.writeValueAsString(result);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -572,13 +594,24 @@ public class McpSchemaTests {
 
 	@Test
 	void testPrompt() throws Exception {
-		McpSchema.PromptArgument arg1 = new McpSchema.PromptArgument("arg1", "First argument", "First argument", true);
+		McpSchema.PromptArgument arg1 = McpSchema.PromptArgument.builder("arg1")
+			.title("First argument")
+			.description("First argument")
+			.required(true)
+			.build();
 
-		McpSchema.PromptArgument arg2 = new McpSchema.PromptArgument("arg2", "Second argument", "Second argument",
-				false);
+		McpSchema.PromptArgument arg2 = McpSchema.PromptArgument.builder("arg2")
+			.title("Second argument")
+			.description("Second argument")
+			.required(false)
+			.build();
 
-		McpSchema.Prompt prompt = new McpSchema.Prompt("test-prompt", "Test Prompt", "A test prompt",
-				Arrays.asList(arg1, arg2), Map.of("metaKey", "metaValue"));
+		McpSchema.Prompt prompt = McpSchema.Prompt.builder("test-prompt")
+			.title("Test Prompt")
+			.description("A test prompt")
+			.arguments(Arrays.asList(arg1, arg2))
+			.meta(Map.of("metaKey", "metaValue"))
+			.build();
 
 		String value = JSON_MAPPER.writeValueAsString(prompt);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -591,9 +624,9 @@ public class McpSchemaTests {
 
 	@Test
 	void testPromptMessage() throws Exception {
-		McpSchema.TextContent content = new McpSchema.TextContent("Hello, world!");
+		McpSchema.TextContent content = McpSchema.TextContent.builder("Hello, world!").build();
 
-		McpSchema.PromptMessage message = new McpSchema.PromptMessage(McpSchema.Role.USER, content);
+		McpSchema.PromptMessage message = McpSchema.PromptMessage.builder(McpSchema.Role.USER, content).build();
 
 		String value = JSON_MAPPER.writeValueAsString(message);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -605,16 +638,27 @@ public class McpSchemaTests {
 
 	@Test
 	void testListPromptsResult() throws Exception {
-		McpSchema.PromptArgument arg = new McpSchema.PromptArgument("arg", "Argument", "An argument", true);
+		McpSchema.PromptArgument arg = McpSchema.PromptArgument.builder("arg")
+			.title("Argument")
+			.description("An argument")
+			.required(true)
+			.build();
 
-		McpSchema.Prompt prompt1 = new McpSchema.Prompt("prompt1", "First prompt", "First prompt",
-				Collections.singletonList(arg));
+		McpSchema.Prompt prompt1 = McpSchema.Prompt.builder("prompt1")
+			.title("First prompt")
+			.description("First prompt")
+			.arguments(Collections.singletonList(arg))
+			.build();
 
-		McpSchema.Prompt prompt2 = new McpSchema.Prompt("prompt2", "Second prompt", "Second prompt",
-				Collections.emptyList());
+		McpSchema.Prompt prompt2 = McpSchema.Prompt.builder("prompt2")
+			.title("Second prompt")
+			.description("Second prompt")
+			.arguments(Collections.emptyList())
+			.build();
 
-		McpSchema.ListPromptsResult result = new McpSchema.ListPromptsResult(Arrays.asList(prompt1, prompt2),
-				"next-cursor");
+		McpSchema.ListPromptsResult result = McpSchema.ListPromptsResult.builder(Arrays.asList(prompt1, prompt2))
+			.nextCursor("next-cursor")
+			.build();
 
 		String value = JSON_MAPPER.writeValueAsString(result);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -631,7 +675,9 @@ public class McpSchemaTests {
 		arguments.put("arg1", "value1");
 		arguments.put("arg2", 42);
 
-		McpSchema.GetPromptRequest request = new McpSchema.GetPromptRequest("test-prompt", arguments);
+		McpSchema.GetPromptRequest request = McpSchema.GetPromptRequest.builder("test-prompt")
+			.arguments(arguments)
+			.build();
 
 		assertThat(JSON_MAPPER.readValue("""
 				{"name":"test-prompt","arguments":{"arg1":"value1","arg2":42}}""", McpSchema.GetPromptRequest.class))
@@ -647,7 +693,10 @@ public class McpSchemaTests {
 		Map<String, Object> meta = new HashMap<>();
 		meta.put("progressToken", "token123");
 
-		McpSchema.GetPromptRequest request = new McpSchema.GetPromptRequest("test-prompt", arguments, meta);
+		McpSchema.GetPromptRequest request = McpSchema.GetPromptRequest.builder("test-prompt")
+			.arguments(arguments)
+			.meta(meta)
+			.build();
 
 		String value = JSON_MAPPER.writeValueAsString(request);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -664,15 +713,16 @@ public class McpSchemaTests {
 
 	@Test
 	void testGetPromptResult() throws Exception {
-		McpSchema.TextContent content1 = new McpSchema.TextContent("System message");
-		McpSchema.TextContent content2 = new McpSchema.TextContent("User message");
+		McpSchema.TextContent content1 = McpSchema.TextContent.builder("System message").build();
+		McpSchema.TextContent content2 = McpSchema.TextContent.builder("User message").build();
 
-		McpSchema.PromptMessage message1 = new McpSchema.PromptMessage(McpSchema.Role.ASSISTANT, content1);
+		McpSchema.PromptMessage message1 = McpSchema.PromptMessage.builder(McpSchema.Role.ASSISTANT, content1).build();
 
-		McpSchema.PromptMessage message2 = new McpSchema.PromptMessage(McpSchema.Role.USER, content2);
+		McpSchema.PromptMessage message2 = McpSchema.PromptMessage.builder(McpSchema.Role.USER, content2).build();
 
-		McpSchema.GetPromptResult result = new McpSchema.GetPromptResult("A test prompt result",
-				Arrays.asList(message1, message2));
+		McpSchema.GetPromptResult result = McpSchema.GetPromptResult.builder(Arrays.asList(message1, message2))
+			.description("A test prompt result")
+			.build();
 
 		String value = JSON_MAPPER.writeValueAsString(result);
 
@@ -793,10 +843,8 @@ public class McpSchemaTests {
 				}
 				""";
 
-		McpSchema.Tool tool = McpSchema.Tool.builder()
-			.name("test-tool")
+		McpSchema.Tool tool = McpSchema.Tool.builder("test-tool", JSON_MAPPER, schemaJson)
 			.description("A test tool")
-			.inputSchema(JSON_MAPPER, schemaJson)
 			.build();
 
 		String value = JSON_MAPPER.writeValueAsString(tool);
@@ -831,10 +879,8 @@ public class McpSchemaTests {
 				}
 				""";
 
-		McpSchema.Tool tool = McpSchema.Tool.builder()
-			.name("addressTool")
+		McpSchema.Tool tool = McpSchema.Tool.builder("addressTool", JSON_MAPPER, complexSchemaJson)
 			.title("Handles addresses")
-			.inputSchema(JSON_MAPPER, complexSchemaJson)
 			.build();
 
 		// Serialize the tool to a string
@@ -877,11 +923,9 @@ public class McpSchemaTests {
 		Map<String, Object> inputSchema = Map.of("inputSchema", schemaJson);
 		Map<String, Object> meta = Map.of("metaKey", "metaValue");
 
-		McpSchema.Tool tool = McpSchema.Tool.builder()
-			.name("addressTool")
+		McpSchema.Tool tool = McpSchema.Tool.builder("addressTool", inputSchema)
 			.title("addressTool")
 			.description("Handles addresses")
-			.inputSchema(inputSchema)
 			.meta(meta)
 			.build();
 
@@ -906,13 +950,17 @@ public class McpSchemaTests {
 					"required": ["name"]
 				}
 				""";
-		McpSchema.ToolAnnotations annotations = new McpSchema.ToolAnnotations("A test tool", false, false, false, false,
-				false);
+		McpSchema.ToolAnnotations annotations = McpSchema.ToolAnnotations.builder()
+			.title("A test tool")
+			.readOnlyHint(false)
+			.destructiveHint(false)
+			.idempotentHint(false)
+			.openWorldHint(false)
+			.returnDirect(false)
+			.build();
 
-		McpSchema.Tool tool = McpSchema.Tool.builder()
-			.name("test-tool")
+		McpSchema.Tool tool = McpSchema.Tool.builder("test-tool", JSON_MAPPER, schemaJson)
 			.description("A test tool")
-			.inputSchema(JSON_MAPPER, schemaJson)
 			.annotations(annotations)
 			.build();
 
@@ -977,10 +1025,8 @@ public class McpSchemaTests {
 				}
 				""";
 
-		McpSchema.Tool tool = McpSchema.Tool.builder()
-			.name("test-tool")
+		McpSchema.Tool tool = McpSchema.Tool.builder("test-tool", JSON_MAPPER, inputSchemaJson)
 			.description("A test tool")
-			.inputSchema(JSON_MAPPER, inputSchemaJson)
 			.outputSchema(JSON_MAPPER, outputSchemaJson)
 			.build();
 
@@ -1041,13 +1087,17 @@ public class McpSchemaTests {
 				}
 				""";
 
-		McpSchema.ToolAnnotations annotations = new McpSchema.ToolAnnotations("A test tool with output", true, false,
-				true, false, true);
+		McpSchema.ToolAnnotations annotations = McpSchema.ToolAnnotations.builder()
+			.title("A test tool with output")
+			.readOnlyHint(true)
+			.destructiveHint(false)
+			.idempotentHint(true)
+			.openWorldHint(false)
+			.returnDirect(true)
+			.build();
 
-		McpSchema.Tool tool = McpSchema.Tool.builder()
-			.name("test-tool")
+		McpSchema.Tool tool = McpSchema.Tool.builder("test-tool", JSON_MAPPER, inputSchemaJson)
 			.description("A test tool")
-			.inputSchema(JSON_MAPPER, inputSchemaJson)
 			.outputSchema(JSON_MAPPER, outputSchemaJson)
 			.annotations(annotations)
 			.build();
@@ -1166,7 +1216,7 @@ public class McpSchemaTests {
 		arguments.put("name", "test");
 		arguments.put("value", 42);
 
-		McpSchema.CallToolRequest request = new McpSchema.CallToolRequest("test-tool", arguments);
+		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("test-tool").arguments(arguments).build();
 
 		String value = JSON_MAPPER.writeValueAsString(request);
 
@@ -1180,12 +1230,12 @@ public class McpSchemaTests {
 	@Test
 	void testCallToolRequestJsonArguments() throws Exception {
 
-		McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(JSON_MAPPER, "test-tool", """
+		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("test-tool").arguments(JSON_MAPPER, """
 				{
 					"name": "test",
 					"value": 42
 				}
-				""");
+				""").build();
 
 		String value = JSON_MAPPER.writeValueAsString(request);
 
@@ -1261,7 +1311,7 @@ public class McpSchemaTests {
 
 	@Test
 	void testCallToolResult() throws Exception {
-		McpSchema.TextContent content = new McpSchema.TextContent("Tool execution result");
+		McpSchema.TextContent content = McpSchema.TextContent.builder("Tool execution result").build();
 
 		McpSchema.CallToolResult result = McpSchema.CallToolResult.builder()
 			.content(Collections.singletonList(content))
@@ -1294,8 +1344,8 @@ public class McpSchemaTests {
 
 	@Test
 	void testCallToolResultBuilderWithMultipleContents() throws Exception {
-		McpSchema.TextContent textContent = new McpSchema.TextContent("Text result");
-		McpSchema.ImageContent imageContent = new McpSchema.ImageContent(null, "base64data", "image/png");
+		McpSchema.TextContent textContent = McpSchema.TextContent.builder("Text result").build();
+		McpSchema.ImageContent imageContent = McpSchema.ImageContent.builder("base64data", "image/png").build();
 
 		McpSchema.CallToolResult result = McpSchema.CallToolResult.builder()
 			.addContent(textContent)
@@ -1315,8 +1365,8 @@ public class McpSchemaTests {
 
 	@Test
 	void testCallToolResultBuilderWithContentList() throws Exception {
-		McpSchema.TextContent textContent = new McpSchema.TextContent("Text result");
-		McpSchema.ImageContent imageContent = new McpSchema.ImageContent(null, "base64data", "image/png");
+		McpSchema.TextContent textContent = McpSchema.TextContent.builder("Text result").build();
+		McpSchema.ImageContent imageContent = McpSchema.ImageContent.builder("base64data", "image/png").build();
 		List<McpSchema.Content> contents = Arrays.asList(textContent, imageContent);
 
 		McpSchema.CallToolResult result = McpSchema.CallToolResult.builder().content(contents).isError(true).build();
@@ -1347,29 +1397,42 @@ public class McpSchemaTests {
 					{"content":[{"type":"text","text":"Error: Operation failed"}],"isError":true}"""));
 	}
 
+	@Test
+	void testCallToolResultDeserializationWithMissingContent() throws Exception {
+		McpSchema.CallToolResult result = JSON_MAPPER.readValue("""
+				{"isError":false}""", McpSchema.CallToolResult.class);
+
+		assertThat(result).isNotNull();
+		assertThat(result.content()).isEmpty();
+		assertThat(result.isError()).isFalse();
+	}
+
 	// Sampling Tests
 
 	@Test
 	void testCreateMessageRequest() throws Exception {
-		McpSchema.TextContent content = new McpSchema.TextContent("User message");
+		McpSchema.TextContent content = McpSchema.TextContent.builder("User message").build();
 
-		McpSchema.SamplingMessage message = new McpSchema.SamplingMessage(McpSchema.Role.USER, content);
+		McpSchema.SamplingMessage message = McpSchema.SamplingMessage.builder(McpSchema.Role.USER, content).build();
 
-		McpSchema.ModelHint hint = new McpSchema.ModelHint("gpt-4");
+		McpSchema.ModelHint hint = McpSchema.ModelHint.of("gpt-4");
 
-		McpSchema.ModelPreferences preferences = new McpSchema.ModelPreferences(Collections.singletonList(hint), 0.3,
-				0.7, 0.9);
+		McpSchema.ModelPreferences preferences = McpSchema.ModelPreferences.builder()
+			.hints(Collections.singletonList(hint))
+			.costPriority(0.3)
+			.speedPriority(0.7)
+			.intelligencePriority(0.9)
+			.build();
 
 		Map<String, Object> metadata = new HashMap<>();
 		metadata.put("session", "test-session");
 
-		McpSchema.CreateMessageRequest request = McpSchema.CreateMessageRequest.builder()
-			.messages(Collections.singletonList(message))
+		McpSchema.CreateMessageRequest request = McpSchema.CreateMessageRequest
+			.builder(Collections.singletonList(message), 1000)
 			.modelPreferences(preferences)
 			.systemPrompt("You are a helpful assistant")
 			.includeContext(McpSchema.CreateMessageRequest.ContextInclusionStrategy.THIS_SERVER)
 			.temperature(0.7)
-			.maxTokens(1000)
 			.stopSequences(Arrays.asList("STOP", "END"))
 			.metadata(metadata)
 			.build();
@@ -1385,13 +1448,31 @@ public class McpSchemaTests {
 	}
 
 	@Test
-	void testCreateMessageResult() throws Exception {
-		McpSchema.TextContent content = new McpSchema.TextContent("Assistant response");
+	void testSamplingMessageDeserializationWithMissingFields() throws Exception {
+		McpSchema.SamplingMessage message = JSON_MAPPER.readValue("{}", McpSchema.SamplingMessage.class);
 
-		McpSchema.CreateMessageResult result = McpSchema.CreateMessageResult.builder()
-			.role(McpSchema.Role.ASSISTANT)
-			.content(content)
-			.model("gpt-4")
+		assertThat(message).isNotNull();
+		assertThat(message.role()).isEqualTo(McpSchema.Role.USER);
+		assertThat(message.content()).isInstanceOf(McpSchema.TextContent.class);
+	}
+
+	@Test
+	void testCreateMessageRequestDeserializationWithMissingRequiredFields() throws Exception {
+		McpSchema.CreateMessageRequest request = JSON_MAPPER.readValue("""
+				{"systemPrompt":"hello"}""", McpSchema.CreateMessageRequest.class);
+
+		assertThat(request).isNotNull();
+		assertThat(request.messages()).isEmpty();
+		assertThat(request.maxTokens()).isZero();
+		assertThat(request.systemPrompt()).isEqualTo("hello");
+	}
+
+	@Test
+	void testCreateMessageResult() throws Exception {
+		McpSchema.TextContent content = McpSchema.TextContent.builder("Assistant response").build();
+
+		McpSchema.CreateMessageResult result = McpSchema.CreateMessageResult
+			.builder(McpSchema.Role.ASSISTANT, content, "gpt-4")
 			.stopReason(McpSchema.CreateMessageResult.StopReason.END_TURN)
 			.build();
 
@@ -1412,11 +1493,9 @@ public class McpSchemaTests {
 
 		McpSchema.CreateMessageResult value = JSON_MAPPER.readValue(input, McpSchema.CreateMessageResult.class);
 
-		McpSchema.TextContent expectedContent = new McpSchema.TextContent("Assistant response");
-		McpSchema.CreateMessageResult expected = McpSchema.CreateMessageResult.builder()
-			.role(McpSchema.Role.ASSISTANT)
-			.content(expectedContent)
-			.model("gpt-4")
+		McpSchema.TextContent expectedContent = McpSchema.TextContent.builder("Assistant response").build();
+		McpSchema.CreateMessageResult expected = McpSchema.CreateMessageResult
+			.builder(McpSchema.Role.ASSISTANT, expectedContent, "gpt-4")
 			.stopReason(McpSchema.CreateMessageResult.StopReason.UNKNOWN)
 			.build();
 		assertThat(value).isEqualTo(expected);
@@ -1426,9 +1505,9 @@ public class McpSchemaTests {
 
 	@Test
 	void testCreateElicitationRequest() throws Exception {
-		McpSchema.ElicitRequest request = McpSchema.ElicitRequest.builder()
-			.requestedSchema(Map.of("type", "object", "required", List.of("a"), "properties",
-					Map.of("foo", Map.of("type", "string"))))
+		McpSchema.ElicitRequest request = McpSchema.ElicitRequest
+			.builder("Please provide additional information", Map.of("type", "object", "required", List.of("a"),
+					"properties", Map.of("foo", Map.of("type", "string"))))
 			.build();
 
 		String value = JSON_MAPPER.writeValueAsString(request);
@@ -1436,15 +1515,15 @@ public class McpSchemaTests {
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
 			.when(Option.IGNORING_EXTRA_ARRAY_ITEMS)
 			.isObject()
-			.isEqualTo(json("""
-					{"requestedSchema":{"properties":{"foo":{"type":"string"}},"required":["a"],"type":"object"}}"""));
+			.isEqualTo(
+					json("""
+							{"message":"Please provide additional information","requestedSchema":{"properties":{"foo":{"type":"string"}},"required":["a"],"type":"object"}}"""));
 	}
 
 	@Test
 	void testCreateElicitationResult() throws Exception {
-		McpSchema.ElicitResult result = McpSchema.ElicitResult.builder()
+		McpSchema.ElicitResult result = McpSchema.ElicitResult.builder(McpSchema.ElicitResult.Action.ACCEPT)
 			.content(Map.of("foo", "bar"))
-			.message(McpSchema.ElicitResult.Action.ACCEPT)
 			.build();
 
 		String value = JSON_MAPPER.writeValueAsString(result);
@@ -1457,6 +1536,15 @@ public class McpSchemaTests {
 	}
 
 	@Test
+	void testElicitRequestDeserializationWithMissingRequiredFields() throws Exception {
+		McpSchema.ElicitRequest request = JSON_MAPPER.readValue("{}", McpSchema.ElicitRequest.class);
+
+		assertThat(request).isNotNull();
+		assertThat(request.message()).isEmpty();
+		assertThat(request.requestedSchema()).isEmpty();
+	}
+
+	@Test
 	void testElicitRequestWithMeta() throws Exception {
 		Map<String, Object> requestedSchema = Map.of("type", "object", "required", List.of("name"), "properties",
 				Map.of("name", Map.of("type", "string")));
@@ -1464,9 +1552,7 @@ public class McpSchemaTests {
 		Map<String, Object> meta = new HashMap<>();
 		meta.put("progressToken", "elicit-token-789");
 
-		McpSchema.ElicitRequest request = McpSchema.ElicitRequest.builder()
-			.message("Please provide your name")
-			.requestedSchema(requestedSchema)
+		McpSchema.ElicitRequest request = McpSchema.ElicitRequest.builder("Please provide your name", requestedSchema)
 			.meta(meta)
 			.build();
 
@@ -1552,7 +1638,7 @@ public class McpSchemaTests {
 		McpSchema.CompleteRequest.CompleteArgument argument = new McpSchema.CompleteRequest.CompleteArgument("arg1",
 				"partial-value");
 
-		McpSchema.CompleteRequest request = new McpSchema.CompleteRequest(promptRef, argument);
+		McpSchema.CompleteRequest request = McpSchema.CompleteRequest.builder(promptRef, argument).build();
 
 		String value = JSON_MAPPER.writeValueAsString(request);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -1576,7 +1662,7 @@ public class McpSchemaTests {
 		Map<String, Object> meta = new HashMap<>();
 		meta.put("progressToken", "complete-progress-789");
 
-		McpSchema.CompleteRequest request = new McpSchema.CompleteRequest(resourceRef, argument, meta, null);
+		McpSchema.CompleteRequest request = McpSchema.CompleteRequest.builder(resourceRef, argument).meta(meta).build();
 
 		String value = JSON_MAPPER.writeValueAsString(request);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -1595,7 +1681,10 @@ public class McpSchemaTests {
 
 	@Test
 	void testRoot() throws Exception {
-		McpSchema.Root root = new McpSchema.Root("file:///path/to/root", "Test Root", Map.of("metaKey", "metaValue"));
+		McpSchema.Root root = McpSchema.Root.builder("file:///path/to/root")
+			.name("Test Root")
+			.meta(Map.of("metaKey", "metaValue"))
+			.build();
 
 		String value = JSON_MAPPER.writeValueAsString(root);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -1607,11 +1696,13 @@ public class McpSchemaTests {
 
 	@Test
 	void testListRootsResult() throws Exception {
-		McpSchema.Root root1 = new McpSchema.Root("file:///path/to/root1", "First Root");
+		McpSchema.Root root1 = McpSchema.Root.builder("file:///path/to/root1").name("First Root").build();
 
-		McpSchema.Root root2 = new McpSchema.Root("file:///path/to/root2", "Second Root");
+		McpSchema.Root root2 = McpSchema.Root.builder("file:///path/to/root2").name("Second Root").build();
 
-		McpSchema.ListRootsResult result = new McpSchema.ListRootsResult(Arrays.asList(root1, root2), "next-cursor");
+		McpSchema.ListRootsResult result = McpSchema.ListRootsResult.builder(Arrays.asList(root1, root2))
+			.nextCursor("next-cursor")
+			.build();
 
 		String value = JSON_MAPPER.writeValueAsString(result);
 
@@ -1729,8 +1820,11 @@ public class McpSchemaTests {
 
 	@Test
 	void testProgressNotificationWithMessage() throws Exception {
-		McpSchema.ProgressNotification notification = new McpSchema.ProgressNotification("progress-token-123", 0.5, 1.0,
-				"Processing file 1 of 2", Map.of("key", "value"));
+		McpSchema.ProgressNotification notification = McpSchema.ProgressNotification.builder("progress-token-123", 0.5)
+			.total(1.0)
+			.message("Processing file 1 of 2")
+			.meta(Map.of("key", "value"))
+			.build();
 
 		String value = JSON_MAPPER.writeValueAsString(notification);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -1756,9 +1850,20 @@ public class McpSchemaTests {
 	}
 
 	@Test
+	void testProgressNotificationDeserializationWithMissingRequiredFields() throws Exception {
+		McpSchema.ProgressNotification notification = JSON_MAPPER.readValue("""
+				{"total":1.0}""", McpSchema.ProgressNotification.class);
+
+		assertThat(notification).isNotNull();
+		assertThat(notification.progressToken()).isEqualTo("");
+		assertThat(notification.progress()).isZero();
+		assertThat(notification.total()).isEqualTo(1.0);
+	}
+
+	@Test
 	void testProgressNotificationWithoutMessage() throws Exception {
-		McpSchema.ProgressNotification notification = new McpSchema.ProgressNotification("progress-token-789", 0.25,
-				null, null);
+		McpSchema.ProgressNotification notification = McpSchema.ProgressNotification.builder("progress-token-789", 0.25)
+			.build();
 
 		String value = JSON_MAPPER.writeValueAsString(notification);
 		assertThatJson(value).when(Option.IGNORING_ARRAY_ORDER)
@@ -1766,6 +1871,17 @@ public class McpSchemaTests {
 			.isObject()
 			.isEqualTo(json("""
 					{"progressToken":"progress-token-789","progress":0.25}"""));
+	}
+
+	@Test
+	void testLoggingMessageNotificationDeserializationWithMissingRequiredFields() throws Exception {
+		McpSchema.LoggingMessageNotification notification = JSON_MAPPER.readValue("""
+				{"logger":"my-logger"}""", McpSchema.LoggingMessageNotification.class);
+
+		assertThat(notification).isNotNull();
+		assertThat(notification.level()).isEqualTo(McpSchema.LoggingLevel.INFO);
+		assertThat(notification.logger()).isEqualTo("my-logger");
+		assertThat(notification.data()).isEmpty();
 	}
 
 }

--- a/mcp-test/src/test/java/io/modelcontextprotocol/spec/SchemaEvolutionTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/spec/SchemaEvolutionTests.java
@@ -41,7 +41,7 @@ class SchemaEvolutionTests {
 
 	@Test
 	void textContentNullAnnotationsOmitted() throws IOException {
-		McpSchema.TextContent content = new McpSchema.TextContent(null, "hello");
+		McpSchema.TextContent content = McpSchema.TextContent.builder("hello").build();
 		String json = mapper.writeValueAsString(content);
 		assertThat(json).doesNotContain("annotations");
 	}
@@ -61,7 +61,7 @@ class SchemaEvolutionTests {
 
 	@Test
 	void promptWithNullArgumentsOmitsFieldOnWire() throws IOException {
-		McpSchema.Prompt prompt = new McpSchema.Prompt("p", "desc", (List<McpSchema.PromptArgument>) null);
+		McpSchema.Prompt prompt = McpSchema.Prompt.builder("p").description("desc").build();
 		String json = mapper.writeValueAsString(prompt);
 		assertThat(json).doesNotContain("arguments");
 	}
@@ -95,8 +95,7 @@ class SchemaEvolutionTests {
 
 	@Test
 	void completeCompletionOmitsNullOptionals() throws IOException {
-		McpSchema.CompleteResult.CompleteCompletion c = new McpSchema.CompleteResult.CompleteCompletion(List.of("x"),
-				null, null);
+		McpSchema.CompleteResult.CompleteCompletion c = new McpSchema.CompleteResult.CompleteCompletion(List.of("x"));
 		String json = mapper.writeValueAsString(c);
 		assertThat(json).doesNotContain("total");
 		assertThat(json).doesNotContain("hasMore");


### PR DESCRIPTION
## Motivation and Context

Every wire-serialized record in McpSchema now validates spec-required
 fields at construction time. Wire deserialization is intentionally
 lenient: a missing required field is replaced with a documented default
 and a WARN is logged, instead of failing the parse. A required-first
 builder convention is introduced across the schema so it is no longer
 possible to obtain a builder that is missing required state.

 Required-field guards
 ---------------------
 Every wire record's compact constructor asserts non-null (and non-empty
 for String identifiers like name, uri, uriTemplate, version) on its
 spec-required components. Passing null now throws
 IllegalArgumentException at construction time instead of silently
 producing invalid JSON via @JsonInclude(NON_ABSENT). This applies to
 the JSON-RPC envelopes, lifecycle types, resource/prompt/tool requests
 and results, sampling and elicitation, content records, root, complete,
 logging and progress notifications, and the two CompleteReference
 implementations. See MIGRATION-2.0.md for the full list.

 Lenient wire deserialization
 ----------------------------
 For each of those records (except JSONRPCResponse.JSONRPCError, which
 still fails fast) a @JsonCreator static `fromJson` factory substitutes
 a documented default for any absent required field — "" for strings,
 [] for collections, {} for maps, 0 / 0.0 for numerics, INFO for
 LoggingLevel, USER for SamplingMessage.role, ASSISTANT for
 CreateMessageResult.role, CANCEL for ElicitResult.action, {values=[]}
 for CompleteResult.completion — and logs a WARN naming the field and
 the value used. Application code can still observe a malformed message
 and react, but the SDK no longer halts the conversation.

 Builder convention
 ------------------
 Records that have a builder gain a required-first factory method
 `builder(req1, req2, …)`; setters for required fields are removed from
 the builder so it cannot be left in an invalid state. Existing no-arg
 `builder()` factories and required-field setters are kept where source
 compatibility demands it but are marked @Deprecated. New builders are
 also added for several records that previously had none (ProgressNotification,
 JSONRPCError, CompleteRequest, list/result types, content records, ...).

 JSON-RPC envelope ergonomics
 ----------------------------
 Previously every JSON-RPC envelope had to be constructed via the
 canonical record constructor and the literal "2.0" string had to be
 threaded through every call site, e.g.

     new JSONRPCRequest("2.0", "tools/call", id, params)
     new JSONRPCResponse("2.0", id, result, null)
     new JSONRPCResponse("2.0", id, null, new JSONRPCError(code, message, null))

 Now:

     new JSONRPCRequest("tools/call", id, params)               // jsonrpc defaulted
     new JSONRPCNotification("notifications/initialized")       // params optional
     JSONRPCResponse.result(id, result)                         // factory
     JSONRPCResponse.error(id, new JSONRPCError(code, message)) // 2-arg error

 JSONRPCResponse's compact constructor additionally enforces the
 JSON-RPC invariant that exactly one of `result` / `error` is set —
 previously the SDK could build envelopes that violated the protocol.

 CompleteReference changes
 -------------------------
 - PromptReference.equals/hashCode now key on `name` only (previously
   derived from identifier()+type()). Two refs with the same name but
   different titles now compare equal — code using PromptReference as a
   map/set key should be audited.
 - PromptReference's compact constructor pins `type` to "ref/prompt"
   and logs a WARN if the caller supplies a different non-null value.
   The legacy two-arg `PromptReference(String type, String name)`
   constructor remains @Deprecated.
 - ResourceReference's record components are reduced from (type, uri)
   to (uri) — positional construction breaks. The legacy
   `ResourceReference(String type, String uri)` constructor stays
   @Deprecated and ignores `type`.
 - CompleteReference.identifier() is @Deprecated and now returns null
   via a default method on the interface.

 Tests / refactor
 ----------------
 Conformance harness, integration tests, sample apps, and internal
 callers were migrated to the new builder factories and convenience
 constructors. No semantic changes to client/server runtime behaviour
 beyond the McpSchema changes above.

 Docs
 ----
 - MIGRATION-2.0.md: required-field section now covers the broader
   record set and the lenient-deserialization behaviour; PromptReference
   WARN behaviour and ResourceReference component reduction are
   documented; the JSON-RPC envelope section is rewritten to compare the
   pre-2.0 surface with the new one.
 - CONTRIBUTING.md: the "Evolving wire-serialized records" recipe is
   split into two cases — adding a new optional field (existing rules)
   and adding/maintaining a spec-required field (new rules covering
   Assert in compact constructor, @JsonCreator fromJson with defaults
   and WARN, required-first builder factory).

## How Has This Been Tested?
Test code that constructed these records without required fields was updated to supply valid values; those tests were testing capability-check or error-path logic that fires after construction, so the missing fields were incidental rather than intentional.

## Breaking Changes
- PromptReference.equals/hashCode now key on `name` only (previously
  derived from identifier()+type()). Two refs with the same name but
  different titles now compare equal — code using PromptReference as a
  map/set key should be audited.
- PromptReference's compact constructor pins `type` to "ref/prompt"
  and logs a WARN if the caller supplies a different non-null value.
  The legacy two-arg `PromptReference(String type, String name)`
  constructor remains @Deprecated.
- ResourceReference's record components are reduced from (type, uri)
  to (uri) — positional construction breaks. The legacy
  `ResourceReference(String type, String uri)` constructor stays
  @Deprecated and ignores `type`.
- CompleteReference.identifier() is @Deprecated and now returns null
  via a default method on the interface.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
