### PR TITLE
fix: set UTF-8 charset before reading request body in servlet transports

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
@@ -386,6 +386,7 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 		}
 
 		try {
+			request.setCharacterEncoding(UTF_8);
 			BufferedReader reader = request.getReader();
 			StringBuilder body = new StringBuilder();
 			String line;

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStatelessServerTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStatelessServerTransport.java
@@ -154,6 +154,7 @@ public class HttpServletStatelessServerTransport extends HttpServlet implements 
 		}
 
 		try {
+			request.setCharacterEncoding(UTF_8);
 			BufferedReader reader = request.getReader();
 			StringBuilder body = new StringBuilder();
 			String line;

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
@@ -428,6 +428,7 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 		McpTransportContext transportContext = this.contextExtractor.extract(request);
 
 		try {
+			request.setCharacterEncoding(UTF_8);
 			BufferedReader reader = request.getReader();
 			StringBuilder body = new StringBuilder();
 			String line;


### PR DESCRIPTION
## Summary

Fixes #880

All three servlet-based server transports called `request.getReader()` without first calling `request.setCharacterEncoding("UTF-8")`. Per the Jakarta Servlet spec, `getReader()` defaults to ISO-8859-1 when the `Content-Type` header does not include an explicit charset parameter. Since `Content-Type: application/json` without a charset is valid per RFC 8259, non-ASCII characters in tool names, argument values, and notification data were silently corrupted.

The fix adds `request.setCharacterEncoding("UTF-8")` immediately before each `request.getReader()` call in the three affected transports:
- `HttpServletStreamableServerTransportProvider`
- `HttpServletSseServerTransportProvider`
- `HttpServletStatelessServerTransport`

This mirrors the fix already applied to `StdioServerTransportProvider` in #826 and the response path in #881.

## Changes

- `HttpServletStreamableServerTransportProvider.java` — set UTF-8 encoding before `getReader()` in POST handler
- `HttpServletSseServerTransportProvider.java` — set UTF-8 encoding before `getReader()` in message handler
- `HttpServletStatelessServerTransport.java` — set UTF-8 encoding before `getReader()` in request handler

## Testing

- All existing servlet integration tests pass: `HttpServletStreamableIntegrationTests` (32 tests), `HttpServletSseIntegrationTests`, `HttpServletStatelessIntegrationTests` (10 tests) — 74 total, 0 failures.
- The fix can be manually verified by sending a tool call with non-ASCII arguments (e.g. Japanese, Chinese, emoji) to any servlet-based MCP server without `charset=utf-8` in the `Content-Type` header.