### PR TITLE
fix: guard against null Prompt.arguments() in completion handlers

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -999,9 +999,8 @@ public class McpAsyncServer {
 						.message("Prompt not found: " + promptReference.name())
 						.build());
 				}
-				if (!promptSpec.prompt()
-					.arguments()
-					.stream()
+				List<McpSchema.PromptArgument> promptArgs = promptSpec.prompt().arguments();
+				if (promptArgs != null && !promptArgs.stream()
 					.filter(arg -> arg.name().equals(argumentName))
 					.findFirst()
 					.isPresent()) {

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
@@ -744,9 +744,8 @@ public class McpStatelessAsyncServer {
 						.message("Prompt not found: " + promptReference.name())
 						.build());
 				}
-				if (!promptSpec.prompt()
-					.arguments()
-					.stream()
+				List<McpSchema.PromptArgument> promptArgs = promptSpec.prompt().arguments();
+				if (promptArgs != null && !promptArgs.stream()
 					.filter(arg -> arg.name().equals(argumentName))
 					.findFirst()
 					.isPresent()) {

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -10,6 +10,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -17,11 +20,10 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.json.TypeRef;
 import io.modelcontextprotocol.util.Assert;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Based on the <a href="http://www.jsonrpc.org/specification">JSON-RPC 2.0
@@ -1176,6 +1178,19 @@ public final class McpSchema {
 
 		public Prompt(String name, String title, String description, List<PromptArgument> arguments) {
 			this(name, title, description, arguments, null);
+		}
+
+		/**
+		 * Creates a Prompt that coerces {@code null} arguments to an empty list,
+		 * preserving the 1.x behaviour. Use this factory when callers expect
+		 * {@code prompt.arguments()} to never return {@code null}.
+		 * @param name the prompt name
+		 * @param description an optional description
+		 * @param arguments the argument list, or {@code null} to default to an empty list
+		 * @return a new Prompt with non-null arguments
+		 */
+		public static Prompt withDefaults(String name, String description, List<PromptArgument> arguments) {
+			return new Prompt(name, null, description, arguments != null ? arguments : new ArrayList<>(), null);
 		}
 	}
 


### PR DESCRIPTION

---

Fixes #932

The 2.0 forward-compat refactor (#972) changed `Prompt` constructors to stop coercing `null` arguments to an empty list, but the completion validation code in `McpAsyncServer` and `McpStatelessAsyncServer` still called `.arguments().stream()` without a null guard, causing a `NullPointerException` when a `Prompt` with null arguments receives a `completion/complete` request.

Additionally, `MIGRATION-2.0.md` references `Prompt.withDefaults()` as the migration path, but this factory method was never implemented.

This commit:
- Adds a null check before `.arguments().stream()` in both `McpAsyncServer` and `McpStatelessAsyncServer`
- Adds `Prompt.withDefaults(name, description, arguments)` factory that coerces `null` to an empty list, matching the 1.x behaviour

## Motivation and Context

After #972 merged, any MCP server that registers a `Prompt` with `null` arguments and a completion handler will crash with a `NullPointerException` when a `completion/complete` request arrives. This is the SDK's own internal code failing to handle the null-semantics change it introduced — not a user error.

## How Has This Been Tested?

- Reproduced the bug with a standalone stdio MCP server that registers a prompt with null arguments and sends a `completion/complete` request — confirmed the NPE
- Applied the fix and verified the server returns an empty completion result instead of crashing
- All existing tests pass (`./mvnw clean test`)

## Breaking Changes

None. This is a bugfix that makes the SDK more tolerant.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [[MCP Documentation](https://modelcontextprotocol.io/)](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

The `Prompt.withDefaults()` factory was documented in `MIGRATION-2.0.md` as the recommended migration path but never implemented. This PR adds it so the migration guide is accurate.