### PR TITLE
Deprecate SSE transports

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/DefaultSseMessageEndpointValidator.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/DefaultSseMessageEndpointValidator.java
@@ -14,7 +14,10 @@ import io.modelcontextprotocol.util.Assert;
  * SSE uri, or be a relative uri.
  *
  * @author Daniel Garnier-Moiroux
+ * @deprecated This validator is part of the deprecated SSE transport.
+ * @see HttpClientSseClientTransport
  */
+@Deprecated
 public final class DefaultSseMessageEndpointValidator implements SseMessageEndpointValidator {
 
 	@Override

--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransport.java
@@ -62,9 +62,15 @@ import reactor.core.publisher.Sinks;
  * </ul>
  *
  * @author Christian Tzolov
+ * @deprecated This SSE transport is deprecated. Use Streamable HTTP instead, with
+ * {@link HttpClientStreamableHttpTransport}.
  * @see io.modelcontextprotocol.spec.McpTransport
  * @see io.modelcontextprotocol.spec.McpClientTransport
+ * @see <a href=
+ * "https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#backwards-compatibility">Transports
+ * backwards compatibility</a>
  */
+@Deprecated
 public class HttpClientSseClientTransport implements McpClientTransport {
 
 	private static final String MCP_PROTOCOL_VERSION = ProtocolVersions.MCP_2024_11_05;

--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/InvalidSseMessageEndpointException.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/InvalidSseMessageEndpointException.java
@@ -9,7 +9,10 @@ package io.modelcontextprotocol.client.transport;
  * not valid.
  *
  * @author Daniel Garnier-Moiroux
+ * @deprecated This exception is part of the deprecated SSE transport.
+ * @see HttpClientSseClientTransport
  */
+@Deprecated
 public class InvalidSseMessageEndpointException extends Exception {
 
 	private final String messageEndpoint;

--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/SseMessageEndpointValidator.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/SseMessageEndpointValidator.java
@@ -11,7 +11,10 @@ import java.net.URI;
  * {@link InvalidSseMessageEndpointException} when then endpoint is not valid.
  *
  * @author Daniel Garnier-Moiroux
+ * @deprecated This validator is part of the deprecated SSE transport.
+ * @see HttpClientSseClientTransport
  */
+@Deprecated
 @FunctionalInterface
 public interface SseMessageEndpointValidator {
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
@@ -62,11 +62,17 @@ import reactor.core.publisher.Mono;
  * </ul>
  *
  * @author Christian Tzolov
+ * @deprecated This SSE transport is deprecated. Use Streamable HTTP instead, with
+ * {@link HttpServletStreamableServerTransportProvider} or
+ * {@link HttpServletStatelessServerTransport}.
  * @author Alexandros Pappas
  * @see McpServerTransportProvider
  * @see HttpServlet
+ * @see <a href=
+ * "https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#backwards-compatibility">Transports
+ * backwards compatibility</a>
  */
-
+@Deprecated
 @WebServlet(asyncSupported = true)
 public class HttpServletSseServerTransportProvider extends HttpServlet implements McpServerTransportProvider {
 


### PR DESCRIPTION
Mark all SSE-transport related classes as `@Deprecated`

## Motivation and Context

The SSE transport has been deprecated seen the 2025-03-26 version of the spec, and should not be used anymore. We keep for backwards compatibility.