### PR TITLE
feat: support dynamic MCP primitive repositories

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/CompletionsRepository.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/CompletionsRepository.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import reactor.core.publisher.Mono;
+
+/**
+ * Repository for context-aware MCP completion handler resolution.
+ *
+ * @author Taewoong Kim
+ */
+public interface CompletionsRepository {
+
+	/**
+	 * Resolve a completion handler for the given reference.
+	 * @param reference the completion reference
+	 * @param exchange the current client exchange
+	 * @return the completion specification, or empty if none is available
+	 */
+	Mono<McpServerFeatures.AsyncCompletionSpecification> resolveCompletion(McpSchema.CompleteReference reference,
+			McpAsyncServerExchange exchange);
+
+	/**
+	 * Add a completion to the repository.
+	 * <p>
+	 * Custom repositories that support adding completions through this repository
+	 * contract must override this method. If not overridden, this method throws
+	 * {@link UnsupportedOperationException}.
+	 * @param completionSpecification the completion specification
+	 */
+	default void addCompletion(McpServerFeatures.AsyncCompletionSpecification completionSpecification) {
+		throw new UnsupportedOperationException("This CompletionsRepository does not support adding completions");
+	}
+
+	/**
+	 * Remove a completion from the repository.
+	 * <p>
+	 * Custom repositories that support removing completions through this repository
+	 * contract must override this method. If not overridden, this method throws
+	 * {@link UnsupportedOperationException}.
+	 * @param reference the completion reference
+	 * @return {@code true} if a completion was removed
+	 */
+	default boolean removeCompletion(McpSchema.CompleteReference reference) {
+		throw new UnsupportedOperationException("This CompletionsRepository does not support removing completions");
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/InMemoryCompletionsRepository.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/InMemoryCompletionsRepository.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+/**
+ * Default in-memory {@link CompletionsRepository}.
+ *
+ * @author Taewoong Kim
+ */
+public class InMemoryCompletionsRepository implements CompletionsRepository {
+
+	private static final Logger logger = LoggerFactory.getLogger(InMemoryCompletionsRepository.class);
+
+	private final ConcurrentHashMap<McpSchema.CompleteReference, McpServerFeatures.AsyncCompletionSpecification> completions = new ConcurrentHashMap<>();
+
+	public InMemoryCompletionsRepository() {
+	}
+
+	public InMemoryCompletionsRepository(
+			Map<McpSchema.CompleteReference, McpServerFeatures.AsyncCompletionSpecification> completions) {
+		if (completions != null) {
+			completions.values().forEach(this::addCompletion);
+		}
+	}
+
+	@Override
+	public Mono<McpServerFeatures.AsyncCompletionSpecification> resolveCompletion(McpSchema.CompleteReference reference,
+			McpAsyncServerExchange exchange) {
+		return Mono.justOrEmpty(this.completions.get(reference));
+	}
+
+	@Override
+	public void addCompletion(McpServerFeatures.AsyncCompletionSpecification completionSpecification) {
+		var previous = this.completions.put(completionSpecification.referenceKey(), completionSpecification);
+		if (previous != null) {
+			logger.warn("Replace existing Completion with reference '{}'", completionSpecification.referenceKey());
+		}
+	}
+
+	@Override
+	public boolean removeCompletion(McpSchema.CompleteReference reference) {
+		return this.completions.remove(reference) != null;
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/InMemoryPromptsRepository.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/InMemoryPromptsRepository.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+/**
+ * Default in-memory {@link PromptsRepository}.
+ *
+ * @author Taewoong Kim
+ */
+public class InMemoryPromptsRepository implements PromptsRepository {
+
+	private static final Logger logger = LoggerFactory.getLogger(InMemoryPromptsRepository.class);
+
+	private final ConcurrentHashMap<String, McpServerFeatures.AsyncPromptSpecification> prompts = new ConcurrentHashMap<>();
+
+	public InMemoryPromptsRepository() {
+	}
+
+	public InMemoryPromptsRepository(Map<String, McpServerFeatures.AsyncPromptSpecification> prompts) {
+		if (prompts != null) {
+			prompts.values().forEach(this::addPrompt);
+		}
+	}
+
+	@Override
+	public Mono<McpSchema.ListPromptsResult> listPrompts(McpAsyncServerExchange exchange,
+			McpSchema.PaginatedRequest request) {
+		var visiblePrompts = this.prompts.values()
+			.stream()
+			.map(McpServerFeatures.AsyncPromptSpecification::prompt)
+			.toList();
+		return Mono.just(McpSchema.ListPromptsResult.builder(visiblePrompts).build());
+	}
+
+	@Override
+	public Mono<McpServerFeatures.AsyncPromptSpecification> resolvePrompt(String name,
+			McpAsyncServerExchange exchange) {
+		return Mono.justOrEmpty(this.prompts.get(name));
+	}
+
+	@Override
+	public void addPrompt(McpServerFeatures.AsyncPromptSpecification promptSpecification) {
+		var previous = this.prompts.put(promptSpecification.prompt().name(), promptSpecification);
+		if (previous != null) {
+			logger.warn("Replace existing Prompt with name '{}'", promptSpecification.prompt().name());
+		}
+	}
+
+	@Override
+	public boolean removePrompt(String name) {
+		return this.prompts.remove(name) != null;
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/InMemoryResourcesRepository.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/InMemoryResourcesRepository.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.util.DefaultMcpUriTemplateManagerFactory;
+import io.modelcontextprotocol.util.McpUriTemplateManagerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+/**
+ * Default in-memory {@link ResourcesRepository}.
+ *
+ * @author Taewoong Kim
+ */
+public class InMemoryResourcesRepository implements ResourcesRepository {
+
+	private static final Logger logger = LoggerFactory.getLogger(InMemoryResourcesRepository.class);
+
+	private final ConcurrentHashMap<String, McpServerFeatures.AsyncResourceSpecification> resources = new ConcurrentHashMap<>();
+
+	private final ConcurrentHashMap<String, McpServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates = new ConcurrentHashMap<>();
+
+	private final McpUriTemplateManagerFactory uriTemplateManagerFactory;
+
+	public InMemoryResourcesRepository() {
+		this(Map.of(), Map.of(), new DefaultMcpUriTemplateManagerFactory());
+	}
+
+	public InMemoryResourcesRepository(Map<String, McpServerFeatures.AsyncResourceSpecification> resources,
+			Map<String, McpServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates,
+			McpUriTemplateManagerFactory uriTemplateManagerFactory) {
+		this.uriTemplateManagerFactory = uriTemplateManagerFactory;
+		if (resources != null) {
+			resources.values().forEach(this::addResource);
+		}
+		if (resourceTemplates != null) {
+			resourceTemplates.values().forEach(this::addResourceTemplate);
+		}
+	}
+
+	@Override
+	public Mono<McpSchema.ListResourcesResult> listResources(McpAsyncServerExchange exchange,
+			McpSchema.PaginatedRequest request) {
+		var visibleResources = this.resources.values()
+			.stream()
+			.map(McpServerFeatures.AsyncResourceSpecification::resource)
+			.toList();
+		return Mono.just(McpSchema.ListResourcesResult.builder(visibleResources).build());
+	}
+
+	@Override
+	public Mono<McpSchema.ListResourceTemplatesResult> listResourceTemplates(McpAsyncServerExchange exchange,
+			McpSchema.PaginatedRequest request) {
+		var visibleResourceTemplates = this.resourceTemplates.values()
+			.stream()
+			.map(McpServerFeatures.AsyncResourceTemplateSpecification::resourceTemplate)
+			.toList();
+		return Mono.just(McpSchema.ListResourceTemplatesResult.builder(visibleResourceTemplates).build());
+	}
+
+	@Override
+	public Mono<McpServerFeatures.AsyncResourceSpecification> resolveResource(String uri,
+			McpAsyncServerExchange exchange) {
+		// Direct resource URIs are matched with the configured URI-template
+		// matcher. With the default matcher, non-template URIs behave like exact
+		// matches.
+		return Mono.justOrEmpty(this.resources.values()
+			.stream()
+			.filter(spec -> this.uriTemplateManagerFactory.create(spec.resource().uri()).matches(uri))
+			.findFirst());
+	}
+
+	@Override
+	public Mono<McpServerFeatures.AsyncResourceTemplateSpecification> resolveResourceTemplate(String uri,
+			McpAsyncServerExchange exchange) {
+		return Mono.justOrEmpty(this.resourceTemplates.values()
+			.stream()
+			.filter(spec -> this.uriTemplateManagerFactory.create(spec.resourceTemplate().uriTemplate()).matches(uri))
+			.findFirst());
+	}
+
+	@Override
+	public void addResource(McpServerFeatures.AsyncResourceSpecification resourceSpecification) {
+		var previous = this.resources.put(resourceSpecification.resource().uri(), resourceSpecification);
+		if (previous != null) {
+			logger.warn("Replace existing Resource with URI '{}'", resourceSpecification.resource().uri());
+		}
+	}
+
+	@Override
+	public boolean removeResource(String uri) {
+		return this.resources.remove(uri) != null;
+	}
+
+	@Override
+	public void addResourceTemplate(
+			McpServerFeatures.AsyncResourceTemplateSpecification resourceTemplateSpecification) {
+		var previous = this.resourceTemplates.put(resourceTemplateSpecification.resourceTemplate().uriTemplate(),
+				resourceTemplateSpecification);
+		if (previous != null) {
+			logger.warn("Replace existing Resource Template with URI '{}'",
+					resourceTemplateSpecification.resourceTemplate().uriTemplate());
+		}
+	}
+
+	@Override
+	public boolean removeResourceTemplate(String uriTemplate) {
+		return this.resourceTemplates.remove(uriTemplate) != null;
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/InMemoryStatelessCompletionsRepository.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/InMemoryStatelessCompletionsRepository.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+/**
+ * Default in-memory {@link StatelessCompletionsRepository}.
+ *
+ * @author Taewoong Kim
+ */
+public class InMemoryStatelessCompletionsRepository implements StatelessCompletionsRepository {
+
+	private static final Logger logger = LoggerFactory.getLogger(InMemoryStatelessCompletionsRepository.class);
+
+	private final ConcurrentHashMap<McpSchema.CompleteReference, McpStatelessServerFeatures.AsyncCompletionSpecification> completions = new ConcurrentHashMap<>();
+
+	public InMemoryStatelessCompletionsRepository() {
+	}
+
+	public InMemoryStatelessCompletionsRepository(
+			Map<McpSchema.CompleteReference, McpStatelessServerFeatures.AsyncCompletionSpecification> completions) {
+		if (completions != null) {
+			completions.values().forEach(this::addCompletion);
+		}
+	}
+
+	@Override
+	public Mono<McpStatelessServerFeatures.AsyncCompletionSpecification> resolveCompletion(
+			McpSchema.CompleteReference reference, McpTransportContext transportContext) {
+		return Mono.justOrEmpty(this.completions.get(reference));
+	}
+
+	@Override
+	public void addCompletion(McpStatelessServerFeatures.AsyncCompletionSpecification completionSpecification) {
+		var previous = this.completions.put(completionSpecification.referenceKey(), completionSpecification);
+		if (previous != null) {
+			logger.warn("Replace existing Completion with reference '{}'", completionSpecification.referenceKey());
+		}
+	}
+
+	@Override
+	public boolean removeCompletion(McpSchema.CompleteReference reference) {
+		return this.completions.remove(reference) != null;
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/InMemoryStatelessPromptsRepository.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/InMemoryStatelessPromptsRepository.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+/**
+ * Default in-memory {@link StatelessPromptsRepository}.
+ *
+ * @author Taewoong Kim
+ */
+public class InMemoryStatelessPromptsRepository implements StatelessPromptsRepository {
+
+	private static final Logger logger = LoggerFactory.getLogger(InMemoryStatelessPromptsRepository.class);
+
+	private final ConcurrentHashMap<String, McpStatelessServerFeatures.AsyncPromptSpecification> prompts = new ConcurrentHashMap<>();
+
+	public InMemoryStatelessPromptsRepository() {
+	}
+
+	public InMemoryStatelessPromptsRepository(
+			Map<String, McpStatelessServerFeatures.AsyncPromptSpecification> prompts) {
+		if (prompts != null) {
+			prompts.values().forEach(this::addPrompt);
+		}
+	}
+
+	@Override
+	public Mono<McpSchema.ListPromptsResult> listPrompts(McpTransportContext transportContext,
+			McpSchema.PaginatedRequest request) {
+		var visiblePrompts = this.prompts.values()
+			.stream()
+			.map(McpStatelessServerFeatures.AsyncPromptSpecification::prompt)
+			.toList();
+		return Mono.just(McpSchema.ListPromptsResult.builder(visiblePrompts).build());
+	}
+
+	@Override
+	public Mono<McpStatelessServerFeatures.AsyncPromptSpecification> resolvePrompt(String name,
+			McpTransportContext transportContext) {
+		return Mono.justOrEmpty(this.prompts.get(name));
+	}
+
+	@Override
+	public void addPrompt(McpStatelessServerFeatures.AsyncPromptSpecification promptSpecification) {
+		var previous = this.prompts.put(promptSpecification.prompt().name(), promptSpecification);
+		if (previous != null) {
+			logger.warn("Replace existing Prompt with name '{}'", promptSpecification.prompt().name());
+		}
+	}
+
+	@Override
+	public boolean removePrompt(String name) {
+		return this.prompts.remove(name) != null;
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/InMemoryStatelessResourcesRepository.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/InMemoryStatelessResourcesRepository.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.util.DefaultMcpUriTemplateManagerFactory;
+import io.modelcontextprotocol.util.McpUriTemplateManagerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+/**
+ * Default in-memory {@link StatelessResourcesRepository}.
+ *
+ * @author Taewoong Kim
+ */
+public class InMemoryStatelessResourcesRepository implements StatelessResourcesRepository {
+
+	private static final Logger logger = LoggerFactory.getLogger(InMemoryStatelessResourcesRepository.class);
+
+	private final ConcurrentHashMap<String, McpStatelessServerFeatures.AsyncResourceSpecification> resources = new ConcurrentHashMap<>();
+
+	private final ConcurrentHashMap<String, McpStatelessServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates = new ConcurrentHashMap<>();
+
+	private final McpUriTemplateManagerFactory uriTemplateManagerFactory;
+
+	public InMemoryStatelessResourcesRepository() {
+		this(Map.of(), Map.of(), new DefaultMcpUriTemplateManagerFactory());
+	}
+
+	public InMemoryStatelessResourcesRepository(
+			Map<String, McpStatelessServerFeatures.AsyncResourceSpecification> resources,
+			Map<String, McpStatelessServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates,
+			McpUriTemplateManagerFactory uriTemplateManagerFactory) {
+		this.uriTemplateManagerFactory = uriTemplateManagerFactory;
+		if (resources != null) {
+			resources.values().forEach(this::addResource);
+		}
+		if (resourceTemplates != null) {
+			resourceTemplates.values().forEach(this::addResourceTemplate);
+		}
+	}
+
+	@Override
+	public Mono<McpSchema.ListResourcesResult> listResources(McpTransportContext transportContext,
+			McpSchema.PaginatedRequest request) {
+		var visibleResources = this.resources.values()
+			.stream()
+			.map(McpStatelessServerFeatures.AsyncResourceSpecification::resource)
+			.toList();
+		return Mono.just(McpSchema.ListResourcesResult.builder(visibleResources).build());
+	}
+
+	@Override
+	public Mono<McpSchema.ListResourceTemplatesResult> listResourceTemplates(McpTransportContext transportContext,
+			McpSchema.PaginatedRequest request) {
+		var visibleResourceTemplates = this.resourceTemplates.values()
+			.stream()
+			.map(McpStatelessServerFeatures.AsyncResourceTemplateSpecification::resourceTemplate)
+			.toList();
+		return Mono.just(McpSchema.ListResourceTemplatesResult.builder(visibleResourceTemplates).build());
+	}
+
+	@Override
+	public Mono<McpStatelessServerFeatures.AsyncResourceSpecification> resolveResource(String uri,
+			McpTransportContext transportContext) {
+		// Direct resource URIs are matched with the configured URI-template
+		// matcher. With the default matcher, non-template URIs behave like exact
+		// matches.
+		return Mono.justOrEmpty(this.resources.values()
+			.stream()
+			.filter(spec -> this.uriTemplateManagerFactory.create(spec.resource().uri()).matches(uri))
+			.findFirst());
+	}
+
+	@Override
+	public Mono<McpStatelessServerFeatures.AsyncResourceTemplateSpecification> resolveResourceTemplate(String uri,
+			McpTransportContext transportContext) {
+		return Mono.justOrEmpty(this.resourceTemplates.values()
+			.stream()
+			.filter(spec -> this.uriTemplateManagerFactory.create(spec.resourceTemplate().uriTemplate()).matches(uri))
+			.findFirst());
+	}
+
+	@Override
+	public void addResource(McpStatelessServerFeatures.AsyncResourceSpecification resourceSpecification) {
+		var previous = this.resources.put(resourceSpecification.resource().uri(), resourceSpecification);
+		if (previous != null) {
+			logger.warn("Replace existing Resource with URI '{}'", resourceSpecification.resource().uri());
+		}
+	}
+
+	@Override
+	public boolean removeResource(String uri) {
+		return this.resources.remove(uri) != null;
+	}
+
+	@Override
+	public void addResourceTemplate(
+			McpStatelessServerFeatures.AsyncResourceTemplateSpecification resourceTemplateSpecification) {
+		var previous = this.resourceTemplates.put(resourceTemplateSpecification.resourceTemplate().uriTemplate(),
+				resourceTemplateSpecification);
+		if (previous != null) {
+			logger.warn("Replace existing Resource Template with URI '{}'",
+					resourceTemplateSpecification.resourceTemplate().uriTemplate());
+		}
+	}
+
+	@Override
+	public boolean removeResourceTemplate(String uriTemplate) {
+		return this.resourceTemplates.remove(uriTemplate) != null;
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/InMemoryStatelessToolsRepository.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/InMemoryStatelessToolsRepository.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+/**
+ * Default in-memory {@link StatelessToolsRepository}.
+ *
+ * @author Taewoong Kim
+ */
+public class InMemoryStatelessToolsRepository implements StatelessToolsRepository {
+
+	private static final Logger logger = LoggerFactory.getLogger(InMemoryStatelessToolsRepository.class);
+
+	private final CopyOnWriteArrayList<McpStatelessServerFeatures.AsyncToolSpecification> tools = new CopyOnWriteArrayList<>();
+
+	public InMemoryStatelessToolsRepository() {
+	}
+
+	public InMemoryStatelessToolsRepository(List<McpStatelessServerFeatures.AsyncToolSpecification> tools) {
+		if (tools != null) {
+			tools.forEach(this::addTool);
+		}
+	}
+
+	@Override
+	public Mono<McpSchema.ListToolsResult> listTools(McpTransportContext transportContext,
+			McpSchema.PaginatedRequest request) {
+		List<McpSchema.Tool> visibleTools = this.tools.stream()
+			.map(McpStatelessServerFeatures.AsyncToolSpecification::tool)
+			.toList();
+		return Mono.just(McpSchema.ListToolsResult.builder(visibleTools).build());
+	}
+
+	@Override
+	public Mono<McpStatelessServerFeatures.AsyncToolSpecification> resolveTool(String name,
+			McpTransportContext transportContext) {
+		return Mono.justOrEmpty(this.tools.stream().filter(tool -> tool.tool().name().equals(name)).findFirst());
+	}
+
+	@Override
+	public void addTool(McpStatelessServerFeatures.AsyncToolSpecification toolSpecification) {
+		if (this.tools.removeIf(tool -> tool.tool().name().equals(toolSpecification.tool().name()))) {
+			logger.warn("Replace existing Tool with name '{}'", toolSpecification.tool().name());
+		}
+		this.tools.add(toolSpecification);
+	}
+
+	@Override
+	public boolean removeTool(String name) {
+		return this.tools.removeIf(tool -> tool.tool().name().equals(name));
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/InMemoryToolsRepository.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/InMemoryToolsRepository.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+/**
+ * Default in-memory {@link ToolsRepository}.
+ *
+ * @author Taewoong Kim
+ */
+public class InMemoryToolsRepository implements ToolsRepository {
+
+	private static final Logger logger = LoggerFactory.getLogger(InMemoryToolsRepository.class);
+
+	private final CopyOnWriteArrayList<McpServerFeatures.AsyncToolSpecification> tools = new CopyOnWriteArrayList<>();
+
+	public InMemoryToolsRepository() {
+	}
+
+	public InMemoryToolsRepository(List<McpServerFeatures.AsyncToolSpecification> tools) {
+		if (tools != null) {
+			tools.forEach(this::addTool);
+		}
+	}
+
+	@Override
+	public Mono<McpSchema.ListToolsResult> listTools(McpAsyncServerExchange exchange,
+			McpSchema.PaginatedRequest request) {
+		List<McpSchema.Tool> visibleTools = this.tools.stream()
+			.map(McpServerFeatures.AsyncToolSpecification::tool)
+			.toList();
+		return Mono.just(McpSchema.ListToolsResult.builder(visibleTools).build());
+	}
+
+	@Override
+	public Mono<McpServerFeatures.AsyncToolSpecification> resolveTool(String name, McpAsyncServerExchange exchange) {
+		return Mono.justOrEmpty(this.tools.stream().filter(tool -> tool.tool().name().equals(name)).findFirst());
+	}
+
+	@Override
+	public void addTool(McpServerFeatures.AsyncToolSpecification toolSpecification) {
+		if (this.tools.removeIf(tool -> tool.tool().name().equals(toolSpecification.tool().name()))) {
+			logger.warn("Replace existing Tool with name '{}'", toolSpecification.tool().name());
+		}
+		this.tools.add(toolSpecification);
+	}
+
+	@Override
+	public boolean removeTool(String name) {
+		return this.tools.removeIf(tool -> tool.tool().name().equals(name));
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -13,7 +13,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiFunction;
 
 import io.modelcontextprotocol.json.McpJsonMapper;
@@ -26,7 +25,6 @@ import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.CompleteResult.CompleteCompletion;
 import io.modelcontextprotocol.spec.McpSchema.ErrorCodes;
-import io.modelcontextprotocol.spec.McpSchema.LoggingLevel;
 import io.modelcontextprotocol.spec.McpSchema.PromptReference;
 import io.modelcontextprotocol.spec.McpSchema.ResourceReference;
 import io.modelcontextprotocol.spec.McpSchema.SetLevelRequest;
@@ -107,15 +105,13 @@ public class McpAsyncServer {
 
 	private final String instructions;
 
-	private final CopyOnWriteArrayList<McpServerFeatures.AsyncToolSpecification> tools = new CopyOnWriteArrayList<>();
+	private final ToolsRepository toolsRepository;
 
-	private final ConcurrentHashMap<String, McpServerFeatures.AsyncResourceSpecification> resources = new ConcurrentHashMap<>();
+	private final ResourcesRepository resourcesRepository;
 
-	private final ConcurrentHashMap<String, McpServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates = new ConcurrentHashMap<>();
+	private final PromptsRepository promptsRepository;
 
-	private final ConcurrentHashMap<String, McpServerFeatures.AsyncPromptSpecification> prompts = new ConcurrentHashMap<>();
-
-	private final ConcurrentHashMap<McpSchema.CompleteReference, McpServerFeatures.AsyncCompletionSpecification> completions = new ConcurrentHashMap<>();
+	private final CompletionsRepository completionsRepository;
 
 	private final ConcurrentHashMap<String, Set<String>> resourceSubscriptions = new ConcurrentHashMap<>();
 
@@ -139,11 +135,13 @@ public class McpAsyncServer {
 		this.serverInfo = features.serverInfo();
 		this.serverCapabilities = features.serverCapabilities().mutate().logging().build();
 		this.instructions = features.instructions();
-		this.tools.addAll(withStructuredOutputHandling(jsonSchemaValidator, features.tools()));
-		this.resources.putAll(features.resources());
-		this.resourceTemplates.putAll(features.resourceTemplates());
-		this.prompts.putAll(features.prompts());
-		this.completions.putAll(features.completions());
+		this.toolsRepository = initializeToolsRepository(features.toolsRepository(), jsonSchemaValidator,
+				features.tools());
+		this.resourcesRepository = initializeResourcesRepository(features.resourcesRepository(), features.resources(),
+				features.resourceTemplates(), uriTemplateManagerFactory);
+		this.promptsRepository = initializePromptsRepository(features.promptsRepository(), features.prompts());
+		this.completionsRepository = initializeCompletionsRepository(features.completionsRepository(),
+				features.completions());
 		this.uriTemplateManagerFactory = uriTemplateManagerFactory;
 		this.jsonSchemaValidator = jsonSchemaValidator;
 		this.validateToolInputs = validateToolInputs;
@@ -170,11 +168,13 @@ public class McpAsyncServer {
 		this.serverInfo = features.serverInfo();
 		this.serverCapabilities = features.serverCapabilities().mutate().logging().build();
 		this.instructions = features.instructions();
-		this.tools.addAll(withStructuredOutputHandling(jsonSchemaValidator, features.tools()));
-		this.resources.putAll(features.resources());
-		this.resourceTemplates.putAll(features.resourceTemplates());
-		this.prompts.putAll(features.prompts());
-		this.completions.putAll(features.completions());
+		this.toolsRepository = initializeToolsRepository(features.toolsRepository(), jsonSchemaValidator,
+				features.tools());
+		this.resourcesRepository = initializeResourcesRepository(features.resourcesRepository(), features.resources(),
+				features.resourceTemplates(), uriTemplateManagerFactory);
+		this.promptsRepository = initializePromptsRepository(features.promptsRepository(), features.prompts());
+		this.completionsRepository = initializeCompletionsRepository(features.completionsRepository(),
+				features.completions());
 		this.uriTemplateManagerFactory = uriTemplateManagerFactory;
 		this.jsonSchemaValidator = jsonSchemaValidator;
 		this.validateToolInputs = validateToolInputs;
@@ -187,6 +187,50 @@ public class McpAsyncServer {
 		mcpTransportProvider.setSessionFactory(new DefaultMcpStreamableServerSessionFactory(requestTimeout,
 				this::asyncInitializeRequestHandler, requestHandlers, notificationHandlers,
 				sessionId -> this.cleanupForSession(sessionId), this.jsonSchemaValidator));
+	}
+
+	private ToolsRepository initializeToolsRepository(ToolsRepository repository,
+			JsonSchemaValidator jsonSchemaValidator, List<McpServerFeatures.AsyncToolSpecification> tools) {
+		List<McpServerFeatures.AsyncToolSpecification> wrappedTools = withStructuredOutputHandling(jsonSchemaValidator,
+				tools);
+		ToolsRepository target = (repository != null) ? repository : new InMemoryToolsRepository();
+		if (wrappedTools != null) {
+			wrappedTools.forEach(target::addTool);
+		}
+		return target;
+	}
+
+	private ResourcesRepository initializeResourcesRepository(ResourcesRepository repository,
+			Map<String, McpServerFeatures.AsyncResourceSpecification> resources,
+			Map<String, McpServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates,
+			McpUriTemplateManagerFactory uriTemplateManagerFactory) {
+		ResourcesRepository target = (repository != null) ? repository
+				: new InMemoryResourcesRepository(Map.of(), Map.of(), uriTemplateManagerFactory);
+		if (resources != null) {
+			resources.values().forEach(target::addResource);
+		}
+		if (resourceTemplates != null) {
+			resourceTemplates.values().forEach(target::addResourceTemplate);
+		}
+		return target;
+	}
+
+	private PromptsRepository initializePromptsRepository(PromptsRepository repository,
+			Map<String, McpServerFeatures.AsyncPromptSpecification> prompts) {
+		PromptsRepository target = (repository != null) ? repository : new InMemoryPromptsRepository();
+		if (prompts != null) {
+			prompts.values().forEach(target::addPrompt);
+		}
+		return target;
+	}
+
+	private CompletionsRepository initializeCompletionsRepository(CompletionsRepository repository,
+			Map<McpSchema.CompleteReference, McpServerFeatures.AsyncCompletionSpecification> completions) {
+		CompletionsRepository target = (repository != null) ? repository : new InMemoryCompletionsRepository();
+		if (completions != null) {
+			completions.values().forEach(target::addCompletion);
+		}
+		return target;
 	}
 
 	private Map<String, McpNotificationHandler> prepareNotificationHandlers(McpServerFeatures.Async features) {
@@ -248,6 +292,14 @@ public class McpAsyncServer {
 			requestHandlers.put(McpSchema.METHOD_COMPLETION_COMPLETE, completionCompleteRequestHandler());
 		}
 		return requestHandlers;
+	}
+
+	private McpSchema.PaginatedRequest paginatedRequest(Object params) {
+		if (params == null) {
+			return new McpSchema.PaginatedRequest();
+		}
+		return this.jsonMapper.convertValue(params, new TypeRef<McpSchema.PaginatedRequest>() {
+		});
 	}
 
 	// ---------------------------------------
@@ -360,12 +412,7 @@ public class McpAsyncServer {
 		var wrappedToolSpecification = withStructuredOutputHandling(this.jsonSchemaValidator, toolSpecification);
 
 		return Mono.defer(() -> {
-			// Remove tools with duplicate tool names first
-			if (this.tools.removeIf(th -> th.tool().name().equals(wrappedToolSpecification.tool().name()))) {
-				logger.warn("Replace existing Tool with name '{}'", wrappedToolSpecification.tool().name());
-			}
-
-			this.tools.add(wrappedToolSpecification);
+			this.toolsRepository.addTool(wrappedToolSpecification);
 			logger.debug("Added tool handler: {}", wrappedToolSpecification.tool().name());
 
 			if (this.serverCapabilities.tools().listChanged()) {
@@ -491,11 +538,18 @@ public class McpAsyncServer {
 	}
 
 	/**
-	 * List all registered tools.
-	 * @return A Flux stream of all registered tools
+	 * List tools from the repository without a client request exchange.
+	 * <p>
+	 * Dynamic repositories should treat the {@code null} exchange passed by this helper
+	 * as a context-free listing.
+	 * @return A Flux stream of context-free visible tools
 	 */
 	public Flux<Tool> listTools() {
-		return Flux.fromIterable(this.tools).map(McpServerFeatures.AsyncToolSpecification::tool);
+		return Flux.defer(() -> this.toolsRepository.listTools(null, new McpSchema.PaginatedRequest())
+			.expand(result -> (result.nextCursor() != null)
+					? this.toolsRepository.listTools(null, new McpSchema.PaginatedRequest(result.nextCursor()))
+					: Mono.empty())
+			.flatMapIterable(McpSchema.ListToolsResult::tools));
 	}
 
 	/**
@@ -512,7 +566,7 @@ public class McpAsyncServer {
 		}
 
 		return Mono.defer(() -> {
-			if (this.tools.removeIf(toolSpecification -> toolSpecification.tool().name().equals(toolName))) {
+			if (this.toolsRepository.removeTool(toolName)) {
 
 				logger.debug("Removed tool handler: {}", toolName);
 				if (this.serverCapabilities.tools().listChanged()) {
@@ -537,9 +591,7 @@ public class McpAsyncServer {
 
 	private McpRequestHandler<McpSchema.ListToolsResult> toolsListRequestHandler() {
 		return (exchange, params) -> {
-			List<Tool> tools = this.tools.stream().map(McpServerFeatures.AsyncToolSpecification::tool).toList();
-
-			return Mono.just(McpSchema.ListToolsResult.builder(tools).build());
+			return this.toolsRepository.listTools(exchange, paginatedRequest(params));
 		};
 	}
 
@@ -549,25 +601,20 @@ public class McpAsyncServer {
 					new TypeRef<McpSchema.CallToolRequest>() {
 					});
 
-			Optional<McpServerFeatures.AsyncToolSpecification> toolSpecification = this.tools.stream()
-				.filter(tr -> callToolRequest.name().equals(tr.tool().name()))
-				.findAny();
-
-			if (toolSpecification.isEmpty()) {
-				return Mono.error(McpError.builder(McpSchema.ErrorCodes.INVALID_PARAMS)
+			return this.toolsRepository.resolveTool(callToolRequest.name(), exchange)
+				.switchIfEmpty(Mono.error(McpError.builder(McpSchema.ErrorCodes.INVALID_PARAMS)
 					.message("Unknown tool: invalid_tool_name")
 					.data("Tool not found: " + callToolRequest.name())
-					.build());
-			}
-
-			McpSchema.Tool tool = toolSpecification.get().tool();
-			CallToolResult validationError = ToolInputValidator.validate(tool, callToolRequest.arguments(),
-					this.validateToolInputs, this.jsonSchemaValidator);
-			if (validationError != null) {
-				return Mono.just(validationError);
-			}
-
-			return toolSpecification.get().callHandler().apply(exchange, callToolRequest);
+					.build()))
+				.flatMap(toolSpecification -> {
+					McpSchema.Tool tool = toolSpecification.tool();
+					CallToolResult validationError = ToolInputValidator.validate(tool, callToolRequest.arguments(),
+							this.validateToolInputs, this.jsonSchemaValidator);
+					if (validationError != null) {
+						return Mono.just(validationError);
+					}
+					return toolSpecification.callHandler().apply(exchange, callToolRequest);
+				});
 		};
 	}
 
@@ -591,13 +638,8 @@ public class McpAsyncServer {
 		}
 
 		return Mono.defer(() -> {
-			var previous = this.resources.put(resourceSpecification.resource().uri(), resourceSpecification);
-			if (previous != null) {
-				logger.warn("Replace existing Resource with URI '{}'", resourceSpecification.resource().uri());
-			}
-			else {
-				logger.debug("Added resource handler: {}", resourceSpecification.resource().uri());
-			}
+			this.resourcesRepository.addResource(resourceSpecification);
+			logger.debug("Added resource handler: {}", resourceSpecification.resource().uri());
 			if (this.serverCapabilities.resources().listChanged()) {
 				return notifyResourcesListChanged();
 			}
@@ -606,11 +648,18 @@ public class McpAsyncServer {
 	}
 
 	/**
-	 * List all registered resources.
-	 * @return A Flux stream of all registered resources
+	 * List resources from the repository without a client request exchange.
+	 * <p>
+	 * Dynamic repositories should treat the {@code null} exchange passed by this helper
+	 * as a context-free listing.
+	 * @return A Flux stream of context-free visible resources
 	 */
 	public Flux<McpSchema.Resource> listResources() {
-		return Flux.fromIterable(this.resources.values()).map(McpServerFeatures.AsyncResourceSpecification::resource);
+		return Flux
+			.defer(() -> this.resourcesRepository.listResources(null, new McpSchema.PaginatedRequest())
+				.expand(result -> (result.nextCursor() != null) ? this.resourcesRepository.listResources(null,
+						new McpSchema.PaginatedRequest(result.nextCursor())) : Mono.empty())
+				.flatMapIterable(McpSchema.ListResourcesResult::resources));
 	}
 
 	/**
@@ -628,8 +677,7 @@ public class McpAsyncServer {
 		}
 
 		return Mono.defer(() -> {
-			McpServerFeatures.AsyncResourceSpecification removed = this.resources.remove(resourceUri);
-			if (removed != null) {
+			if (this.resourcesRepository.removeResource(resourceUri)) {
 				logger.debug("Removed resource handler: {}", resourceUri);
 				if (this.serverCapabilities.resources().listChanged()) {
 					return notifyResourcesListChanged();
@@ -657,16 +705,9 @@ public class McpAsyncServer {
 		}
 
 		return Mono.defer(() -> {
-			var previous = this.resourceTemplates.put(resourceTemplateSpecification.resourceTemplate().uriTemplate(),
-					resourceTemplateSpecification);
-			if (previous != null) {
-				logger.warn("Replace existing Resource Template with URI '{}'",
-						resourceTemplateSpecification.resourceTemplate().uriTemplate());
-			}
-			else {
-				logger.debug("Added resource template handler: {}",
-						resourceTemplateSpecification.resourceTemplate().uriTemplate());
-			}
+			this.resourcesRepository.addResourceTemplate(resourceTemplateSpecification);
+			logger.debug("Added resource template handler: {}",
+					resourceTemplateSpecification.resourceTemplate().uriTemplate());
 			if (this.serverCapabilities.resources().listChanged()) {
 				return notifyResourcesListChanged();
 			}
@@ -675,18 +716,28 @@ public class McpAsyncServer {
 	}
 
 	/**
-	 * List all registered resource templates.
-	 * @return A Flux stream of all registered resource templates
+	 * List resource templates from the repository without a client request exchange.
+	 * <p>
+	 * Dynamic repositories should treat the {@code null} exchange passed by this helper
+	 * as a context-free listing.
+	 * @return A Flux stream of context-free visible resource templates
 	 */
 	public Flux<McpSchema.ResourceTemplate> listResourceTemplates() {
-		return Flux.fromIterable(this.resourceTemplates.values())
-			.map(McpServerFeatures.AsyncResourceTemplateSpecification::resourceTemplate);
+		return Flux.defer(() -> this.resourcesRepository.listResourceTemplates(null, new McpSchema.PaginatedRequest())
+			.expand(result -> (result.nextCursor() != null) ? this.resourcesRepository.listResourceTemplates(null,
+					new McpSchema.PaginatedRequest(result.nextCursor())) : Mono.empty())
+			.flatMapIterable(McpSchema.ListResourceTemplatesResult::resourceTemplates));
 	}
 
 	/**
 	 * Remove a resource template at runtime.
+	 * <p>
+	 * This method does not automatically send a
+	 * {@code notifications/resources/list_changed} notification. Call
+	 * {@link #notifyResourcesListChanged()} explicitly when clients should refresh the
+	 * resource and resource-template lists.
 	 * @param uriTemplate The URI template of the resource template to remove
-	 * @return Mono that completes when clients have been notified of the change
+	 * @return Mono that completes when the repository has been updated
 	 */
 	public Mono<Void> removeResourceTemplate(String uriTemplate) {
 
@@ -696,8 +747,7 @@ public class McpAsyncServer {
 		}
 
 		return Mono.defer(() -> {
-			McpServerFeatures.AsyncResourceTemplateSpecification removed = this.resourceTemplates.remove(uriTemplate);
-			if (removed != null) {
+			if (this.resourcesRepository.removeResourceTemplate(uriTemplate)) {
 				logger.debug("Removed resource template: {}", uriTemplate);
 			}
 			else {
@@ -787,21 +837,13 @@ public class McpAsyncServer {
 
 	private McpRequestHandler<McpSchema.ListResourcesResult> resourcesListRequestHandler() {
 		return (exchange, params) -> {
-			var resourceList = this.resources.values()
-				.stream()
-				.map(McpServerFeatures.AsyncResourceSpecification::resource)
-				.toList();
-			return Mono.just(McpSchema.ListResourcesResult.builder(resourceList).build());
+			return this.resourcesRepository.listResources(exchange, paginatedRequest(params));
 		};
 	}
 
 	private McpRequestHandler<McpSchema.ListResourceTemplatesResult> resourceTemplateListRequestHandler() {
 		return (exchange, params) -> {
-			var resourceList = this.resourceTemplates.values()
-				.stream()
-				.map(McpServerFeatures.AsyncResourceTemplateSpecification::resourceTemplate)
-				.toList();
-			return Mono.just(McpSchema.ListResourceTemplatesResult.builder(resourceList).build());
+			return this.resourcesRepository.listResourceTemplates(exchange, paginatedRequest(params));
 		};
 	}
 
@@ -812,34 +854,13 @@ public class McpAsyncServer {
 
 			var resourceUri = resourceRequest.uri();
 
-			// First try to find a static resource specification
-			// Static resources have exact URIs
-			return this.findResourceSpecification(resourceUri)
-				.map(spec -> spec.readHandler().apply(ex, resourceRequest))
-				.orElseGet(() -> {
-					// If not found, try to find a dynamic resource specification
-					// Dynamic resources have URI templates
-					return this.findResourceTemplateSpecification(resourceUri)
-						.map(spec -> spec.readHandler().apply(ex, resourceRequest))
-						.orElseGet(() -> Mono.error(RESOURCE_NOT_FOUND.apply(resourceUri)));
-				});
+			// Resolve direct resources first, then resource templates.
+			return this.resourcesRepository.resolveResource(resourceUri, ex)
+				.flatMap(spec -> spec.readHandler().apply(ex, resourceRequest))
+				.switchIfEmpty(this.resourcesRepository.resolveResourceTemplate(resourceUri, ex)
+					.flatMap(spec -> spec.readHandler().apply(ex, resourceRequest))
+					.switchIfEmpty(Mono.error(RESOURCE_NOT_FOUND.apply(resourceUri))));
 		};
-	}
-
-	private Optional<McpServerFeatures.AsyncResourceSpecification> findResourceSpecification(String uri) {
-		var result = this.resources.values()
-			.stream()
-			.filter(spec -> this.uriTemplateManagerFactory.create(spec.resource().uri()).matches(uri))
-			.findFirst();
-		return result;
-	}
-
-	private Optional<McpServerFeatures.AsyncResourceTemplateSpecification> findResourceTemplateSpecification(
-			String uri) {
-		return this.resourceTemplates.values()
-			.stream()
-			.filter(spec -> this.uriTemplateManagerFactory.create(spec.resourceTemplate().uriTemplate()).matches(uri))
-			.findFirst();
 	}
 
 	// ---------------------------------------
@@ -860,13 +881,8 @@ public class McpAsyncServer {
 		}
 
 		return Mono.defer(() -> {
-			var previous = this.prompts.put(promptSpecification.prompt().name(), promptSpecification);
-			if (previous != null) {
-				logger.warn("Replace existing Prompt with name '{}'", promptSpecification.prompt().name());
-			}
-			else {
-				logger.debug("Added prompt handler: {}", promptSpecification.prompt().name());
-			}
+			this.promptsRepository.addPrompt(promptSpecification);
+			logger.debug("Added prompt handler: {}", promptSpecification.prompt().name());
 			if (this.serverCapabilities.prompts().listChanged()) {
 				return this.notifyPromptsListChanged();
 			}
@@ -876,11 +892,18 @@ public class McpAsyncServer {
 	}
 
 	/**
-	 * List all registered prompts.
-	 * @return A Flux stream of all registered prompts
+	 * List prompts from the repository without a client request exchange.
+	 * <p>
+	 * Dynamic repositories should treat the {@code null} exchange passed by this helper
+	 * as a context-free listing.
+	 * @return A Flux stream of context-free visible prompts
 	 */
 	public Flux<McpSchema.Prompt> listPrompts() {
-		return Flux.fromIterable(this.prompts.values()).map(McpServerFeatures.AsyncPromptSpecification::prompt);
+		return Flux.defer(
+				() -> this.promptsRepository.listPrompts(null, new McpSchema.PaginatedRequest())
+					.expand(result -> (result.nextCursor() != null) ? this.promptsRepository.listPrompts(null,
+							new McpSchema.PaginatedRequest(result.nextCursor())) : Mono.empty())
+					.flatMapIterable(McpSchema.ListPromptsResult::prompts));
 	}
 
 	/**
@@ -897,9 +920,7 @@ public class McpAsyncServer {
 		}
 
 		return Mono.defer(() -> {
-			McpServerFeatures.AsyncPromptSpecification removed = this.prompts.remove(promptName);
-
-			if (removed != null) {
+			if (this.promptsRepository.removePrompt(promptName)) {
 				logger.debug("Removed prompt handler: {}", promptName);
 				if (this.serverCapabilities.prompts().listChanged()) {
 					return this.notifyPromptsListChanged();
@@ -923,17 +944,7 @@ public class McpAsyncServer {
 
 	private McpRequestHandler<McpSchema.ListPromptsResult> promptsListRequestHandler() {
 		return (exchange, params) -> {
-			// TODO: Implement pagination
-			// McpSchema.PaginatedRequest request = objectMapper.convertValue(params,
-			// new TypeReference<McpSchema.PaginatedRequest>() {
-			// });
-
-			var promptList = this.prompts.values()
-				.stream()
-				.map(McpServerFeatures.AsyncPromptSpecification::prompt)
-				.toList();
-
-			return Mono.just(McpSchema.ListPromptsResult.builder(promptList).build());
+			return this.promptsRepository.listPrompts(exchange, paginatedRequest(params));
 		};
 	}
 
@@ -943,17 +954,12 @@ public class McpAsyncServer {
 					new TypeRef<McpSchema.GetPromptRequest>() {
 					});
 
-			// Implement prompt retrieval logic here
-			McpServerFeatures.AsyncPromptSpecification specification = this.prompts.get(promptRequest.name());
-
-			if (specification == null) {
-				return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
+			return this.promptsRepository.resolvePrompt(promptRequest.name(), exchange)
+				.switchIfEmpty(Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
 					.message("Invalid prompt name")
 					.data("Prompt not found: " + promptRequest.name())
-					.build());
-			}
-
-			return Mono.defer(() -> specification.promptHandler().apply(exchange, promptRequest));
+					.build()))
+				.flatMap(specification -> specification.promptHandler().apply(exchange, promptRequest));
 		};
 	}
 
@@ -995,89 +1001,82 @@ public class McpAsyncServer {
 					.build());
 			}
 
-			String type = request.ref().type();
+			return validateCompletionRequest(request, exchange)
+				.switchIfEmpty(this.completionsRepository.resolveCompletion(request.ref(), exchange)
+					.switchIfEmpty(Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
+						.message("AsyncCompletionSpecification not found: " + request.ref())
+						.build()))
+					.flatMap(specification -> specification.completionHandler().apply(exchange, request)));
+		};
+	}
 
-			String argumentName = request.argument().name();
+	private Mono<McpSchema.CompleteResult> validateCompletionRequest(McpSchema.CompleteRequest request,
+			McpAsyncServerExchange exchange) {
+		String type = request.ref().type();
+		String argumentName = request.argument().name();
 
-			// Check if valid a Prompt exists for this completion request
-			if (type.equals(PromptReference.TYPE)
-					&& request.ref() instanceof McpSchema.PromptReference promptReference) {
+		if (type.equals(PromptReference.TYPE) && request.ref() instanceof McpSchema.PromptReference promptReference) {
+			return this.promptsRepository.resolvePrompt(promptReference.name(), exchange)
+				.switchIfEmpty(Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
+					.message("Prompt not found: " + promptReference.name())
+					.build()))
+				.flatMap(promptSpec -> {
+					List<McpSchema.PromptArgument> arguments = promptSpec.prompt().arguments();
+					if (arguments == null || arguments.stream().noneMatch(arg -> arg.name().equals(argumentName))) {
+						logger.warn("Argument not found: {} in prompt: {}", argumentName, promptReference.name());
+						return EMPTY_COMPLETION_RESULT;
+					}
+					return Mono.empty();
+				});
+		}
 
-				McpServerFeatures.AsyncPromptSpecification promptSpec = this.prompts.get(promptReference.name());
-				if (promptSpec == null) {
-					return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
-						.message("Prompt not found: " + promptReference.name())
-						.build());
-				}
-				List<McpSchema.PromptArgument> arguments = promptSpec.prompt().arguments();
-				if (arguments == null
-						|| !arguments.stream().filter(arg -> arg.name().equals(argumentName)).findFirst().isPresent()) {
+		if (type.equals(ResourceReference.TYPE)
+				&& request.ref() instanceof McpSchema.ResourceReference resourceReference) {
+			return validateResourceCompletionRequest(resourceReference, argumentName, exchange);
+		}
 
-					logger.warn("Argument not found: {} in prompt: {}", argumentName, promptReference.name());
+		return Mono.empty();
+	}
 
-					return EMPTY_COMPLETION_RESULT;
-				}
-			}
+	private Mono<McpSchema.CompleteResult> validateResourceCompletionRequest(
+			McpSchema.ResourceReference resourceReference, String argumentName, McpAsyncServerExchange exchange) {
+		var uriTemplateManager = uriTemplateManagerFactory.create(resourceReference.uri());
 
-			// Check if valid Resource or ResourceTemplate exists for this completion
-			// request
-			if (type.equals(ResourceReference.TYPE)
-					&& request.ref() instanceof McpSchema.ResourceReference resourceReference) {
+		if (!uriTemplateManager.isUriTemplate(resourceReference.uri())) {
+			// Attempting to autocomplete a fixed resource URI is not an error in the
+			// spec.
+			return EMPTY_COMPLETION_RESULT;
+		}
 
-				var uriTemplateManager = uriTemplateManagerFactory.create(resourceReference.uri());
-
-				if (!uriTemplateManager.isUriTemplate(resourceReference.uri())) {
-					// Attempting to autocomplete a fixed resource URI is not an error in
-					// the spec (but probably should be).
-					return EMPTY_COMPLETION_RESULT;
-				}
-
-				McpServerFeatures.AsyncResourceSpecification resourceSpec = this
-					.findResourceSpecification(resourceReference.uri())
-					.orElse(null);
-
-				if (resourceSpec != null) {
-					if (!uriTemplateManagerFactory.create(resourceSpec.resource().uri())
+		return this.resourcesRepository.resolveResource(resourceReference.uri(), exchange)
+			.map(Optional::of)
+			.defaultIfEmpty(Optional.empty())
+			.flatMap(resourceSpec -> {
+				if (resourceSpec.isPresent()) {
+					if (!uriTemplateManagerFactory.create(resourceSpec.get().resource().uri())
 						.getVariableNames()
 						.contains(argumentName)) {
-
 						return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
 							.message("Argument not found: " + argumentName + " in resource: " + resourceReference.uri())
 							.build());
 					}
+					return Mono.empty();
 				}
-				else {
-					var templateSpec = this.findResourceTemplateSpecification(resourceReference.uri()).orElse(null);
-					if (templateSpec != null) {
 
+				return this.resourcesRepository.resolveResourceTemplate(resourceReference.uri(), exchange)
+					.switchIfEmpty(Mono.error(RESOURCE_NOT_FOUND.apply(resourceReference.uri())))
+					.flatMap(templateSpec -> {
 						if (!uriTemplateManagerFactory.create(templateSpec.resourceTemplate().uriTemplate())
 							.getVariableNames()
 							.contains(argumentName)) {
-
 							return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
 								.message("Argument not found: " + argumentName + " in resource template: "
 										+ resourceReference.uri())
 								.build());
 						}
-					}
-					else {
-						return Mono.error(RESOURCE_NOT_FOUND.apply(resourceReference.uri()));
-					}
-				}
-			}
-
-			// Handle the completion request using the registered handler
-			// for the given reference.
-			McpServerFeatures.AsyncCompletionSpecification specification = this.completions.get(request.ref());
-
-			if (specification == null) {
-				return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
-					.message("AsyncCompletionSpecification not found: " + request.ref())
-					.build());
-			}
-
-			return Mono.defer(() -> specification.completionHandler().apply(exchange, request));
-		};
+						return Mono.empty();
+					});
+			});
 	}
 
 	/**

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServer.java
@@ -95,15 +95,15 @@ import reactor.core.publisher.Mono;
  *     .tools(
  *         McpServerFeatures.AsyncToolSpecification.builder()
  * 			.tool(calculatorTool)
- *   	    .callTool((exchange, args) -> Mono.fromSupplier(() -> calculate(args.arguments()))
+ *   	    .callHandler((exchange, args) -> Mono.fromSupplier(() -> calculate(args.arguments()))
  *                 .map(result -> CallToolResult.builder()
  *                   .content(List.of(McpSchema.TextContent.builder("Result: " + result).build()))
  *                   .isError(false)
  *                   .build()))
- *.         .build(),
+ *         .build(),
  *         McpServerFeatures.AsyncToolSpecification.builder()
- * 	        .tool((weatherTool)
- *          .callTool((exchange, args) -> Mono.fromSupplier(() -> getWeather(args.arguments()))
+ * 	        .tool(weatherTool)
+ *          .callHandler((exchange, args) -> Mono.fromSupplier(() -> getWeather(args.arguments()))
  *                 .map(result -> CallToolResult.builder()
  *                   .content(List.of(McpSchema.TextContent.builder("Weather: " + result).build()))
  *                   .isError(false)
@@ -121,17 +121,27 @@ import reactor.core.publisher.Mono;
  *     )
  *     // Add resource templates
  *     .resourceTemplates(
- *         new ResourceTemplate("file://{path}", "Access files"),
- *         new ResourceTemplate("db://{table}", "Access database")
+ *         new McpServerFeatures.AsyncResourceTemplateSpecification(
+ *             McpSchema.ResourceTemplate.builder("file://{path}", "files")
+ *                 .description("Access files")
+ *                 .build(),
+ *             (exchange, req) -> Mono.fromSupplier(() -> readFile(req))
+ *                 .map(ReadResourceResult::new)),
+ *         new McpServerFeatures.AsyncResourceTemplateSpecification(
+ *             McpSchema.ResourceTemplate.builder("db://{table}", "database")
+ *                 .description("Access database")
+ *                 .build(),
+ *             (exchange, req) -> Mono.fromSupplier(() -> queryDb(req))
+ *                 .map(ReadResourceResult::new))
  *     )
  *     // Register prompts
  *     .prompts(
  *         new McpServerFeatures.AsyncPromptSpecification(analysisPrompt,
  *             (exchange, req) -> Mono.fromSupplier(() -> generateAnalysisPrompt(req))
- *                 .map(GetPromptResult::new)),
- *         new McpServerFeatures.AsyncPromptRegistration(summaryPrompt,
+ *                 .map(messages -> McpSchema.GetPromptResult.builder(messages).build())),
+ *         new McpServerFeatures.AsyncPromptSpecification(summaryPrompt,
  *             (exchange, req) -> Mono.fromSupplier(() -> generateSummaryPrompt(req))
- *                 .map(GetPromptResult::new))
+ *                 .map(messages -> McpSchema.GetPromptResult.builder(messages).build()))
  *     )
  *     .build();
  * }</pre>
@@ -147,6 +157,19 @@ public interface McpServer {
 
 	McpSchema.Implementation DEFAULT_SERVER_INFO = McpSchema.Implementation.builder("Java SDK MCP Server", "0.15.0")
 		.build();
+
+	private static void assertNoRepository(Object repository, String repositoryName, String staticRegistrationName) {
+		if (repository != null) {
+			throw new IllegalStateException(staticRegistrationName + " cannot be combined with " + repositoryName);
+		}
+	}
+
+	private static void assertNoStaticRegistrations(boolean hasStaticRegistrations, String repositoryName,
+			String staticRegistrationName) {
+		if (hasStaticRegistrations) {
+			throw new IllegalStateException(repositoryName + " cannot be combined with " + staticRegistrationName);
+		}
+	}
 
 	/**
 	 * Starts building a synchronous MCP server that provides blocking operations.
@@ -237,8 +260,9 @@ public interface McpServer {
 		@Override
 		public McpAsyncServer build() {
 			var features = new McpServerFeatures.Async(this.serverInfo, this.serverCapabilities, this.tools,
-					this.resources, this.resourceTemplates, this.prompts, this.completions, this.rootsChangeHandlers,
-					this.instructions);
+					this.toolsRepository, this.resources, this.resourceTemplates, this.resourcesRepository,
+					this.prompts, this.promptsRepository, this.completions, this.completionsRepository,
+					this.rootsChangeHandlers, this.instructions);
 
 			var jsonSchemaValidator = (this.jsonSchemaValidator != null) ? this.jsonSchemaValidator
 					: McpJsonDefaults.getSchemaValidator();
@@ -267,8 +291,9 @@ public interface McpServer {
 		@Override
 		public McpAsyncServer build() {
 			var features = new McpServerFeatures.Async(this.serverInfo, this.serverCapabilities, this.tools,
-					this.resources, this.resourceTemplates, this.prompts, this.completions, this.rootsChangeHandlers,
-					this.instructions);
+					this.toolsRepository, this.resources, this.resourceTemplates, this.resourcesRepository,
+					this.prompts, this.promptsRepository, this.completions, this.completionsRepository,
+					this.rootsChangeHandlers, this.instructions);
 			var jsonSchemaValidator = this.jsonSchemaValidator != null ? this.jsonSchemaValidator
 					: McpJsonDefaults.getSchemaValidator();
 
@@ -310,6 +335,8 @@ public interface McpServer {
 		 */
 		final List<McpServerFeatures.AsyncToolSpecification> tools = new ArrayList<>();
 
+		ToolsRepository toolsRepository;
+
 		/**
 		 * The Model Context Protocol (MCP) provides a standardized way for servers to
 		 * expose resources to clients. Resources allow servers to share data that
@@ -328,6 +355,8 @@ public interface McpServer {
 		 */
 		final Map<String, McpServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates = new HashMap<>();
 
+		ResourcesRepository resourcesRepository;
+
 		/**
 		 * The Model Context Protocol (MCP) provides a standardized way for servers to
 		 * expose prompt templates to clients. Prompts allow servers to provide structured
@@ -337,13 +366,68 @@ public interface McpServer {
 		 */
 		final Map<String, McpServerFeatures.AsyncPromptSpecification> prompts = new HashMap<>();
 
+		PromptsRepository promptsRepository;
+
 		final Map<McpSchema.CompleteReference, McpServerFeatures.AsyncCompletionSpecification> completions = new HashMap<>();
+
+		CompletionsRepository completionsRepository;
 
 		final List<BiFunction<McpAsyncServerExchange, List<McpSchema.Root>, Mono<Void>>> rootsChangeHandlers = new ArrayList<>();
 
 		Duration requestTimeout = Duration.ofHours(10); // Default timeout
 
 		public abstract McpAsyncServer build();
+
+		/**
+		 * Sets a custom repository for tool discovery and resolution.
+		 * @param toolsRepository the tools repository. Must not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public AsyncSpecification<S> toolsRepository(ToolsRepository toolsRepository) {
+			Assert.notNull(toolsRepository, "Tools repository must not be null");
+			assertNoStaticRegistrations(!this.tools.isEmpty(), "toolsRepository", "static tool registrations");
+			this.toolsRepository = toolsRepository;
+			return this;
+		}
+
+		/**
+		 * Sets a custom repository for resource and resource template discovery and
+		 * resolution.
+		 * @param resourcesRepository the resources repository. Must not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public AsyncSpecification<S> resourcesRepository(ResourcesRepository resourcesRepository) {
+			Assert.notNull(resourcesRepository, "Resources repository must not be null");
+			assertNoStaticRegistrations(!this.resources.isEmpty() || !this.resourceTemplates.isEmpty(),
+					"resourcesRepository", "static resource or resource template registrations");
+			this.resourcesRepository = resourcesRepository;
+			return this;
+		}
+
+		/**
+		 * Sets a custom repository for prompt discovery and resolution.
+		 * @param promptsRepository the prompts repository. Must not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public AsyncSpecification<S> promptsRepository(PromptsRepository promptsRepository) {
+			Assert.notNull(promptsRepository, "Prompts repository must not be null");
+			assertNoStaticRegistrations(!this.prompts.isEmpty(), "promptsRepository", "static prompt registrations");
+			this.promptsRepository = promptsRepository;
+			return this;
+		}
+
+		/**
+		 * Sets a custom repository for completion resolution.
+		 * @param completionsRepository the completions repository. Must not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public AsyncSpecification<S> completionsRepository(CompletionsRepository completionsRepository) {
+			Assert.notNull(completionsRepository, "Completions repository must not be null");
+			assertNoStaticRegistrations(!this.completions.isEmpty(), "completionsRepository",
+					"static completion registrations");
+			this.completionsRepository = completionsRepository;
+			return this;
+		}
 
 		/**
 		 * Sets the URI template manager factory to use for creating URI templates. This
@@ -476,6 +560,7 @@ public interface McpServer {
 		public AsyncSpecification<S> toolCall(McpSchema.Tool tool,
 				BiFunction<McpAsyncServerExchange, McpSchema.CallToolRequest, Mono<CallToolResult>> callHandler) {
 
+			assertNoRepository(this.toolsRepository, "toolsRepository", "Static tool registrations");
 			Assert.notNull(tool, "Tool must not be null");
 			Assert.notNull(callHandler, "Handler must not be null");
 			validateToolName(tool.name());
@@ -499,6 +584,7 @@ public interface McpServer {
 		 */
 		public AsyncSpecification<S> tools(List<McpServerFeatures.AsyncToolSpecification> toolSpecifications) {
 			Assert.notNull(toolSpecifications, "Tool handlers list must not be null");
+			assertNoRepository(this.toolsRepository, "toolsRepository", "Static tool registrations");
 
 			for (var tool : toolSpecifications) {
 				validateToolName(tool.tool().name());
@@ -516,9 +602,9 @@ public interface McpServer {
 		 * <p>
 		 * Example usage: <pre>{@code
 		 * .tools(
-		 *     McpServerFeatures.AsyncToolSpecification.builder().tool(calculatorTool).callTool(calculatorHandler).build(),
-		 *     McpServerFeatures.AsyncToolSpecification.builder().tool(weatherTool).callTool(weatherHandler).build(),
-		 *     McpServerFeatures.AsyncToolSpecification.builder().tool(fileManagerTool).callTool(fileManagerHandler).build()
+		 *     McpServerFeatures.AsyncToolSpecification.builder().tool(calculatorTool).callHandler(calculatorHandler).build(),
+		 *     McpServerFeatures.AsyncToolSpecification.builder().tool(weatherTool).callHandler(weatherHandler).build(),
+		 *     McpServerFeatures.AsyncToolSpecification.builder().tool(fileManagerTool).callHandler(fileManagerHandler).build()
 		 * )
 		 * }</pre>
 		 * @param toolSpecifications The tool specifications to add. Must not be null.
@@ -527,6 +613,7 @@ public interface McpServer {
 		 */
 		public AsyncSpecification<S> tools(McpServerFeatures.AsyncToolSpecification... toolSpecifications) {
 			Assert.notNull(toolSpecifications, "Tool handlers list must not be null");
+			assertNoRepository(this.toolsRepository, "toolsRepository", "Static tool registrations");
 
 			for (McpServerFeatures.AsyncToolSpecification tool : toolSpecifications) {
 				validateToolName(tool.tool().name());
@@ -559,6 +646,7 @@ public interface McpServer {
 		public AsyncSpecification<S> resources(
 				Map<String, McpServerFeatures.AsyncResourceSpecification> resourceSpecifications) {
 			Assert.notNull(resourceSpecifications, "Resource handlers map must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository", "Static resource registrations");
 			this.resources.putAll(resourceSpecifications);
 			return this;
 		}
@@ -575,6 +663,7 @@ public interface McpServer {
 		public AsyncSpecification<S> resources(
 				List<McpServerFeatures.AsyncResourceSpecification> resourceSpecifications) {
 			Assert.notNull(resourceSpecifications, "Resource handlers list must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository", "Static resource registrations");
 			for (McpServerFeatures.AsyncResourceSpecification resource : resourceSpecifications) {
 				this.resources.put(resource.resource().uri(), resource);
 			}
@@ -600,6 +689,7 @@ public interface McpServer {
 		 */
 		public AsyncSpecification<S> resources(McpServerFeatures.AsyncResourceSpecification... resourceSpecifications) {
 			Assert.notNull(resourceSpecifications, "Resource handlers list must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository", "Static resource registrations");
 			for (McpServerFeatures.AsyncResourceSpecification resource : resourceSpecifications) {
 				this.resources.put(resource.resource().uri(), resource);
 			}
@@ -618,6 +708,8 @@ public interface McpServer {
 		public AsyncSpecification<S> resourceTemplates(
 				List<McpServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates) {
 			Assert.notNull(resourceTemplates, "Resource templates must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository",
+					"Static resource template registrations");
 			for (var resourceTemplate : resourceTemplates) {
 				this.resourceTemplates.put(resourceTemplate.resourceTemplate().uriTemplate(), resourceTemplate);
 			}
@@ -637,6 +729,8 @@ public interface McpServer {
 		public AsyncSpecification<S> resourceTemplates(
 				McpServerFeatures.AsyncResourceTemplateSpecification... resourceTemplates) {
 			Assert.notNull(resourceTemplates, "Resource templates must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository",
+					"Static resource template registrations");
 			for (McpServerFeatures.AsyncResourceTemplateSpecification resource : resourceTemplates) {
 				this.resourceTemplates.put(resource.resourceTemplate().uriTemplate(), resource);
 			}
@@ -651,9 +745,9 @@ public interface McpServer {
 		 * <p>
 		 * Example usage: <pre>{@code
 		 * .prompts(Map.of("analysis", new McpServerFeatures.AsyncPromptSpecification(
-		 *     new Prompt("analysis", "Code analysis template"),
-		 *     request -> Mono.fromSupplier(() -> generateAnalysisPrompt(request))
-		 *         .map(GetPromptResult::new)
+		 *     McpSchema.Prompt.builder("analysis").description("Code analysis template").build(),
+		 *     (exchange, request) -> Mono.fromSupplier(() -> generateAnalysisPrompt(request))
+		 *         .map(messages -> McpSchema.GetPromptResult.builder(messages).build())
 		 * )));
 		 * }</pre>
 		 * @param prompts Map of prompt name to specification. Must not be null.
@@ -662,6 +756,7 @@ public interface McpServer {
 		 */
 		public AsyncSpecification<S> prompts(Map<String, McpServerFeatures.AsyncPromptSpecification> prompts) {
 			Assert.notNull(prompts, "Prompts map must not be null");
+			assertNoRepository(this.promptsRepository, "promptsRepository", "Static prompt registrations");
 			this.prompts.putAll(prompts);
 			return this;
 		}
@@ -676,6 +771,7 @@ public interface McpServer {
 		 */
 		public AsyncSpecification<S> prompts(List<McpServerFeatures.AsyncPromptSpecification> prompts) {
 			Assert.notNull(prompts, "Prompts list must not be null");
+			assertNoRepository(this.promptsRepository, "promptsRepository", "Static prompt registrations");
 			for (McpServerFeatures.AsyncPromptSpecification prompt : prompts) {
 				this.prompts.put(prompt.prompt().name(), prompt);
 			}
@@ -700,6 +796,7 @@ public interface McpServer {
 		 */
 		public AsyncSpecification<S> prompts(McpServerFeatures.AsyncPromptSpecification... prompts) {
 			Assert.notNull(prompts, "Prompts list must not be null");
+			assertNoRepository(this.promptsRepository, "promptsRepository", "Static prompt registrations");
 			for (McpServerFeatures.AsyncPromptSpecification prompt : prompts) {
 				this.prompts.put(prompt.prompt().name(), prompt);
 			}
@@ -715,6 +812,7 @@ public interface McpServer {
 		 */
 		public AsyncSpecification<S> completions(List<McpServerFeatures.AsyncCompletionSpecification> completions) {
 			Assert.notNull(completions, "Completions list must not be null");
+			assertNoRepository(this.completionsRepository, "completionsRepository", "Static completion registrations");
 			for (McpServerFeatures.AsyncCompletionSpecification completion : completions) {
 				this.completions.put(completion.referenceKey(), completion);
 			}
@@ -730,6 +828,7 @@ public interface McpServer {
 		 */
 		public AsyncSpecification<S> completions(McpServerFeatures.AsyncCompletionSpecification... completions) {
 			Assert.notNull(completions, "Completions list must not be null");
+			assertNoRepository(this.completionsRepository, "completionsRepository", "Static completion registrations");
 			for (McpServerFeatures.AsyncCompletionSpecification completion : completions) {
 				this.completions.put(completion.referenceKey(), completion);
 			}
@@ -829,7 +928,8 @@ public interface McpServer {
 		@Override
 		public McpSyncServer build() {
 			McpServerFeatures.Sync syncFeatures = new McpServerFeatures.Sync(this.serverInfo, this.serverCapabilities,
-					this.tools, this.resources, this.resourceTemplates, this.prompts, this.completions,
+					this.tools, this.toolsRepository, this.resources, this.resourceTemplates, this.resourcesRepository,
+					this.prompts, this.promptsRepository, this.completions, this.completionsRepository,
 					this.rootsChangeHandlers, this.instructions);
 			McpServerFeatures.Async asyncFeatures = McpServerFeatures.Async.fromSync(syncFeatures,
 					this.immediateExecution);
@@ -864,7 +964,8 @@ public interface McpServer {
 		@Override
 		public McpSyncServer build() {
 			McpServerFeatures.Sync syncFeatures = new McpServerFeatures.Sync(this.serverInfo, this.serverCapabilities,
-					this.tools, this.resources, this.resourceTemplates, this.prompts, this.completions,
+					this.tools, this.toolsRepository, this.resources, this.resourceTemplates, this.resourcesRepository,
+					this.prompts, this.promptsRepository, this.completions, this.completionsRepository,
 					this.rootsChangeHandlers, this.instructions);
 			McpServerFeatures.Async asyncFeatures = McpServerFeatures.Async.fromSync(syncFeatures,
 					this.immediateExecution);
@@ -909,6 +1010,8 @@ public interface McpServer {
 		 */
 		final List<McpServerFeatures.SyncToolSpecification> tools = new ArrayList<>();
 
+		ToolsRepository toolsRepository;
+
 		/**
 		 * The Model Context Protocol (MCP) provides a standardized way for servers to
 		 * expose resources to clients. Resources allow servers to share data that
@@ -927,6 +1030,8 @@ public interface McpServer {
 		 */
 		final Map<String, McpServerFeatures.SyncResourceTemplateSpecification> resourceTemplates = new HashMap<>();
 
+		ResourcesRepository resourcesRepository;
+
 		JsonSchemaValidator jsonSchemaValidator;
 
 		/**
@@ -938,7 +1043,11 @@ public interface McpServer {
 		 */
 		final Map<String, McpServerFeatures.SyncPromptSpecification> prompts = new HashMap<>();
 
+		PromptsRepository promptsRepository;
+
 		final Map<McpSchema.CompleteReference, McpServerFeatures.SyncCompletionSpecification> completions = new HashMap<>();
+
+		CompletionsRepository completionsRepository;
 
 		final List<BiConsumer<McpSyncServerExchange, List<McpSchema.Root>>> rootsChangeHandlers = new ArrayList<>();
 
@@ -947,6 +1056,57 @@ public interface McpServer {
 		boolean immediateExecution = false;
 
 		public abstract McpSyncServer build();
+
+		/**
+		 * Sets a custom repository for tool discovery and resolution.
+		 * @param toolsRepository the tools repository. Must not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public SyncSpecification<S> toolsRepository(ToolsRepository toolsRepository) {
+			Assert.notNull(toolsRepository, "Tools repository must not be null");
+			assertNoStaticRegistrations(!this.tools.isEmpty(), "toolsRepository", "static tool registrations");
+			this.toolsRepository = toolsRepository;
+			return this;
+		}
+
+		/**
+		 * Sets a custom repository for resource and resource template discovery and
+		 * resolution.
+		 * @param resourcesRepository the resources repository. Must not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public SyncSpecification<S> resourcesRepository(ResourcesRepository resourcesRepository) {
+			Assert.notNull(resourcesRepository, "Resources repository must not be null");
+			assertNoStaticRegistrations(!this.resources.isEmpty() || !this.resourceTemplates.isEmpty(),
+					"resourcesRepository", "static resource or resource template registrations");
+			this.resourcesRepository = resourcesRepository;
+			return this;
+		}
+
+		/**
+		 * Sets a custom repository for prompt discovery and resolution.
+		 * @param promptsRepository the prompts repository. Must not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public SyncSpecification<S> promptsRepository(PromptsRepository promptsRepository) {
+			Assert.notNull(promptsRepository, "Prompts repository must not be null");
+			assertNoStaticRegistrations(!this.prompts.isEmpty(), "promptsRepository", "static prompt registrations");
+			this.promptsRepository = promptsRepository;
+			return this;
+		}
+
+		/**
+		 * Sets a custom repository for completion resolution.
+		 * @param completionsRepository the completions repository. Must not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public SyncSpecification<S> completionsRepository(CompletionsRepository completionsRepository) {
+			Assert.notNull(completionsRepository, "Completions repository must not be null");
+			assertNoStaticRegistrations(!this.completions.isEmpty(), "completionsRepository",
+					"static completion registrations");
+			this.completionsRepository = completionsRepository;
+			return this;
+		}
 
 		/**
 		 * Sets the URI template manager factory to use for creating URI templates. This
@@ -1072,12 +1232,13 @@ public interface McpServer {
 		 * @param handler The function that implements the tool's logic. Must not be null.
 		 * The function's first argument is an {@link McpSyncServerExchange} upon which
 		 * the server can interact with the connected client. The second argument is the
-		 * list of arguments passed to the tool.
+		 * {@link McpSchema.CallToolRequest} object containing the tool call.
 		 * @return This builder instance for method chaining
 		 * @throws IllegalArgumentException if tool or handler is null
 		 */
 		public SyncSpecification<S> toolCall(McpSchema.Tool tool,
 				BiFunction<McpSyncServerExchange, McpSchema.CallToolRequest, McpSchema.CallToolResult> handler) {
+			assertNoRepository(this.toolsRepository, "toolsRepository", "Static tool registrations");
 			Assert.notNull(tool, "Tool must not be null");
 			Assert.notNull(handler, "Handler must not be null");
 			validateToolName(tool.name());
@@ -1100,6 +1261,7 @@ public interface McpServer {
 		 */
 		public SyncSpecification<S> tools(List<McpServerFeatures.SyncToolSpecification> toolSpecifications) {
 			Assert.notNull(toolSpecifications, "Tool handlers list must not be null");
+			assertNoRepository(this.toolsRepository, "toolsRepository", "Static tool registrations");
 
 			for (var tool : toolSpecifications) {
 				String toolName = tool.tool().name();
@@ -1130,6 +1292,7 @@ public interface McpServer {
 		 */
 		public SyncSpecification<S> tools(McpServerFeatures.SyncToolSpecification... toolSpecifications) {
 			Assert.notNull(toolSpecifications, "Tool handlers list must not be null");
+			assertNoRepository(this.toolsRepository, "toolsRepository", "Static tool registrations");
 
 			for (McpServerFeatures.SyncToolSpecification tool : toolSpecifications) {
 				validateToolName(tool.tool().name());
@@ -1162,6 +1325,7 @@ public interface McpServer {
 		public SyncSpecification<S> resources(
 				Map<String, McpServerFeatures.SyncResourceSpecification> resourceSpecifications) {
 			Assert.notNull(resourceSpecifications, "Resource handlers map must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository", "Static resource registrations");
 			this.resources.putAll(resourceSpecifications);
 			return this;
 		}
@@ -1178,6 +1342,7 @@ public interface McpServer {
 		public SyncSpecification<S> resources(
 				List<McpServerFeatures.SyncResourceSpecification> resourceSpecifications) {
 			Assert.notNull(resourceSpecifications, "Resource handlers list must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository", "Static resource registrations");
 			for (McpServerFeatures.SyncResourceSpecification resource : resourceSpecifications) {
 				this.resources.put(resource.resource().uri(), resource);
 			}
@@ -1203,6 +1368,7 @@ public interface McpServer {
 		 */
 		public SyncSpecification<S> resources(McpServerFeatures.SyncResourceSpecification... resourceSpecifications) {
 			Assert.notNull(resourceSpecifications, "Resource handlers list must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository", "Static resource registrations");
 			for (McpServerFeatures.SyncResourceSpecification resource : resourceSpecifications) {
 				this.resources.put(resource.resource().uri(), resource);
 			}
@@ -1220,6 +1386,8 @@ public interface McpServer {
 		public SyncSpecification<S> resourceTemplates(
 				List<McpServerFeatures.SyncResourceTemplateSpecification> resourceTemplates) {
 			Assert.notNull(resourceTemplates, "Resource templates must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository",
+					"Static resource template registrations");
 			for (McpServerFeatures.SyncResourceTemplateSpecification resource : resourceTemplates) {
 				this.resourceTemplates.put(resource.resourceTemplate().uriTemplate(), resource);
 			}
@@ -1237,6 +1405,8 @@ public interface McpServer {
 		public SyncSpecification<S> resourceTemplates(
 				McpServerFeatures.SyncResourceTemplateSpecification... resourceTemplates) {
 			Assert.notNull(resourceTemplates, "Resource templates must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository",
+					"Static resource template registrations");
 			for (McpServerFeatures.SyncResourceTemplateSpecification resourceTemplate : resourceTemplates) {
 				this.resourceTemplates.put(resourceTemplate.resourceTemplate().uriTemplate(), resourceTemplate);
 			}
@@ -1250,10 +1420,10 @@ public interface McpServer {
 		 *
 		 * <p>
 		 * Example usage: <pre>{@code
-		 * Map<String, PromptSpecification> prompts = new HashMap<>();
-		 * prompts.put("analysis", new PromptSpecification(
-		 *     new Prompt("analysis", "Code analysis template"),
-		 *     (exchange, request) -> new GetPromptResult(generateAnalysisPrompt(request))
+		 * Map<String, McpServerFeatures.SyncPromptSpecification> prompts = new HashMap<>();
+		 * prompts.put("analysis", new McpServerFeatures.SyncPromptSpecification(
+		 *     McpSchema.Prompt.builder("analysis").description("Code analysis template").build(),
+		 *     (exchange, request) -> McpSchema.GetPromptResult.builder(generateAnalysisPrompt(request)).build()
 		 * ));
 		 * .prompts(prompts)
 		 * }</pre>
@@ -1263,6 +1433,7 @@ public interface McpServer {
 		 */
 		public SyncSpecification<S> prompts(Map<String, McpServerFeatures.SyncPromptSpecification> prompts) {
 			Assert.notNull(prompts, "Prompts map must not be null");
+			assertNoRepository(this.promptsRepository, "promptsRepository", "Static prompt registrations");
 			this.prompts.putAll(prompts);
 			return this;
 		}
@@ -1277,6 +1448,7 @@ public interface McpServer {
 		 */
 		public SyncSpecification<S> prompts(List<McpServerFeatures.SyncPromptSpecification> prompts) {
 			Assert.notNull(prompts, "Prompts list must not be null");
+			assertNoRepository(this.promptsRepository, "promptsRepository", "Static prompt registrations");
 			for (McpServerFeatures.SyncPromptSpecification prompt : prompts) {
 				this.prompts.put(prompt.prompt().name(), prompt);
 			}
@@ -1290,9 +1462,9 @@ public interface McpServer {
 		 * <p>
 		 * Example usage: <pre>{@code
 		 * .prompts(
-		 *     new PromptSpecification(analysisPrompt, analysisHandler),
-		 *     new PromptSpecification(summaryPrompt, summaryHandler),
-		 *     new PromptSpecification(reviewPrompt, reviewHandler)
+		 *     new McpServerFeatures.SyncPromptSpecification(analysisPrompt, analysisHandler),
+		 *     new McpServerFeatures.SyncPromptSpecification(summaryPrompt, summaryHandler),
+		 *     new McpServerFeatures.SyncPromptSpecification(reviewPrompt, reviewHandler)
 		 * )
 		 * }</pre>
 		 * @param prompts The prompt specifications to add. Must not be null.
@@ -1301,6 +1473,7 @@ public interface McpServer {
 		 */
 		public SyncSpecification<S> prompts(McpServerFeatures.SyncPromptSpecification... prompts) {
 			Assert.notNull(prompts, "Prompts list must not be null");
+			assertNoRepository(this.promptsRepository, "promptsRepository", "Static prompt registrations");
 			for (McpServerFeatures.SyncPromptSpecification prompt : prompts) {
 				this.prompts.put(prompt.prompt().name(), prompt);
 			}
@@ -1317,6 +1490,7 @@ public interface McpServer {
 		 */
 		public SyncSpecification<S> completions(List<McpServerFeatures.SyncCompletionSpecification> completions) {
 			Assert.notNull(completions, "Completions list must not be null");
+			assertNoRepository(this.completionsRepository, "completionsRepository", "Static completion registrations");
 			for (McpServerFeatures.SyncCompletionSpecification completion : completions) {
 				this.completions.put(completion.referenceKey(), completion);
 			}
@@ -1332,6 +1506,7 @@ public interface McpServer {
 		 */
 		public SyncSpecification<S> completions(McpServerFeatures.SyncCompletionSpecification... completions) {
 			Assert.notNull(completions, "Completions list must not be null");
+			assertNoRepository(this.completionsRepository, "completionsRepository", "Static completion registrations");
 			for (McpServerFeatures.SyncCompletionSpecification completion : completions) {
 				this.completions.put(completion.referenceKey(), completion);
 			}
@@ -1451,6 +1626,8 @@ public interface McpServer {
 		 */
 		final List<McpStatelessServerFeatures.AsyncToolSpecification> tools = new ArrayList<>();
 
+		StatelessToolsRepository toolsRepository;
+
 		/**
 		 * The Model Context Protocol (MCP) provides a standardized way for servers to
 		 * expose resources to clients. Resources allow servers to share data that
@@ -1469,6 +1646,8 @@ public interface McpServer {
 		 */
 		final Map<String, McpStatelessServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates = new HashMap<>();
 
+		StatelessResourcesRepository resourcesRepository;
+
 		/**
 		 * The Model Context Protocol (MCP) provides a standardized way for servers to
 		 * expose prompt templates to clients. Prompts allow servers to provide structured
@@ -1478,12 +1657,67 @@ public interface McpServer {
 		 */
 		final Map<String, McpStatelessServerFeatures.AsyncPromptSpecification> prompts = new HashMap<>();
 
+		StatelessPromptsRepository promptsRepository;
+
 		final Map<McpSchema.CompleteReference, McpStatelessServerFeatures.AsyncCompletionSpecification> completions = new HashMap<>();
+
+		StatelessCompletionsRepository completionsRepository;
 
 		Duration requestTimeout = Duration.ofSeconds(10); // Default timeout
 
 		public StatelessAsyncSpecification(McpStatelessServerTransport transport) {
 			this.transport = transport;
+		}
+
+		/**
+		 * Sets a custom repository for tool discovery and resolution.
+		 * @param toolsRepository the tools repository. Must not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public StatelessAsyncSpecification toolsRepository(StatelessToolsRepository toolsRepository) {
+			Assert.notNull(toolsRepository, "Tools repository must not be null");
+			assertNoStaticRegistrations(!this.tools.isEmpty(), "toolsRepository", "static tool registrations");
+			this.toolsRepository = toolsRepository;
+			return this;
+		}
+
+		/**
+		 * Sets a custom repository for resource and resource template discovery and
+		 * resolution.
+		 * @param resourcesRepository the resources repository. Must not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public StatelessAsyncSpecification resourcesRepository(StatelessResourcesRepository resourcesRepository) {
+			Assert.notNull(resourcesRepository, "Resources repository must not be null");
+			assertNoStaticRegistrations(!this.resources.isEmpty() || !this.resourceTemplates.isEmpty(),
+					"resourcesRepository", "static resource or resource template registrations");
+			this.resourcesRepository = resourcesRepository;
+			return this;
+		}
+
+		/**
+		 * Sets a custom repository for prompt discovery and resolution.
+		 * @param promptsRepository the prompts repository. Must not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public StatelessAsyncSpecification promptsRepository(StatelessPromptsRepository promptsRepository) {
+			Assert.notNull(promptsRepository, "Prompts repository must not be null");
+			assertNoStaticRegistrations(!this.prompts.isEmpty(), "promptsRepository", "static prompt registrations");
+			this.promptsRepository = promptsRepository;
+			return this;
+		}
+
+		/**
+		 * Sets a custom repository for completion resolution.
+		 * @param completionsRepository the completions repository. Must not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public StatelessAsyncSpecification completionsRepository(StatelessCompletionsRepository completionsRepository) {
+			Assert.notNull(completionsRepository, "Completions repository must not be null");
+			assertNoStaticRegistrations(!this.completions.isEmpty(), "completionsRepository",
+					"static completion registrations");
+			this.completionsRepository = completionsRepository;
+			return this;
 		}
 
 		/**
@@ -1605,19 +1839,20 @@ public interface McpServer {
 		/**
 		 * Adds a single tool with its implementation handler to the server. This is a
 		 * convenience method for registering individual tools without creating a
-		 * {@link McpServerFeatures.AsyncToolSpecification} explicitly.
+		 * {@link McpStatelessServerFeatures.AsyncToolSpecification} explicitly.
 		 * @param tool The tool definition including name, description, and schema. Must
 		 * not be null.
 		 * @param callHandler The function that implements the tool's logic. Must not be
-		 * null. The function's first argument is an {@link McpAsyncServerExchange} upon
-		 * which the server can interact with the connected client. The second argument is
-		 * the {@link McpSchema.CallToolRequest} object containing the tool call
+		 * null. The function's first argument is an {@link McpTransportContext}. The
+		 * second argument is the {@link McpSchema.CallToolRequest} object containing the
+		 * tool call
 		 * @return This builder instance for method chaining
 		 * @throws IllegalArgumentException if tool or handler is null
 		 */
 		public StatelessAsyncSpecification toolCall(McpSchema.Tool tool,
 				BiFunction<McpTransportContext, McpSchema.CallToolRequest, Mono<CallToolResult>> callHandler) {
 
+			assertNoRepository(this.toolsRepository, "toolsRepository", "Static tool registrations");
 			Assert.notNull(tool, "Tool must not be null");
 			Assert.notNull(callHandler, "Handler must not be null");
 			validateToolName(tool.name());
@@ -1641,6 +1876,7 @@ public interface McpServer {
 		public StatelessAsyncSpecification tools(
 				List<McpStatelessServerFeatures.AsyncToolSpecification> toolSpecifications) {
 			Assert.notNull(toolSpecifications, "Tool handlers list must not be null");
+			assertNoRepository(this.toolsRepository, "toolsRepository", "Static tool registrations");
 
 			for (var tool : toolSpecifications) {
 				validateToolName(tool.tool().name());
@@ -1658,9 +1894,9 @@ public interface McpServer {
 		 * <p>
 		 * Example usage: <pre>{@code
 		 * .tools(
-		 *     McpServerFeatures.AsyncToolSpecification.builder().tool(calculatorTool).callTool(calculatorHandler).build(),
-		 *     McpServerFeatures.AsyncToolSpecification.builder().tool(weatherTool).callTool(weatherHandler).build(),
-		 *     McpServerFeatures.AsyncToolSpecification.builder().tool(fileManagerTool).callTool(fileManagerHandler).build()
+		 *     McpStatelessServerFeatures.AsyncToolSpecification.builder().tool(calculatorTool).callHandler(calculatorHandler).build(),
+		 *     McpStatelessServerFeatures.AsyncToolSpecification.builder().tool(weatherTool).callHandler(weatherHandler).build(),
+		 *     McpStatelessServerFeatures.AsyncToolSpecification.builder().tool(fileManagerTool).callHandler(fileManagerHandler).build()
 		 * )
 		 * }</pre>
 		 * @param toolSpecifications The tool specifications to add. Must not be null.
@@ -1670,6 +1906,7 @@ public interface McpServer {
 		public StatelessAsyncSpecification tools(
 				McpStatelessServerFeatures.AsyncToolSpecification... toolSpecifications) {
 			Assert.notNull(toolSpecifications, "Tool handlers list must not be null");
+			assertNoRepository(this.toolsRepository, "toolsRepository", "Static tool registrations");
 
 			for (var tool : toolSpecifications) {
 				validateToolName(tool.tool().name());
@@ -1702,6 +1939,7 @@ public interface McpServer {
 		public StatelessAsyncSpecification resources(
 				Map<String, McpStatelessServerFeatures.AsyncResourceSpecification> resourceSpecifications) {
 			Assert.notNull(resourceSpecifications, "Resource handlers map must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository", "Static resource registrations");
 			this.resources.putAll(resourceSpecifications);
 			return this;
 		}
@@ -1718,6 +1956,7 @@ public interface McpServer {
 		public StatelessAsyncSpecification resources(
 				List<McpStatelessServerFeatures.AsyncResourceSpecification> resourceSpecifications) {
 			Assert.notNull(resourceSpecifications, "Resource handlers list must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository", "Static resource registrations");
 			for (var resource : resourceSpecifications) {
 				this.resources.put(resource.resource().uri(), resource);
 			}
@@ -1744,6 +1983,7 @@ public interface McpServer {
 		public StatelessAsyncSpecification resources(
 				McpStatelessServerFeatures.AsyncResourceSpecification... resourceSpecifications) {
 			Assert.notNull(resourceSpecifications, "Resource handlers list must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository", "Static resource registrations");
 			for (var resource : resourceSpecifications) {
 				this.resources.put(resource.resource().uri(), resource);
 			}
@@ -1761,6 +2001,8 @@ public interface McpServer {
 		public StatelessAsyncSpecification resourceTemplates(
 				List<McpStatelessServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates) {
 			Assert.notNull(resourceTemplates, "Resource templates must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository",
+					"Static resource template registrations");
 			for (var resourceTemplate : resourceTemplates) {
 				this.resourceTemplates.put(resourceTemplate.resourceTemplate().uriTemplate(), resourceTemplate);
 			}
@@ -1778,6 +2020,8 @@ public interface McpServer {
 		public StatelessAsyncSpecification resourceTemplates(
 				McpStatelessServerFeatures.AsyncResourceTemplateSpecification... resourceTemplates) {
 			Assert.notNull(resourceTemplates, "Resource templates must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository",
+					"Static resource template registrations");
 			for (McpStatelessServerFeatures.AsyncResourceTemplateSpecification resourceTemplate : resourceTemplates) {
 				this.resourceTemplates.put(resourceTemplate.resourceTemplate().uriTemplate(), resourceTemplate);
 			}
@@ -1791,10 +2035,10 @@ public interface McpServer {
 		 *
 		 * <p>
 		 * Example usage: <pre>{@code
-		 * .prompts(Map.of("analysis", new McpServerFeatures.AsyncPromptSpecification(
-		 *     new Prompt("analysis", "Code analysis template"),
-		 *     request -> Mono.fromSupplier(() -> generateAnalysisPrompt(request))
-		 *         .map(GetPromptResult::new)
+		 * .prompts(Map.of("analysis", new McpStatelessServerFeatures.AsyncPromptSpecification(
+		 *     McpSchema.Prompt.builder("analysis").description("Code analysis template").build(),
+		 *     (transportContext, request) -> Mono.fromSupplier(() -> generateAnalysisPrompt(request))
+		 *         .map(messages -> McpSchema.GetPromptResult.builder(messages).build())
 		 * )));
 		 * }</pre>
 		 * @param prompts Map of prompt name to specification. Must not be null.
@@ -1804,6 +2048,7 @@ public interface McpServer {
 		public StatelessAsyncSpecification prompts(
 				Map<String, McpStatelessServerFeatures.AsyncPromptSpecification> prompts) {
 			Assert.notNull(prompts, "Prompts map must not be null");
+			assertNoRepository(this.promptsRepository, "promptsRepository", "Static prompt registrations");
 			this.prompts.putAll(prompts);
 			return this;
 		}
@@ -1818,6 +2063,7 @@ public interface McpServer {
 		 */
 		public StatelessAsyncSpecification prompts(List<McpStatelessServerFeatures.AsyncPromptSpecification> prompts) {
 			Assert.notNull(prompts, "Prompts list must not be null");
+			assertNoRepository(this.promptsRepository, "promptsRepository", "Static prompt registrations");
 			for (var prompt : prompts) {
 				this.prompts.put(prompt.prompt().name(), prompt);
 			}
@@ -1831,9 +2077,9 @@ public interface McpServer {
 		 * <p>
 		 * Example usage: <pre>{@code
 		 * .prompts(
-		 *     new McpServerFeatures.AsyncPromptSpecification(analysisPrompt, analysisHandler),
-		 *     new McpServerFeatures.AsyncPromptSpecification(summaryPrompt, summaryHandler),
-		 *     new McpServerFeatures.AsyncPromptSpecification(reviewPrompt, reviewHandler)
+		 *     new McpStatelessServerFeatures.AsyncPromptSpecification(analysisPrompt, analysisHandler),
+		 *     new McpStatelessServerFeatures.AsyncPromptSpecification(summaryPrompt, summaryHandler),
+		 *     new McpStatelessServerFeatures.AsyncPromptSpecification(reviewPrompt, reviewHandler)
 		 * )
 		 * }</pre>
 		 * @param prompts The prompt specifications to add. Must not be null.
@@ -1842,6 +2088,7 @@ public interface McpServer {
 		 */
 		public StatelessAsyncSpecification prompts(McpStatelessServerFeatures.AsyncPromptSpecification... prompts) {
 			Assert.notNull(prompts, "Prompts list must not be null");
+			assertNoRepository(this.promptsRepository, "promptsRepository", "Static prompt registrations");
 			for (var prompt : prompts) {
 				this.prompts.put(prompt.prompt().name(), prompt);
 			}
@@ -1858,6 +2105,7 @@ public interface McpServer {
 		public StatelessAsyncSpecification completions(
 				List<McpStatelessServerFeatures.AsyncCompletionSpecification> completions) {
 			Assert.notNull(completions, "Completions list must not be null");
+			assertNoRepository(this.completionsRepository, "completionsRepository", "Static completion registrations");
 			for (var completion : completions) {
 				this.completions.put(completion.referenceKey(), completion);
 			}
@@ -1874,6 +2122,7 @@ public interface McpServer {
 		public StatelessAsyncSpecification completions(
 				McpStatelessServerFeatures.AsyncCompletionSpecification... completions) {
 			Assert.notNull(completions, "Completions list must not be null");
+			assertNoRepository(this.completionsRepository, "completionsRepository", "Static completion registrations");
 			for (var completion : completions) {
 				this.completions.put(completion.referenceKey(), completion);
 			}
@@ -1908,7 +2157,9 @@ public interface McpServer {
 
 		public McpStatelessAsyncServer build() {
 			var features = new McpStatelessServerFeatures.Async(this.serverInfo, this.serverCapabilities, this.tools,
-					this.resources, this.resourceTemplates, this.prompts, this.completions, this.instructions);
+					this.toolsRepository, this.resources, this.resourceTemplates, this.resourcesRepository,
+					this.prompts, this.promptsRepository, this.completions, this.completionsRepository,
+					this.instructions);
 			var jsonSchemaValidator = this.jsonSchemaValidator != null ? this.jsonSchemaValidator
 					: McpJsonDefaults.getSchemaValidator();
 
@@ -1951,6 +2202,8 @@ public interface McpServer {
 		 */
 		final List<McpStatelessServerFeatures.SyncToolSpecification> tools = new ArrayList<>();
 
+		StatelessToolsRepository toolsRepository;
+
 		/**
 		 * The Model Context Protocol (MCP) provides a standardized way for servers to
 		 * expose resources to clients. Resources allow servers to share data that
@@ -1969,6 +2222,8 @@ public interface McpServer {
 		 */
 		final Map<String, McpStatelessServerFeatures.SyncResourceTemplateSpecification> resourceTemplates = new HashMap<>();
 
+		StatelessResourcesRepository resourcesRepository;
+
 		/**
 		 * The Model Context Protocol (MCP) provides a standardized way for servers to
 		 * expose prompt templates to clients. Prompts allow servers to provide structured
@@ -1978,12 +2233,67 @@ public interface McpServer {
 		 */
 		final Map<String, McpStatelessServerFeatures.SyncPromptSpecification> prompts = new HashMap<>();
 
+		StatelessPromptsRepository promptsRepository;
+
 		final Map<McpSchema.CompleteReference, McpStatelessServerFeatures.SyncCompletionSpecification> completions = new HashMap<>();
+
+		StatelessCompletionsRepository completionsRepository;
 
 		Duration requestTimeout = Duration.ofSeconds(10); // Default timeout
 
 		public StatelessSyncSpecification(McpStatelessServerTransport transport) {
 			this.transport = transport;
+		}
+
+		/**
+		 * Sets a custom repository for tool discovery and resolution.
+		 * @param toolsRepository the tools repository. Must not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public StatelessSyncSpecification toolsRepository(StatelessToolsRepository toolsRepository) {
+			Assert.notNull(toolsRepository, "Tools repository must not be null");
+			assertNoStaticRegistrations(!this.tools.isEmpty(), "toolsRepository", "static tool registrations");
+			this.toolsRepository = toolsRepository;
+			return this;
+		}
+
+		/**
+		 * Sets a custom repository for resource and resource template discovery and
+		 * resolution.
+		 * @param resourcesRepository the resources repository. Must not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public StatelessSyncSpecification resourcesRepository(StatelessResourcesRepository resourcesRepository) {
+			Assert.notNull(resourcesRepository, "Resources repository must not be null");
+			assertNoStaticRegistrations(!this.resources.isEmpty() || !this.resourceTemplates.isEmpty(),
+					"resourcesRepository", "static resource or resource template registrations");
+			this.resourcesRepository = resourcesRepository;
+			return this;
+		}
+
+		/**
+		 * Sets a custom repository for prompt discovery and resolution.
+		 * @param promptsRepository the prompts repository. Must not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public StatelessSyncSpecification promptsRepository(StatelessPromptsRepository promptsRepository) {
+			Assert.notNull(promptsRepository, "Prompts repository must not be null");
+			assertNoStaticRegistrations(!this.prompts.isEmpty(), "promptsRepository", "static prompt registrations");
+			this.promptsRepository = promptsRepository;
+			return this;
+		}
+
+		/**
+		 * Sets a custom repository for completion resolution.
+		 * @param completionsRepository the completions repository. Must not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public StatelessSyncSpecification completionsRepository(StatelessCompletionsRepository completionsRepository) {
+			Assert.notNull(completionsRepository, "Completions repository must not be null");
+			assertNoStaticRegistrations(!this.completions.isEmpty(), "completionsRepository",
+					"static completion registrations");
+			this.completionsRepository = completionsRepository;
+			return this;
 		}
 
 		/**
@@ -2105,19 +2415,20 @@ public interface McpServer {
 		/**
 		 * Adds a single tool with its implementation handler to the server. This is a
 		 * convenience method for registering individual tools without creating a
-		 * {@link McpServerFeatures.SyncToolSpecification} explicitly.
+		 * {@link McpStatelessServerFeatures.SyncToolSpecification} explicitly.
 		 * @param tool The tool definition including name, description, and schema. Must
 		 * not be null.
 		 * @param callHandler The function that implements the tool's logic. Must not be
-		 * null. The function's first argument is an {@link McpSyncServerExchange} upon
-		 * which the server can interact with the connected client. The second argument is
-		 * the {@link McpSchema.CallToolRequest} object containing the tool call
+		 * null. The function's first argument is an {@link McpTransportContext}. The
+		 * second argument is the {@link McpSchema.CallToolRequest} object containing the
+		 * tool call
 		 * @return This builder instance for method chaining
 		 * @throws IllegalArgumentException if tool or handler is null
 		 */
 		public StatelessSyncSpecification toolCall(McpSchema.Tool tool,
 				BiFunction<McpTransportContext, McpSchema.CallToolRequest, CallToolResult> callHandler) {
 
+			assertNoRepository(this.toolsRepository, "toolsRepository", "Static tool registrations");
 			Assert.notNull(tool, "Tool must not be null");
 			Assert.notNull(callHandler, "Handler must not be null");
 			validateToolName(tool.name());
@@ -2141,6 +2452,7 @@ public interface McpServer {
 		public StatelessSyncSpecification tools(
 				List<McpStatelessServerFeatures.SyncToolSpecification> toolSpecifications) {
 			Assert.notNull(toolSpecifications, "Tool handlers list must not be null");
+			assertNoRepository(this.toolsRepository, "toolsRepository", "Static tool registrations");
 
 			for (var tool : toolSpecifications) {
 				validateToolName(tool.tool().name());
@@ -2158,9 +2470,9 @@ public interface McpServer {
 		 * <p>
 		 * Example usage: <pre>{@code
 		 * .tools(
-		 *     McpServerFeatures.SyncToolSpecification.builder().tool(calculatorTool).callTool(calculatorHandler).build(),
-		 *     McpServerFeatures.SyncToolSpecification.builder().tool(weatherTool).callTool(weatherHandler).build(),
-		 *     McpServerFeatures.SyncToolSpecification.builder().tool(fileManagerTool).callTool(fileManagerHandler).build()
+		 *     McpStatelessServerFeatures.SyncToolSpecification.builder().tool(calculatorTool).callHandler(calculatorHandler).build(),
+		 *     McpStatelessServerFeatures.SyncToolSpecification.builder().tool(weatherTool).callHandler(weatherHandler).build(),
+		 *     McpStatelessServerFeatures.SyncToolSpecification.builder().tool(fileManagerTool).callHandler(fileManagerHandler).build()
 		 * )
 		 * }</pre>
 		 * @param toolSpecifications The tool specifications to add. Must not be null.
@@ -2170,6 +2482,7 @@ public interface McpServer {
 		public StatelessSyncSpecification tools(
 				McpStatelessServerFeatures.SyncToolSpecification... toolSpecifications) {
 			Assert.notNull(toolSpecifications, "Tool handlers list must not be null");
+			assertNoRepository(this.toolsRepository, "toolsRepository", "Static tool registrations");
 
 			for (var tool : toolSpecifications) {
 				validateToolName(tool.tool().name());
@@ -2202,6 +2515,7 @@ public interface McpServer {
 		public StatelessSyncSpecification resources(
 				Map<String, McpStatelessServerFeatures.SyncResourceSpecification> resourceSpecifications) {
 			Assert.notNull(resourceSpecifications, "Resource handlers map must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository", "Static resource registrations");
 			this.resources.putAll(resourceSpecifications);
 			return this;
 		}
@@ -2218,6 +2532,7 @@ public interface McpServer {
 		public StatelessSyncSpecification resources(
 				List<McpStatelessServerFeatures.SyncResourceSpecification> resourceSpecifications) {
 			Assert.notNull(resourceSpecifications, "Resource handlers list must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository", "Static resource registrations");
 			for (var resource : resourceSpecifications) {
 				this.resources.put(resource.resource().uri(), resource);
 			}
@@ -2244,6 +2559,7 @@ public interface McpServer {
 		public StatelessSyncSpecification resources(
 				McpStatelessServerFeatures.SyncResourceSpecification... resourceSpecifications) {
 			Assert.notNull(resourceSpecifications, "Resource handlers list must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository", "Static resource registrations");
 			for (var resource : resourceSpecifications) {
 				this.resources.put(resource.resource().uri(), resource);
 			}
@@ -2261,6 +2577,8 @@ public interface McpServer {
 		public StatelessSyncSpecification resourceTemplates(
 				List<McpStatelessServerFeatures.SyncResourceTemplateSpecification> resourceTemplatesSpec) {
 			Assert.notNull(resourceTemplatesSpec, "Resource templates must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository",
+					"Static resource template registrations");
 			for (var resourceTemplate : resourceTemplatesSpec) {
 				this.resourceTemplates.put(resourceTemplate.resourceTemplate().uriTemplate(), resourceTemplate);
 			}
@@ -2278,6 +2596,8 @@ public interface McpServer {
 		public StatelessSyncSpecification resourceTemplates(
 				McpStatelessServerFeatures.SyncResourceTemplateSpecification... resourceTemplates) {
 			Assert.notNull(resourceTemplates, "Resource templates must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository",
+					"Static resource template registrations");
 			for (McpStatelessServerFeatures.SyncResourceTemplateSpecification resourceTemplate : resourceTemplates) {
 				this.resourceTemplates.put(resourceTemplate.resourceTemplate().uriTemplate(), resourceTemplate);
 			}
@@ -2291,10 +2611,9 @@ public interface McpServer {
 		 *
 		 * <p>
 		 * Example usage: <pre>{@code
-		 * .prompts(Map.of("analysis", new McpServerFeatures.SyncPromptSpecification(
-		 *     new Prompt("analysis", "Code analysis template"),
-		 *     request -> Mono.fromSupplier(() -> generateAnalysisPrompt(request))
-		 *         .map(GetPromptResult::new)
+		 * .prompts(Map.of("analysis", new McpStatelessServerFeatures.SyncPromptSpecification(
+		 *     McpSchema.Prompt.builder("analysis").description("Code analysis template").build(),
+		 *     (transportContext, request) -> McpSchema.GetPromptResult.builder(generateAnalysisPrompt(request)).build()
 		 * )));
 		 * }</pre>
 		 * @param prompts Map of prompt name to specification. Must not be null.
@@ -2304,6 +2623,7 @@ public interface McpServer {
 		public StatelessSyncSpecification prompts(
 				Map<String, McpStatelessServerFeatures.SyncPromptSpecification> prompts) {
 			Assert.notNull(prompts, "Prompts map must not be null");
+			assertNoRepository(this.promptsRepository, "promptsRepository", "Static prompt registrations");
 			this.prompts.putAll(prompts);
 			return this;
 		}
@@ -2318,6 +2638,7 @@ public interface McpServer {
 		 */
 		public StatelessSyncSpecification prompts(List<McpStatelessServerFeatures.SyncPromptSpecification> prompts) {
 			Assert.notNull(prompts, "Prompts list must not be null");
+			assertNoRepository(this.promptsRepository, "promptsRepository", "Static prompt registrations");
 			for (var prompt : prompts) {
 				this.prompts.put(prompt.prompt().name(), prompt);
 			}
@@ -2331,9 +2652,9 @@ public interface McpServer {
 		 * <p>
 		 * Example usage: <pre>{@code
 		 * .prompts(
-		 *     new McpServerFeatures.SyncPromptSpecification(analysisPrompt, analysisHandler),
-		 *     new McpServerFeatures.SyncPromptSpecification(summaryPrompt, summaryHandler),
-		 *     new McpServerFeatures.SyncPromptSpecification(reviewPrompt, reviewHandler)
+		 *     new McpStatelessServerFeatures.SyncPromptSpecification(analysisPrompt, analysisHandler),
+		 *     new McpStatelessServerFeatures.SyncPromptSpecification(summaryPrompt, summaryHandler),
+		 *     new McpStatelessServerFeatures.SyncPromptSpecification(reviewPrompt, reviewHandler)
 		 * )
 		 * }</pre>
 		 * @param prompts The prompt specifications to add. Must not be null.
@@ -2342,6 +2663,7 @@ public interface McpServer {
 		 */
 		public StatelessSyncSpecification prompts(McpStatelessServerFeatures.SyncPromptSpecification... prompts) {
 			Assert.notNull(prompts, "Prompts list must not be null");
+			assertNoRepository(this.promptsRepository, "promptsRepository", "Static prompt registrations");
 			for (var prompt : prompts) {
 				this.prompts.put(prompt.prompt().name(), prompt);
 			}
@@ -2358,6 +2680,7 @@ public interface McpServer {
 		public StatelessSyncSpecification completions(
 				List<McpStatelessServerFeatures.SyncCompletionSpecification> completions) {
 			Assert.notNull(completions, "Completions list must not be null");
+			assertNoRepository(this.completionsRepository, "completionsRepository", "Static completion registrations");
 			for (var completion : completions) {
 				this.completions.put(completion.referenceKey(), completion);
 			}
@@ -2374,6 +2697,7 @@ public interface McpServer {
 		public StatelessSyncSpecification completions(
 				McpStatelessServerFeatures.SyncCompletionSpecification... completions) {
 			Assert.notNull(completions, "Completions list must not be null");
+			assertNoRepository(this.completionsRepository, "completionsRepository", "Static completion registrations");
 			for (var completion : completions) {
 				this.completions.put(completion.referenceKey(), completion);
 			}
@@ -2424,7 +2748,9 @@ public interface McpServer {
 
 		public McpStatelessSyncServer build() {
 			var syncFeatures = new McpStatelessServerFeatures.Sync(this.serverInfo, this.serverCapabilities, this.tools,
-					this.resources, this.resourceTemplates, this.prompts, this.completions, this.instructions);
+					this.toolsRepository, this.resources, this.resourceTemplates, this.resourcesRepository,
+					this.prompts, this.promptsRepository, this.completions, this.completionsRepository,
+					this.instructions);
 			var asyncFeatures = McpStatelessServerFeatures.Async.fromSync(syncFeatures, this.immediateExecution);
 			var jsonSchemaValidator = this.jsonSchemaValidator != null ? this.jsonSchemaValidator
 					: McpJsonDefaults.getSchemaValidator();

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServerFeatures.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServerFeatures.java
@@ -32,18 +32,26 @@ public class McpServerFeatures {
 	 * @param serverInfo The server implementation details
 	 * @param serverCapabilities The server capabilities
 	 * @param tools The list of tool specifications
+	 * @param toolsRepository The custom tools repository
 	 * @param resources The map of resource specifications
-	 * @param resourceTemplates The list of resource templates
+	 * @param resourceTemplates The map of resource templates
+	 * @param resourcesRepository The custom resources repository
 	 * @param prompts The map of prompt specifications
+	 * @param promptsRepository The custom prompts repository
+	 * @param completions The map of completion specifications
+	 * @param completionsRepository The custom completions repository
 	 * @param rootsChangeConsumers The list of consumers that will be notified when the
 	 * roots list changes
 	 * @param instructions The server instructions text
 	 */
 	record Async(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
-			List<McpServerFeatures.AsyncToolSpecification> tools, Map<String, AsyncResourceSpecification> resources,
+			List<McpServerFeatures.AsyncToolSpecification> tools, ToolsRepository toolsRepository,
+			Map<String, AsyncResourceSpecification> resources,
 			Map<String, McpServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates,
-			Map<String, McpServerFeatures.AsyncPromptSpecification> prompts,
+			ResourcesRepository resourcesRepository, Map<String, McpServerFeatures.AsyncPromptSpecification> prompts,
+			PromptsRepository promptsRepository,
 			Map<McpSchema.CompleteReference, McpServerFeatures.AsyncCompletionSpecification> completions,
+			CompletionsRepository completionsRepository,
 			List<BiFunction<McpAsyncServerExchange, List<McpSchema.Root>, Mono<Void>>> rootsChangeConsumers,
 			String instructions) {
 
@@ -52,18 +60,26 @@ public class McpServerFeatures {
 		 * @param serverInfo The server implementation details
 		 * @param serverCapabilities The server capabilities
 		 * @param tools The list of tool specifications
+		 * @param toolsRepository The custom tools repository
 		 * @param resources The map of resource specifications
 		 * @param resourceTemplates The map of resource templates
+		 * @param resourcesRepository The custom resources repository
 		 * @param prompts The map of prompt specifications
+		 * @param promptsRepository The custom prompts repository
+		 * @param completions The map of completion specifications
+		 * @param completionsRepository The custom completions repository
 		 * @param rootsChangeConsumers The list of consumers that will be notified when
 		 * the roots list changes
 		 * @param instructions The server instructions text
 		 */
 		Async(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
-				List<McpServerFeatures.AsyncToolSpecification> tools, Map<String, AsyncResourceSpecification> resources,
+				List<McpServerFeatures.AsyncToolSpecification> tools, ToolsRepository toolsRepository,
+				Map<String, AsyncResourceSpecification> resources,
 				Map<String, McpServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates,
-				Map<String, McpServerFeatures.AsyncPromptSpecification> prompts,
+				ResourcesRepository resourcesRepository,
+				Map<String, McpServerFeatures.AsyncPromptSpecification> prompts, PromptsRepository promptsRepository,
 				Map<McpSchema.CompleteReference, McpServerFeatures.AsyncCompletionSpecification> completions,
+				CompletionsRepository completionsRepository,
 				List<BiFunction<McpAsyncServerExchange, List<McpSchema.Root>, Mono<Void>>> rootsChangeConsumers,
 				String instructions) {
 
@@ -71,24 +87,32 @@ public class McpServerFeatures {
 
 			this.serverInfo = serverInfo;
 			this.serverCapabilities = (serverCapabilities != null) ? serverCapabilities
-					: new McpSchema.ServerCapabilities(null, // completions
+					: new McpSchema.ServerCapabilities(
+							(!Utils.isEmpty(completions) || completionsRepository != null)
+									? new McpSchema.ServerCapabilities.CompletionCapabilities() : null,
 							null, // experimental
 							new McpSchema.ServerCapabilities.LoggingCapabilities(), // Enable
 																					// logging
 																					// by
 																					// default
-							!Utils.isEmpty(prompts) ? McpSchema.ServerCapabilities.PromptCapabilities.builder().build()
-									: null,
-							!Utils.isEmpty(resources)
-									? McpSchema.ServerCapabilities.ResourceCapabilities.builder().build() : null,
-							!Utils.isEmpty(tools) ? McpSchema.ServerCapabilities.ToolCapabilities.builder().build()
-									: null);
+							(!Utils.isEmpty(prompts) || promptsRepository != null)
+									? McpSchema.ServerCapabilities.PromptCapabilities.builder().build() : null,
+							(!Utils.isEmpty(resources) || !Utils.isEmpty(resourceTemplates)
+									|| resourcesRepository != null)
+											? McpSchema.ServerCapabilities.ResourceCapabilities.builder().build()
+											: null,
+							(!Utils.isEmpty(tools) || toolsRepository != null)
+									? McpSchema.ServerCapabilities.ToolCapabilities.builder().build() : null);
 
 			this.tools = (tools != null) ? tools : List.of();
+			this.toolsRepository = toolsRepository;
 			this.resources = (resources != null) ? resources : Map.of();
 			this.resourceTemplates = (resourceTemplates != null) ? resourceTemplates : Map.of();
+			this.resourcesRepository = resourcesRepository;
 			this.prompts = (prompts != null) ? prompts : Map.of();
+			this.promptsRepository = promptsRepository;
 			this.completions = (completions != null) ? completions : Map.of();
+			this.completionsRepository = completionsRepository;
 			this.rootsChangeConsumers = (rootsChangeConsumers != null) ? rootsChangeConsumers : List.of();
 			this.instructions = instructions;
 		}
@@ -137,8 +161,9 @@ public class McpServerFeatures {
 					.subscribeOn(Schedulers.boundedElastic()));
 			}
 
-			return new Async(syncSpec.serverInfo(), syncSpec.serverCapabilities(), tools, resources, resourceTemplates,
-					prompts, completions, rootChangeConsumers, syncSpec.instructions());
+			return new Async(syncSpec.serverInfo(), syncSpec.serverCapabilities(), tools, syncSpec.toolsRepository(),
+					resources, resourceTemplates, syncSpec.resourcesRepository(), prompts, syncSpec.promptsRepository(),
+					completions, syncSpec.completionsRepository(), rootChangeConsumers, syncSpec.instructions());
 		}
 	}
 
@@ -148,19 +173,26 @@ public class McpServerFeatures {
 	 * @param serverInfo The server implementation details
 	 * @param serverCapabilities The server capabilities
 	 * @param tools The list of tool specifications
+	 * @param toolsRepository The custom tools repository
 	 * @param resources The map of resource specifications
-	 * @param resourceTemplates The list of resource templates
+	 * @param resourceTemplates The map of resource templates
+	 * @param resourcesRepository The custom resources repository
 	 * @param prompts The map of prompt specifications
+	 * @param promptsRepository The custom prompts repository
+	 * @param completions The map of completion specifications
+	 * @param completionsRepository The custom completions repository
 	 * @param rootsChangeConsumers The list of consumers that will be notified when the
 	 * roots list changes
 	 * @param instructions The server instructions text
 	 */
 	record Sync(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
-			List<McpServerFeatures.SyncToolSpecification> tools,
+			List<McpServerFeatures.SyncToolSpecification> tools, ToolsRepository toolsRepository,
 			Map<String, McpServerFeatures.SyncResourceSpecification> resources,
 			Map<String, McpServerFeatures.SyncResourceTemplateSpecification> resourceTemplates,
-			Map<String, McpServerFeatures.SyncPromptSpecification> prompts,
+			ResourcesRepository resourcesRepository, Map<String, McpServerFeatures.SyncPromptSpecification> prompts,
+			PromptsRepository promptsRepository,
 			Map<McpSchema.CompleteReference, McpServerFeatures.SyncCompletionSpecification> completions,
+			CompletionsRepository completionsRepository,
 			List<BiConsumer<McpSyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumers, String instructions) {
 
 		/**
@@ -168,19 +200,26 @@ public class McpServerFeatures {
 		 * @param serverInfo The server implementation details
 		 * @param serverCapabilities The server capabilities
 		 * @param tools The list of tool specifications
+		 * @param toolsRepository The custom tools repository
 		 * @param resources The map of resource specifications
-		 * @param resourceTemplates The list of resource templates
+		 * @param resourceTemplates The map of resource templates
+		 * @param resourcesRepository The custom resources repository
 		 * @param prompts The map of prompt specifications
+		 * @param promptsRepository The custom prompts repository
+		 * @param completions The map of completion specifications
+		 * @param completionsRepository The custom completions repository
 		 * @param rootsChangeConsumers The list of consumers that will be notified when
 		 * the roots list changes
 		 * @param instructions The server instructions text
 		 */
 		Sync(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
-				List<McpServerFeatures.SyncToolSpecification> tools,
+				List<McpServerFeatures.SyncToolSpecification> tools, ToolsRepository toolsRepository,
 				Map<String, McpServerFeatures.SyncResourceSpecification> resources,
 				Map<String, McpServerFeatures.SyncResourceTemplateSpecification> resourceTemplates,
-				Map<String, McpServerFeatures.SyncPromptSpecification> prompts,
+				ResourcesRepository resourcesRepository, Map<String, McpServerFeatures.SyncPromptSpecification> prompts,
+				PromptsRepository promptsRepository,
 				Map<McpSchema.CompleteReference, McpServerFeatures.SyncCompletionSpecification> completions,
+				CompletionsRepository completionsRepository,
 				List<BiConsumer<McpSyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumers,
 				String instructions) {
 
@@ -188,24 +227,32 @@ public class McpServerFeatures {
 
 			this.serverInfo = serverInfo;
 			this.serverCapabilities = (serverCapabilities != null) ? serverCapabilities
-					: new McpSchema.ServerCapabilities(null, // completions
+					: new McpSchema.ServerCapabilities(
+							(!Utils.isEmpty(completions) || completionsRepository != null)
+									? new McpSchema.ServerCapabilities.CompletionCapabilities() : null,
 							null, // experimental
 							new McpSchema.ServerCapabilities.LoggingCapabilities(), // Enable
 																					// logging
 																					// by
 																					// default
-							!Utils.isEmpty(prompts) ? McpSchema.ServerCapabilities.PromptCapabilities.builder().build()
-									: null,
-							!Utils.isEmpty(resources)
-									? McpSchema.ServerCapabilities.ResourceCapabilities.builder().build() : null,
-							!Utils.isEmpty(tools) ? McpSchema.ServerCapabilities.ToolCapabilities.builder().build()
-									: null);
+							(!Utils.isEmpty(prompts) || promptsRepository != null)
+									? McpSchema.ServerCapabilities.PromptCapabilities.builder().build() : null,
+							(!Utils.isEmpty(resources) || !Utils.isEmpty(resourceTemplates)
+									|| resourcesRepository != null)
+											? McpSchema.ServerCapabilities.ResourceCapabilities.builder().build()
+											: null,
+							(!Utils.isEmpty(tools) || toolsRepository != null)
+									? McpSchema.ServerCapabilities.ToolCapabilities.builder().build() : null);
 
 			this.tools = (tools != null) ? tools : new ArrayList<>();
+			this.toolsRepository = toolsRepository;
 			this.resources = (resources != null) ? resources : new HashMap<>();
 			this.resourceTemplates = (resourceTemplates != null) ? resourceTemplates : Map.of();
+			this.resourcesRepository = resourcesRepository;
 			this.prompts = (prompts != null) ? prompts : new HashMap<>();
+			this.promptsRepository = promptsRepository;
 			this.completions = (completions != null) ? completions : new HashMap<>();
+			this.completionsRepository = completionsRepository;
 			this.rootsChangeConsumers = (rootsChangeConsumers != null) ? rootsChangeConsumers : new ArrayList<>();
 			this.instructions = instructions;
 		}
@@ -218,13 +265,12 @@ public class McpServerFeatures {
 	 * represents a specific capability.
 	 *
 	 * @param tool The tool definition including name, description, and parameter schema
-	 * @param call Deprecated. Use the {@link AsyncToolSpecification#callHandler} instead.
 	 * @param callHandler The function that implements the tool's logic, receiving a
 	 * {@link McpAsyncServerExchange} and a
 	 * {@link io.modelcontextprotocol.spec.McpSchema.CallToolRequest} and returning
 	 * results. The function's first argument is an {@link McpAsyncServerExchange} upon
-	 * which the server can interact with the connected client. The second arguments is a
-	 * map of tool arguments.
+	 * which the server can interact with the connected client. The second argument is the
+	 * {@link io.modelcontextprotocol.spec.McpSchema.CallToolRequest} object.
 	 */
 	public record AsyncToolSpecification(McpSchema.Tool tool,
 			BiFunction<McpAsyncServerExchange, McpSchema.CallToolRequest, Mono<McpSchema.CallToolResult>> callHandler) {
@@ -320,21 +366,19 @@ public class McpServerFeatures {
 	 *
 	 * <pre>{@code
 	 * new McpServerFeatures.AsyncResourceSpecification(
-	 *     Resource.builder()
-	 *         .uri("docs")
-	 *         .name("Documentation files")
+	 *     McpSchema.Resource.builder("file:///docs", "Documentation files")
 	 * 		   .title("Documentation files")
 	 * 		   .mimeType("text/markdown")
 	 * 		   .description("Markdown documentation files")
 	 * 		   .build(),
-	 * 		(exchange, request) -> Mono.fromSupplier(() -> readFile(request.getPath()))
-	 * 				.map(ReadResourceResult::new))
+	 * 		(exchange, request) -> Mono.fromSupplier(() -> readFile(request.uri()))
+	 * 				.map(contents -> McpSchema.ReadResourceResult.builder(contents).build()))
 	 * }</pre>
 	 *
 	 * @param resource The resource definition including name, description, and MIME type
 	 * @param readHandler The function that handles resource read requests. The function's
 	 * first argument is an {@link McpAsyncServerExchange} upon which the server can
-	 * interact with the connected client. The second arguments is a
+	 * interact with the connected client. The second argument is a
 	 * {@link io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest}.
 	 */
 	public record AsyncResourceSpecification(McpSchema.Resource resource,
@@ -354,7 +398,7 @@ public class McpServerFeatures {
 	}
 
 	/**
-	 * Specification of a resource template with its synchronous handler function.
+	 * Specification of a resource template with its asynchronous handler function.
 	 * Resource templates allow servers to expose parameterized resources using URI
 	 * templates: <a href=https://datatracker.ietf.org/doc/html/rfc6570> URI
 	 * templates.</a>. Arguments may be auto-completed through <a href=
@@ -370,10 +414,10 @@ public class McpServerFeatures {
 	 * </ul>
 	 *
 	 * @param resourceTemplate The resource template definition including name,
-	 * description, and parameter schema
+	 * description, and URI template
 	 * @param readHandler The function that handles resource read requests. The function's
-	 * first argument is an {@link McpSyncServerExchange} upon which the server can
-	 * interact with the connected client. The second arguments is a
+	 * first argument is an {@link McpAsyncServerExchange} upon which the server can
+	 * interact with the connected client. The second argument is a
 	 * {@link McpSchema.ReadResourceRequest}. {@link McpSchema.ResourceTemplate}
 	 * {@link McpSchema.ReadResourceResult}
 	 */
@@ -410,11 +454,13 @@ public class McpServerFeatures {
 	 *
 	 * <pre>{@code
 	 * new McpServerFeatures.AsyncPromptSpecification(
-	 * 		new Prompt("analyze", "Code analysis template"),
+	 * 		McpSchema.Prompt.builder("analyze").description("Code analysis template").build(),
 	 * 		(exchange, request) -> {
-	 * 			String code = request.getArguments().get("code");
-	 * 			return Mono.just(new GetPromptResult(
-	 * 					"Analyze this code:\n\n" + code + "\n\nProvide feedback on:"));
+	 * 			String code = (String) request.arguments().get("code");
+	 * 			var message = McpSchema.PromptMessage.builder(McpSchema.Role.USER,
+	 * 					McpSchema.TextContent.builder("Analyze this code:\n\n" + code + "\n\nProvide feedback on:").build())
+	 * 				.build();
+	 * 			return Mono.just(McpSchema.GetPromptResult.builder(List.of(message)).build());
 	 * 		})
 	 * }</pre>
 	 *
@@ -422,7 +468,7 @@ public class McpServerFeatures {
 	 * @param promptHandler The function that processes prompt requests and returns
 	 * formatted templates. The function's first argument is an
 	 * {@link McpAsyncServerExchange} upon which the server can interact with the
-	 * connected client. The second arguments is a
+	 * connected client. The second argument is a
 	 * {@link io.modelcontextprotocol.spec.McpSchema.GetPromptRequest}.
 	 */
 	public record AsyncPromptSpecification(McpSchema.Prompt prompt,
@@ -588,23 +634,21 @@ public class McpServerFeatures {
 	 *
 	 * <pre>{@code
 	 * new McpServerFeatures.SyncResourceSpecification(
-	 *     Resource.builder()
-	 *         .uri("docs")
-	 *         .name("Documentation files")
+	 *     McpSchema.Resource.builder("file:///docs", "Documentation files")
 	 * 		   .title("Documentation files")
 	 * 		   .mimeType("text/markdown")
 	 * 		   .description("Markdown documentation files")
 	 * 		   .build(),
 	 * 		(exchange, request) -> {
-	 * 			String content = readFile(request.getPath());
-	 * 			return new ReadResourceResult(content);
+	 * 			var contents = readFile(request.uri());
+	 * 			return McpSchema.ReadResourceResult.builder(contents).build();
 	 * 		})
 	 * }</pre>
 	 *
 	 * @param resource The resource definition including name, description, and MIME type
 	 * @param readHandler The function that handles resource read requests. The function's
 	 * first argument is an {@link McpSyncServerExchange} upon which the server can
-	 * interact with the connected client. The second arguments is a
+	 * interact with the connected client. The second argument is a
 	 * {@link io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest}.
 	 */
 	public record SyncResourceSpecification(McpSchema.Resource resource,
@@ -628,10 +672,10 @@ public class McpServerFeatures {
 	 * </ul>
 	 *
 	 * @param resourceTemplate The resource template definition including name,
-	 * description, and parameter schema
+	 * description, and URI template
 	 * @param readHandler The function that handles resource read requests. The function's
 	 * first argument is an {@link McpSyncServerExchange} upon which the server can
-	 * interact with the connected client. The second arguments is a
+	 * interact with the connected client. The second argument is a
 	 * {@link McpSchema.ReadResourceRequest}. {@link McpSchema.ResourceTemplate}
 	 * {@link McpSchema.ReadResourceResult}
 	 */
@@ -655,11 +699,13 @@ public class McpServerFeatures {
 	 *
 	 * <pre>{@code
 	 * new McpServerFeatures.SyncPromptSpecification(
-	 * 		new Prompt("analyze", "Code analysis template"),
+	 * 		McpSchema.Prompt.builder("analyze").description("Code analysis template").build(),
 	 * 		(exchange, request) -> {
-	 * 			String code = request.getArguments().get("code");
-	 * 			return new GetPromptResult(
-	 * 					"Analyze this code:\n\n" + code + "\n\nProvide feedback on:");
+	 * 			String code = (String) request.arguments().get("code");
+	 * 			var message = McpSchema.PromptMessage.builder(McpSchema.Role.USER,
+	 * 					McpSchema.TextContent.builder("Analyze this code:\n\n" + code + "\n\nProvide feedback on:").build())
+	 * 				.build();
+	 * 			return McpSchema.GetPromptResult.builder(List.of(message)).build();
 	 * 		})
 	 * }</pre>
 	 *
@@ -667,7 +713,7 @@ public class McpServerFeatures {
 	 * @param promptHandler The function that processes prompt requests and returns
 	 * formatted templates. The function's first argument is an
 	 * {@link McpSyncServerExchange} upon which the server can interact with the connected
-	 * client. The second arguments is a
+	 * client. The second argument is a
 	 * {@link io.modelcontextprotocol.spec.McpSchema.GetPromptRequest}.
 	 */
 	public record SyncPromptSpecification(McpSchema.Prompt prompt,

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
@@ -8,7 +8,6 @@ import io.modelcontextprotocol.json.TypeRef;
 import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
-import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncResourceTemplateSpecification;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -34,8 +33,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiFunction;
 
 import static io.modelcontextprotocol.spec.McpError.RESOURCE_NOT_FOUND;
@@ -62,15 +59,13 @@ public class McpStatelessAsyncServer {
 
 	private final String instructions;
 
-	private final CopyOnWriteArrayList<McpStatelessServerFeatures.AsyncToolSpecification> tools = new CopyOnWriteArrayList<>();
+	private final StatelessToolsRepository toolsRepository;
 
-	private final ConcurrentHashMap<String, McpStatelessServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates = new ConcurrentHashMap<>();
+	private final StatelessResourcesRepository resourcesRepository;
 
-	private final ConcurrentHashMap<String, McpStatelessServerFeatures.AsyncResourceSpecification> resources = new ConcurrentHashMap<>();
+	private final StatelessPromptsRepository promptsRepository;
 
-	private final ConcurrentHashMap<String, McpStatelessServerFeatures.AsyncPromptSpecification> prompts = new ConcurrentHashMap<>();
-
-	private final ConcurrentHashMap<McpSchema.CompleteReference, McpStatelessServerFeatures.AsyncCompletionSpecification> completions = new ConcurrentHashMap<>();
+	private final StatelessCompletionsRepository completionsRepository;
 
 	private List<String> protocolVersions;
 
@@ -89,11 +84,13 @@ public class McpStatelessAsyncServer {
 		this.serverInfo = features.serverInfo();
 		this.serverCapabilities = features.serverCapabilities();
 		this.instructions = features.instructions();
-		this.tools.addAll(withStructuredOutputHandling(jsonSchemaValidator, features.tools()));
-		this.resources.putAll(features.resources());
-		this.resourceTemplates.putAll(features.resourceTemplates());
-		this.prompts.putAll(features.prompts());
-		this.completions.putAll(features.completions());
+		this.toolsRepository = initializeToolsRepository(features.toolsRepository(), jsonSchemaValidator,
+				features.tools());
+		this.resourcesRepository = initializeResourcesRepository(features.resourcesRepository(), features.resources(),
+				features.resourceTemplates(), uriTemplateManagerFactory);
+		this.promptsRepository = initializePromptsRepository(features.promptsRepository(), features.prompts());
+		this.completionsRepository = initializeCompletionsRepository(features.completionsRepository(),
+				features.completions());
 		this.uriTemplateManagerFactory = uriTemplateManagerFactory;
 		this.jsonSchemaValidator = jsonSchemaValidator;
 		this.validateToolInputs = validateToolInputs;
@@ -135,6 +132,60 @@ public class McpStatelessAsyncServer {
 
 		McpStatelessServerHandler handler = new DefaultMcpStatelessServerHandler(requestHandlers, Map.of());
 		mcpTransport.setMcpHandler(handler);
+	}
+
+	private StatelessToolsRepository initializeToolsRepository(StatelessToolsRepository repository,
+			JsonSchemaValidator jsonSchemaValidator, List<McpStatelessServerFeatures.AsyncToolSpecification> tools) {
+		List<McpStatelessServerFeatures.AsyncToolSpecification> wrappedTools = withStructuredOutputHandling(
+				jsonSchemaValidator, tools);
+		StatelessToolsRepository target = (repository != null) ? repository : new InMemoryStatelessToolsRepository();
+		if (wrappedTools != null) {
+			wrappedTools.forEach(target::addTool);
+		}
+		return target;
+	}
+
+	private StatelessResourcesRepository initializeResourcesRepository(StatelessResourcesRepository repository,
+			Map<String, McpStatelessServerFeatures.AsyncResourceSpecification> resources,
+			Map<String, McpStatelessServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates,
+			McpUriTemplateManagerFactory uriTemplateManagerFactory) {
+		StatelessResourcesRepository target = (repository != null) ? repository
+				: new InMemoryStatelessResourcesRepository(Map.of(), Map.of(), uriTemplateManagerFactory);
+		if (resources != null) {
+			resources.values().forEach(target::addResource);
+		}
+		if (resourceTemplates != null) {
+			resourceTemplates.values().forEach(target::addResourceTemplate);
+		}
+		return target;
+	}
+
+	private StatelessPromptsRepository initializePromptsRepository(StatelessPromptsRepository repository,
+			Map<String, McpStatelessServerFeatures.AsyncPromptSpecification> prompts) {
+		StatelessPromptsRepository target = (repository != null) ? repository
+				: new InMemoryStatelessPromptsRepository();
+		if (prompts != null) {
+			prompts.values().forEach(target::addPrompt);
+		}
+		return target;
+	}
+
+	private StatelessCompletionsRepository initializeCompletionsRepository(StatelessCompletionsRepository repository,
+			Map<McpSchema.CompleteReference, McpStatelessServerFeatures.AsyncCompletionSpecification> completions) {
+		StatelessCompletionsRepository target = (repository != null) ? repository
+				: new InMemoryStatelessCompletionsRepository();
+		if (completions != null) {
+			completions.values().forEach(target::addCompletion);
+		}
+		return target;
+	}
+
+	private McpSchema.PaginatedRequest paginatedRequest(Object params) {
+		if (params == null) {
+			return new McpSchema.PaginatedRequest();
+		}
+		return this.jsonMapper.convertValue(params, new TypeRef<McpSchema.PaginatedRequest>() {
+		});
 	}
 
 	// ---------------------------------------
@@ -323,7 +374,7 @@ public class McpStatelessAsyncServer {
 	/**
 	 * Add a new tool specification at runtime.
 	 * @param toolSpecification The tool specification to add
-	 * @return Mono that completes when clients have been notified of the change
+	 * @return Mono that completes when the repository has been updated
 	 */
 	public Mono<Void> addTool(McpStatelessServerFeatures.AsyncToolSpecification toolSpecification) {
 		if (toolSpecification == null) {
@@ -351,12 +402,7 @@ public class McpStatelessAsyncServer {
 		var wrappedToolSpecification = withStructuredOutputHandling(this.jsonSchemaValidator, toolSpecification);
 
 		return Mono.defer(() -> {
-			// Remove tools with duplicate tool names first
-			if (this.tools.removeIf(th -> th.tool().name().equals(wrappedToolSpecification.tool().name()))) {
-				logger.warn("Replace existing Tool with name '{}'", wrappedToolSpecification.tool().name());
-			}
-
-			this.tools.add(wrappedToolSpecification);
+			this.toolsRepository.addTool(wrappedToolSpecification);
 			logger.debug("Added tool handler: {}", wrappedToolSpecification.tool().name());
 
 			return Mono.empty();
@@ -364,17 +410,24 @@ public class McpStatelessAsyncServer {
 	}
 
 	/**
-	 * List all registered tools.
-	 * @return A Flux stream of all registered tools
+	 * List tools from the repository without a transport request context.
+	 * <p>
+	 * Dynamic repositories should treat the {@link McpTransportContext#EMPTY} context
+	 * passed by this helper as a context-free listing.
+	 * @return A Flux stream of context-free visible tools
 	 */
 	public Flux<Tool> listTools() {
-		return Flux.fromIterable(this.tools).map(McpStatelessServerFeatures.AsyncToolSpecification::tool);
+		return Flux.defer(() -> this.toolsRepository
+			.listTools(McpTransportContext.EMPTY, new McpSchema.PaginatedRequest())
+			.expand(result -> (result.nextCursor() != null) ? this.toolsRepository.listTools(McpTransportContext.EMPTY,
+					new McpSchema.PaginatedRequest(result.nextCursor())) : Mono.empty())
+			.flatMapIterable(McpSchema.ListToolsResult::tools));
 	}
 
 	/**
 	 * Remove a tool handler at runtime.
 	 * @param toolName The name of the tool handler to remove
-	 * @return Mono that completes when clients have been notified of the change
+	 * @return Mono that completes when the repository has been updated
 	 */
 	public Mono<Void> removeTool(String toolName) {
 		if (toolName == null) {
@@ -385,7 +438,7 @@ public class McpStatelessAsyncServer {
 		}
 
 		return Mono.defer(() -> {
-			if (this.tools.removeIf(toolSpecification -> toolSpecification.tool().name().equals(toolName))) {
+			if (this.toolsRepository.removeTool(toolName)) {
 
 				logger.debug("Removed tool handler: {}", toolName);
 			}
@@ -399,10 +452,7 @@ public class McpStatelessAsyncServer {
 
 	private McpStatelessRequestHandler<McpSchema.ListToolsResult> toolsListRequestHandler() {
 		return (ctx, params) -> {
-			List<Tool> tools = this.tools.stream()
-				.map(McpStatelessServerFeatures.AsyncToolSpecification::tool)
-				.toList();
-			return Mono.just(McpSchema.ListToolsResult.builder(tools).build());
+			return this.toolsRepository.listTools(ctx, paginatedRequest(params));
 		};
 	}
 
@@ -412,25 +462,20 @@ public class McpStatelessAsyncServer {
 					new TypeRef<McpSchema.CallToolRequest>() {
 					});
 
-			Optional<McpStatelessServerFeatures.AsyncToolSpecification> toolSpecification = this.tools.stream()
-				.filter(tr -> callToolRequest.name().equals(tr.tool().name()))
-				.findAny();
-
-			if (toolSpecification.isEmpty()) {
-				return Mono.error(McpError.builder(McpSchema.ErrorCodes.INVALID_PARAMS)
+			return this.toolsRepository.resolveTool(callToolRequest.name(), ctx)
+				.switchIfEmpty(Mono.error(McpError.builder(McpSchema.ErrorCodes.INVALID_PARAMS)
 					.message("Unknown tool: invalid_tool_name")
 					.data("Tool not found: " + callToolRequest.name())
-					.build());
-			}
-
-			McpSchema.Tool tool = toolSpecification.get().tool();
-			CallToolResult validationError = ToolInputValidator.validate(tool, callToolRequest.arguments(),
-					this.validateToolInputs, this.jsonSchemaValidator);
-			if (validationError != null) {
-				return Mono.just(validationError);
-			}
-
-			return toolSpecification.get().callHandler().apply(ctx, callToolRequest);
+					.build()))
+				.flatMap(toolSpecification -> {
+					McpSchema.Tool tool = toolSpecification.tool();
+					CallToolResult validationError = ToolInputValidator.validate(tool, callToolRequest.arguments(),
+							this.validateToolInputs, this.jsonSchemaValidator);
+					if (validationError != null) {
+						return Mono.just(validationError);
+					}
+					return toolSpecification.callHandler().apply(ctx, callToolRequest);
+				});
 		};
 	}
 
@@ -441,7 +486,7 @@ public class McpStatelessAsyncServer {
 	/**
 	 * Add a new resource handler at runtime.
 	 * @param resourceSpecification The resource handler to add
-	 * @return Mono that completes when clients have been notified of the change
+	 * @return Mono that completes when the repository has been updated
 	 */
 	public Mono<Void> addResource(McpStatelessServerFeatures.AsyncResourceSpecification resourceSpecification) {
 		if (resourceSpecification == null || resourceSpecification.resource() == null) {
@@ -453,30 +498,31 @@ public class McpStatelessAsyncServer {
 		}
 
 		return Mono.defer(() -> {
-			var previous = this.resources.put(resourceSpecification.resource().uri(), resourceSpecification);
-			if (previous != null) {
-				logger.warn("Replace existing Resource with URI '{}'", resourceSpecification.resource().uri());
-			}
-			else {
-				logger.debug("Added resource handler: {}", resourceSpecification.resource().uri());
-			}
+			this.resourcesRepository.addResource(resourceSpecification);
+			logger.debug("Added resource handler: {}", resourceSpecification.resource().uri());
 			return Mono.empty();
 		});
 	}
 
 	/**
-	 * List all registered resources.
-	 * @return A Flux stream of all registered resources
+	 * List resources from the repository without a transport request context.
+	 * <p>
+	 * Dynamic repositories should treat the {@link McpTransportContext#EMPTY} context
+	 * passed by this helper as a context-free listing.
+	 * @return A Flux stream of context-free visible resources
 	 */
 	public Flux<McpSchema.Resource> listResources() {
-		return Flux.fromIterable(this.resources.values())
-			.map(McpStatelessServerFeatures.AsyncResourceSpecification::resource);
+		return Flux.defer(() -> this.resourcesRepository
+			.listResources(McpTransportContext.EMPTY, new McpSchema.PaginatedRequest())
+			.expand(result -> (result.nextCursor() != null) ? this.resourcesRepository.listResources(
+					McpTransportContext.EMPTY, new McpSchema.PaginatedRequest(result.nextCursor())) : Mono.empty())
+			.flatMapIterable(McpSchema.ListResourcesResult::resources));
 	}
 
 	/**
 	 * Remove a resource handler at runtime.
 	 * @param resourceUri The URI of the resource handler to remove
-	 * @return Mono that completes when clients have been notified of the change
+	 * @return Mono that completes when the repository has been updated
 	 */
 	public Mono<Void> removeResource(String resourceUri) {
 		if (resourceUri == null) {
@@ -487,8 +533,7 @@ public class McpStatelessAsyncServer {
 		}
 
 		return Mono.defer(() -> {
-			McpStatelessServerFeatures.AsyncResourceSpecification removed = this.resources.remove(resourceUri);
-			if (removed != null) {
+			if (this.resourcesRepository.removeResource(resourceUri)) {
 				logger.debug("Removed resource handler: {}", resourceUri);
 			}
 			else {
@@ -501,7 +546,7 @@ public class McpStatelessAsyncServer {
 	/**
 	 * Add a new resource template at runtime.
 	 * @param resourceTemplateSpecification The resource template to add
-	 * @return Mono that completes when clients have been notified of the change
+	 * @return Mono that completes when the repository has been updated
 	 */
 	public Mono<Void> addResourceTemplate(
 			McpStatelessServerFeatures.AsyncResourceTemplateSpecification resourceTemplateSpecification) {
@@ -512,33 +557,32 @@ public class McpStatelessAsyncServer {
 		}
 
 		return Mono.defer(() -> {
-			var previous = this.resourceTemplates.put(resourceTemplateSpecification.resourceTemplate().uriTemplate(),
-					resourceTemplateSpecification);
-			if (previous != null) {
-				logger.warn("Replace existing Resource Template with URI '{}'",
-						resourceTemplateSpecification.resourceTemplate().uriTemplate());
-			}
-			else {
-				logger.debug("Added resource template handler: {}",
-						resourceTemplateSpecification.resourceTemplate().uriTemplate());
-			}
+			this.resourcesRepository.addResourceTemplate(resourceTemplateSpecification);
+			logger.debug("Added resource template handler: {}",
+					resourceTemplateSpecification.resourceTemplate().uriTemplate());
 			return Mono.empty();
 		});
 	}
 
 	/**
-	 * List all registered resource templates.
-	 * @return A Flux stream of all registered resource templates
+	 * List resource templates from the repository without a transport request context.
+	 * <p>
+	 * Dynamic repositories should treat the {@link McpTransportContext#EMPTY} context
+	 * passed by this helper as a context-free listing.
+	 * @return A Flux stream of context-free visible resource templates
 	 */
 	public Flux<McpSchema.ResourceTemplate> listResourceTemplates() {
-		return Flux.fromIterable(this.resourceTemplates.values())
-			.map(McpStatelessServerFeatures.AsyncResourceTemplateSpecification::resourceTemplate);
+		return Flux.defer(() -> this.resourcesRepository
+			.listResourceTemplates(McpTransportContext.EMPTY, new McpSchema.PaginatedRequest())
+			.expand(result -> (result.nextCursor() != null) ? this.resourcesRepository.listResourceTemplates(
+					McpTransportContext.EMPTY, new McpSchema.PaginatedRequest(result.nextCursor())) : Mono.empty())
+			.flatMapIterable(McpSchema.ListResourceTemplatesResult::resourceTemplates));
 	}
 
 	/**
 	 * Remove a resource template at runtime.
 	 * @param uriTemplate The URI template of the resource template to remove
-	 * @return Mono that completes when clients have been notified of the change
+	 * @return Mono that completes when the repository has been updated
 	 */
 	public Mono<Void> removeResourceTemplate(String uriTemplate) {
 
@@ -548,9 +592,7 @@ public class McpStatelessAsyncServer {
 		}
 
 		return Mono.defer(() -> {
-			McpStatelessServerFeatures.AsyncResourceTemplateSpecification removed = this.resourceTemplates
-				.remove(uriTemplate);
-			if (removed != null) {
+			if (this.resourcesRepository.removeResourceTemplate(uriTemplate)) {
 				logger.debug("Removed resource template: {}", uriTemplate);
 			}
 			else {
@@ -562,21 +604,13 @@ public class McpStatelessAsyncServer {
 
 	private McpStatelessRequestHandler<McpSchema.ListResourcesResult> resourcesListRequestHandler() {
 		return (ctx, params) -> {
-			var resourceList = this.resources.values()
-				.stream()
-				.map(McpStatelessServerFeatures.AsyncResourceSpecification::resource)
-				.toList();
-			return Mono.just(McpSchema.ListResourcesResult.builder(resourceList).build());
+			return this.resourcesRepository.listResources(ctx, paginatedRequest(params));
 		};
 	}
 
 	private McpStatelessRequestHandler<McpSchema.ListResourceTemplatesResult> resourceTemplateListRequestHandler() {
 		return (exchange, params) -> {
-			var resourceList = this.resourceTemplates.values()
-				.stream()
-				.map(AsyncResourceTemplateSpecification::resourceTemplate)
-				.toList();
-			return Mono.just(McpSchema.ListResourceTemplatesResult.builder(resourceList).build());
+			return this.resourcesRepository.listResourceTemplates(exchange, paginatedRequest(params));
 		};
 	}
 
@@ -586,35 +620,14 @@ public class McpStatelessAsyncServer {
 			});
 			var resourceUri = resourceRequest.uri();
 
-			// First try to find a static resource specification
-			// Static resources have exact URIs
-			return this.findResourceSpecification(resourceUri)
-				.map(spec -> spec.readHandler().apply(ctx, resourceRequest))
-				.orElseGet(() -> {
-					// If not found, try to find a dynamic resource specification
-					// Dynamic resources have URI templates
-					return this.findResourceTemplateSpecification(resourceUri)
-						.map(spec -> spec.readHandler().apply(ctx, resourceRequest))
-						.orElseGet(() -> Mono.error(RESOURCE_NOT_FOUND.apply(resourceUri)));
-				});
+			// Resolve direct resources first, then resource templates.
+			return this.resourcesRepository.resolveResource(resourceUri, ctx)
+				.flatMap(spec -> spec.readHandler().apply(ctx, resourceRequest))
+				.switchIfEmpty(this.resourcesRepository.resolveResourceTemplate(resourceUri, ctx)
+					.flatMap(spec -> spec.readHandler().apply(ctx, resourceRequest))
+					.switchIfEmpty(Mono.error(RESOURCE_NOT_FOUND.apply(resourceUri))));
 
 		};
-	}
-
-	private Optional<McpStatelessServerFeatures.AsyncResourceSpecification> findResourceSpecification(String uri) {
-		var result = this.resources.values()
-			.stream()
-			.filter(spec -> this.uriTemplateManagerFactory.create(spec.resource().uri()).matches(uri))
-			.findFirst();
-		return result;
-	}
-
-	private Optional<McpStatelessServerFeatures.AsyncResourceTemplateSpecification> findResourceTemplateSpecification(
-			String uri) {
-		return this.resourceTemplates.values()
-			.stream()
-			.filter(spec -> this.uriTemplateManagerFactory.create(spec.resourceTemplate().uriTemplate()).matches(uri))
-			.findFirst();
 	}
 
 	// ---------------------------------------
@@ -624,7 +637,7 @@ public class McpStatelessAsyncServer {
 	/**
 	 * Add a new prompt handler at runtime.
 	 * @param promptSpecification The prompt handler to add
-	 * @return Mono that completes when clients have been notified of the change
+	 * @return Mono that completes when the repository has been updated
 	 */
 	public Mono<Void> addPrompt(McpStatelessServerFeatures.AsyncPromptSpecification promptSpecification) {
 		if (promptSpecification == null) {
@@ -635,31 +648,32 @@ public class McpStatelessAsyncServer {
 		}
 
 		return Mono.defer(() -> {
-			var previous = this.prompts.put(promptSpecification.prompt().name(), promptSpecification);
-			if (previous != null) {
-				logger.warn("Replace existing Prompt with name '{}'", promptSpecification.prompt().name());
-			}
-			else {
-				logger.debug("Added prompt handler: {}", promptSpecification.prompt().name());
-			}
+			this.promptsRepository.addPrompt(promptSpecification);
+			logger.debug("Added prompt handler: {}", promptSpecification.prompt().name());
 
 			return Mono.empty();
 		});
 	}
 
 	/**
-	 * List all registered prompts.
-	 * @return A Flux stream of all registered prompts
+	 * List prompts from the repository without a transport request context.
+	 * <p>
+	 * Dynamic repositories should treat the {@link McpTransportContext#EMPTY} context
+	 * passed by this helper as a context-free listing.
+	 * @return A Flux stream of context-free visible prompts
 	 */
 	public Flux<McpSchema.Prompt> listPrompts() {
-		return Flux.fromIterable(this.prompts.values())
-			.map(McpStatelessServerFeatures.AsyncPromptSpecification::prompt);
+		return Flux
+			.defer(() -> this.promptsRepository.listPrompts(McpTransportContext.EMPTY, new McpSchema.PaginatedRequest())
+				.expand(result -> (result.nextCursor() != null) ? this.promptsRepository.listPrompts(
+						McpTransportContext.EMPTY, new McpSchema.PaginatedRequest(result.nextCursor())) : Mono.empty())
+				.flatMapIterable(McpSchema.ListPromptsResult::prompts));
 	}
 
 	/**
 	 * Remove a prompt handler at runtime.
 	 * @param promptName The name of the prompt handler to remove
-	 * @return Mono that completes when clients have been notified of the change
+	 * @return Mono that completes when the repository has been updated
 	 */
 	public Mono<Void> removePrompt(String promptName) {
 		if (promptName == null) {
@@ -670,9 +684,7 @@ public class McpStatelessAsyncServer {
 		}
 
 		return Mono.defer(() -> {
-			McpStatelessServerFeatures.AsyncPromptSpecification removed = this.prompts.remove(promptName);
-
-			if (removed != null) {
+			if (this.promptsRepository.removePrompt(promptName)) {
 				logger.debug("Removed prompt handler: {}", promptName);
 				return Mono.empty();
 			}
@@ -686,17 +698,7 @@ public class McpStatelessAsyncServer {
 
 	private McpStatelessRequestHandler<McpSchema.ListPromptsResult> promptsListRequestHandler() {
 		return (ctx, params) -> {
-			// TODO: Implement pagination
-			// McpSchema.PaginatedRequest request = objectMapper.convertValue(params,
-			// new TypeReference<McpSchema.PaginatedRequest>() {
-			// });
-
-			var promptList = this.prompts.values()
-				.stream()
-				.map(McpStatelessServerFeatures.AsyncPromptSpecification::prompt)
-				.toList();
-
-			return Mono.just(McpSchema.ListPromptsResult.builder(promptList).build());
+			return this.promptsRepository.listPrompts(ctx, paginatedRequest(params));
 		};
 	}
 
@@ -706,16 +708,12 @@ public class McpStatelessAsyncServer {
 					new TypeRef<McpSchema.GetPromptRequest>() {
 					});
 
-			// Implement prompt retrieval logic here
-			McpStatelessServerFeatures.AsyncPromptSpecification specification = this.prompts.get(promptRequest.name());
-			if (specification == null) {
-				return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
+			return this.promptsRepository.resolvePrompt(promptRequest.name(), ctx)
+				.switchIfEmpty(Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
 					.message("Invalid prompt name")
 					.data("Prompt not found: " + promptRequest.name())
-					.build());
-			}
-
-			return specification.promptHandler().apply(ctx, promptRequest);
+					.build()))
+				.flatMap(specification -> specification.promptHandler().apply(ctx, promptRequest));
 		};
 	}
 
@@ -738,88 +736,82 @@ public class McpStatelessAsyncServer {
 					.build());
 			}
 
-			String type = request.ref().type();
+			return validateCompletionRequest(request, ctx)
+				.switchIfEmpty(this.completionsRepository.resolveCompletion(request.ref(), ctx)
+					.switchIfEmpty(Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
+						.message("AsyncCompletionSpecification not found: " + request.ref())
+						.build()))
+					.flatMap(specification -> specification.completionHandler().apply(ctx, request)));
+		};
+	}
 
-			String argumentName = request.argument().name();
+	private Mono<McpSchema.CompleteResult> validateCompletionRequest(McpSchema.CompleteRequest request,
+			McpTransportContext transportContext) {
+		String type = request.ref().type();
+		String argumentName = request.argument().name();
 
-			// Check if valid a Prompt exists for this completion request
-			if (type.equals(PromptReference.TYPE)
-					&& request.ref() instanceof McpSchema.PromptReference promptReference) {
+		if (type.equals(PromptReference.TYPE) && request.ref() instanceof McpSchema.PromptReference promptReference) {
+			return this.promptsRepository.resolvePrompt(promptReference.name(), transportContext)
+				.switchIfEmpty(Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
+					.message("Prompt not found: " + promptReference.name())
+					.build()))
+				.flatMap(promptSpec -> {
+					List<McpSchema.PromptArgument> arguments = promptSpec.prompt().arguments();
+					if (arguments == null || arguments.stream().noneMatch(arg -> arg.name().equals(argumentName))) {
+						logger.warn("Argument not found: {} in prompt: {}", argumentName, promptReference.name());
+						return EMPTY_COMPLETION_RESULT;
+					}
+					return Mono.empty();
+				});
+		}
 
-				McpStatelessServerFeatures.AsyncPromptSpecification promptSpec = this.prompts
-					.get(promptReference.name());
-				if (promptSpec == null) {
-					return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
-						.message("Prompt not found: " + promptReference.name())
-						.build());
-				}
-				List<McpSchema.PromptArgument> arguments = promptSpec.prompt().arguments();
-				if (arguments == null
-						|| !arguments.stream().filter(arg -> arg.name().equals(argumentName)).findFirst().isPresent()) {
+		if (type.equals(ResourceReference.TYPE)
+				&& request.ref() instanceof McpSchema.ResourceReference resourceReference) {
+			return validateResourceCompletionRequest(resourceReference, argumentName, transportContext);
+		}
 
-					logger.warn("Argument not found: {} in prompt: {}", argumentName, promptReference.name());
+		return Mono.empty();
+	}
 
-					return EMPTY_COMPLETION_RESULT;
-				}
-			}
+	private Mono<McpSchema.CompleteResult> validateResourceCompletionRequest(
+			McpSchema.ResourceReference resourceReference, String argumentName, McpTransportContext transportContext) {
+		var uriTemplateManager = uriTemplateManagerFactory.create(resourceReference.uri());
 
-			// Check if valid Resource or ResourceTemplate exists for this completion
-			// request
-			if (type.equals(ResourceReference.TYPE)
-					&& request.ref() instanceof McpSchema.ResourceReference resourceReference) {
+		if (!uriTemplateManager.isUriTemplate(resourceReference.uri())) {
+			// Attempting to autocomplete a fixed resource URI is not an error in the
+			// spec.
+			return EMPTY_COMPLETION_RESULT;
+		}
 
-				var uriTemplateManager = uriTemplateManagerFactory.create(resourceReference.uri());
-
-				if (!uriTemplateManager.isUriTemplate(resourceReference.uri())) {
-					// Attempting to autocomplete a fixed resource URI is not an error in
-					// the spec (but probably should be).
-					return EMPTY_COMPLETION_RESULT;
-				}
-
-				McpStatelessServerFeatures.AsyncResourceSpecification resourceSpec = this
-					.findResourceSpecification(resourceReference.uri())
-					.orElse(null);
-
-				if (resourceSpec != null) {
-					if (!uriTemplateManagerFactory.create(resourceSpec.resource().uri())
+		return this.resourcesRepository.resolveResource(resourceReference.uri(), transportContext)
+			.map(Optional::of)
+			.defaultIfEmpty(Optional.empty())
+			.flatMap(resourceSpec -> {
+				if (resourceSpec.isPresent()) {
+					if (!uriTemplateManagerFactory.create(resourceSpec.get().resource().uri())
 						.getVariableNames()
 						.contains(argumentName)) {
-
 						return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
 							.message("Argument not found: " + argumentName + " in resource: " + resourceReference.uri())
 							.build());
 					}
+					return Mono.empty();
 				}
-				else {
-					var templateSpec = this.findResourceTemplateSpecification(resourceReference.uri()).orElse(null);
-					if (templateSpec != null) {
 
+				return this.resourcesRepository.resolveResourceTemplate(resourceReference.uri(), transportContext)
+					.switchIfEmpty(Mono.error(RESOURCE_NOT_FOUND.apply(resourceReference.uri())))
+					.flatMap(templateSpec -> {
 						if (!uriTemplateManagerFactory.create(templateSpec.resourceTemplate().uriTemplate())
 							.getVariableNames()
 							.contains(argumentName)) {
-
 							return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
 								.message("Argument not found: " + argumentName + " in resource template: "
 										+ resourceReference.uri())
 								.build());
 						}
-					}
-					else {
-						return Mono.error(RESOURCE_NOT_FOUND.apply(resourceReference.uri()));
-					}
-				}
-			}
-
-			McpStatelessServerFeatures.AsyncCompletionSpecification specification = this.completions.get(request.ref());
-
-			if (specification == null) {
-				return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
-					.message("AsyncCompletionSpecification not found: " + request.ref())
-					.build());
-			}
-
-			return specification.completionHandler().apply(ctx, request);
-		};
+						return Mono.empty();
+					});
+			});
 	}
 
 	/**

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessServerFeatures.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessServerFeatures.java
@@ -33,56 +33,78 @@ public class McpStatelessServerFeatures {
 	 * @param serverInfo The server implementation details
 	 * @param serverCapabilities The server capabilities
 	 * @param tools The list of tool specifications
+	 * @param toolsRepository The custom tools repository
 	 * @param resources The map of resource specifications
 	 * @param resourceTemplates The map of resource templates
+	 * @param resourcesRepository The custom resources repository
 	 * @param prompts The map of prompt specifications
+	 * @param promptsRepository The custom prompts repository
+	 * @param completions The map of completion specifications
+	 * @param completionsRepository The custom completions repository
 	 * @param instructions The server instructions text
 	 */
 	record Async(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
-			List<McpStatelessServerFeatures.AsyncToolSpecification> tools,
+			List<McpStatelessServerFeatures.AsyncToolSpecification> tools, StatelessToolsRepository toolsRepository,
 			Map<String, AsyncResourceSpecification> resources,
 			Map<String, McpStatelessServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates,
+			StatelessResourcesRepository resourcesRepository,
 			Map<String, McpStatelessServerFeatures.AsyncPromptSpecification> prompts,
+			StatelessPromptsRepository promptsRepository,
 			Map<McpSchema.CompleteReference, McpStatelessServerFeatures.AsyncCompletionSpecification> completions,
-			String instructions) {
+			StatelessCompletionsRepository completionsRepository, String instructions) {
 
 		/**
 		 * Create an instance and validate the arguments.
 		 * @param serverInfo The server implementation details
 		 * @param serverCapabilities The server capabilities
 		 * @param tools The list of tool specifications
+		 * @param toolsRepository The custom tools repository
 		 * @param resources The map of resource specifications
 		 * @param resourceTemplates The map of resource templates
+		 * @param resourcesRepository The custom resources repository
 		 * @param prompts The map of prompt specifications
+		 * @param promptsRepository The custom prompts repository
+		 * @param completions The map of completion specifications
+		 * @param completionsRepository The custom completions repository
 		 * @param instructions The server instructions text
 		 */
 		Async(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
-				List<McpStatelessServerFeatures.AsyncToolSpecification> tools,
+				List<McpStatelessServerFeatures.AsyncToolSpecification> tools, StatelessToolsRepository toolsRepository,
 				Map<String, AsyncResourceSpecification> resources,
 				Map<String, McpStatelessServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates,
+				StatelessResourcesRepository resourcesRepository,
 				Map<String, McpStatelessServerFeatures.AsyncPromptSpecification> prompts,
+				StatelessPromptsRepository promptsRepository,
 				Map<McpSchema.CompleteReference, McpStatelessServerFeatures.AsyncCompletionSpecification> completions,
-				String instructions) {
+				StatelessCompletionsRepository completionsRepository, String instructions) {
 
 			Assert.notNull(serverInfo, "Server info must not be null");
 
 			this.serverInfo = serverInfo;
 			this.serverCapabilities = (serverCapabilities != null) ? serverCapabilities
-					: new McpSchema.ServerCapabilities(null, // completions
+					: new McpSchema.ServerCapabilities(
+							(!Utils.isEmpty(completions) || completionsRepository != null)
+									? new McpSchema.ServerCapabilities.CompletionCapabilities() : null,
 							null, // experimental
 							null, // currently statless server doesn't support set logging
-							!Utils.isEmpty(prompts) ? McpSchema.ServerCapabilities.PromptCapabilities.builder().build()
-									: null,
-							!Utils.isEmpty(resources)
-									? McpSchema.ServerCapabilities.ResourceCapabilities.builder().build() : null,
-							!Utils.isEmpty(tools) ? McpSchema.ServerCapabilities.ToolCapabilities.builder().build()
-									: null);
+							(!Utils.isEmpty(prompts) || promptsRepository != null)
+									? McpSchema.ServerCapabilities.PromptCapabilities.builder().build() : null,
+							(!Utils.isEmpty(resources) || !Utils.isEmpty(resourceTemplates)
+									|| resourcesRepository != null)
+											? McpSchema.ServerCapabilities.ResourceCapabilities.builder().build()
+											: null,
+							(!Utils.isEmpty(tools) || toolsRepository != null)
+									? McpSchema.ServerCapabilities.ToolCapabilities.builder().build() : null);
 
 			this.tools = (tools != null) ? tools : List.of();
+			this.toolsRepository = toolsRepository;
 			this.resources = (resources != null) ? resources : Map.of();
 			this.resourceTemplates = (resourceTemplates != null) ? resourceTemplates : Map.of();
+			this.resourcesRepository = resourcesRepository;
 			this.prompts = (prompts != null) ? prompts : Map.of();
+			this.promptsRepository = promptsRepository;
 			this.completions = (completions != null) ? completions : Map.of();
+			this.completionsRepository = completionsRepository;
 			this.instructions = instructions;
 		}
 
@@ -122,8 +144,9 @@ public class McpStatelessServerFeatures {
 				completions.put(key, AsyncCompletionSpecification.fromSync(completion, immediateExecution));
 			});
 
-			return new Async(syncSpec.serverInfo(), syncSpec.serverCapabilities(), tools, resources, resourceTemplates,
-					prompts, completions, syncSpec.instructions());
+			return new Async(syncSpec.serverInfo(), syncSpec.serverCapabilities(), tools, syncSpec.toolsRepository(),
+					resources, resourceTemplates, syncSpec.resourcesRepository(), prompts, syncSpec.promptsRepository(),
+					completions, syncSpec.completionsRepository(), syncSpec.instructions());
 		}
 	}
 
@@ -133,59 +156,81 @@ public class McpStatelessServerFeatures {
 	 * @param serverInfo The server implementation details
 	 * @param serverCapabilities The server capabilities
 	 * @param tools The list of tool specifications
+	 * @param toolsRepository The custom tools repository
 	 * @param resources The map of resource specifications
 	 * @param resourceTemplates The map of resource templates
+	 * @param resourcesRepository The custom resources repository
 	 * @param prompts The map of prompt specifications
+	 * @param promptsRepository The custom prompts repository
+	 * @param completions The map of completion specifications
+	 * @param completionsRepository The custom completions repository
 	 * @param instructions The server instructions text
 	 */
 	record Sync(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
-			List<McpStatelessServerFeatures.SyncToolSpecification> tools,
+			List<McpStatelessServerFeatures.SyncToolSpecification> tools, StatelessToolsRepository toolsRepository,
 			Map<String, McpStatelessServerFeatures.SyncResourceSpecification> resources,
 			Map<String, McpStatelessServerFeatures.SyncResourceTemplateSpecification> resourceTemplates,
+			StatelessResourcesRepository resourcesRepository,
 			Map<String, McpStatelessServerFeatures.SyncPromptSpecification> prompts,
+			StatelessPromptsRepository promptsRepository,
 			Map<McpSchema.CompleteReference, McpStatelessServerFeatures.SyncCompletionSpecification> completions,
-			String instructions) {
+			StatelessCompletionsRepository completionsRepository, String instructions) {
 
 		/**
 		 * Create an instance and validate the arguments.
 		 * @param serverInfo The server implementation details
 		 * @param serverCapabilities The server capabilities
 		 * @param tools The list of tool specifications
+		 * @param toolsRepository The custom tools repository
 		 * @param resources The map of resource specifications
 		 * @param resourceTemplates The map of resource templates
+		 * @param resourcesRepository The custom resources repository
 		 * @param prompts The map of prompt specifications
+		 * @param promptsRepository The custom prompts repository
+		 * @param completions The map of completion specifications
+		 * @param completionsRepository The custom completions repository
 		 * @param instructions The server instructions text
 		 */
 		Sync(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
-				List<McpStatelessServerFeatures.SyncToolSpecification> tools,
+				List<McpStatelessServerFeatures.SyncToolSpecification> tools, StatelessToolsRepository toolsRepository,
 				Map<String, McpStatelessServerFeatures.SyncResourceSpecification> resources,
 				Map<String, McpStatelessServerFeatures.SyncResourceTemplateSpecification> resourceTemplates,
+				StatelessResourcesRepository resourcesRepository,
 				Map<String, McpStatelessServerFeatures.SyncPromptSpecification> prompts,
+				StatelessPromptsRepository promptsRepository,
 				Map<McpSchema.CompleteReference, McpStatelessServerFeatures.SyncCompletionSpecification> completions,
-				String instructions) {
+				StatelessCompletionsRepository completionsRepository, String instructions) {
 
 			Assert.notNull(serverInfo, "Server info must not be null");
 
 			this.serverInfo = serverInfo;
 			this.serverCapabilities = (serverCapabilities != null) ? serverCapabilities
-					: new McpSchema.ServerCapabilities(null, // completions
+					: new McpSchema.ServerCapabilities(
+							(!Utils.isEmpty(completions) || completionsRepository != null)
+									? new McpSchema.ServerCapabilities.CompletionCapabilities() : null,
 							null, // experimental
 							new McpSchema.ServerCapabilities.LoggingCapabilities(), // Enable
 																					// logging
 																					// by
 																					// default
-							!Utils.isEmpty(prompts) ? McpSchema.ServerCapabilities.PromptCapabilities.builder().build()
-									: null,
-							!Utils.isEmpty(resources)
-									? McpSchema.ServerCapabilities.ResourceCapabilities.builder().build() : null,
-							!Utils.isEmpty(tools) ? McpSchema.ServerCapabilities.ToolCapabilities.builder().build()
-									: null);
+							(!Utils.isEmpty(prompts) || promptsRepository != null)
+									? McpSchema.ServerCapabilities.PromptCapabilities.builder().build() : null,
+							(!Utils.isEmpty(resources) || !Utils.isEmpty(resourceTemplates)
+									|| resourcesRepository != null)
+											? McpSchema.ServerCapabilities.ResourceCapabilities.builder().build()
+											: null,
+							(!Utils.isEmpty(tools) || toolsRepository != null)
+									? McpSchema.ServerCapabilities.ToolCapabilities.builder().build() : null);
 
 			this.tools = (tools != null) ? tools : new ArrayList<>();
+			this.toolsRepository = toolsRepository;
 			this.resources = (resources != null) ? resources : new HashMap<>();
 			this.resourceTemplates = (resourceTemplates != null) ? resourceTemplates : Map.of();
+			this.resourcesRepository = resourcesRepository;
 			this.prompts = (prompts != null) ? prompts : new HashMap<>();
+			this.promptsRepository = promptsRepository;
 			this.completions = (completions != null) ? completions : new HashMap<>();
+			this.completionsRepository = completionsRepository;
 			this.instructions = instructions;
 		}
 
@@ -290,7 +335,8 @@ public class McpStatelessServerFeatures {
 	 *
 	 * @param resource The resource definition including name, description, and MIME type
 	 * @param readHandler The function that handles resource read requests. The function's
-	 * argument is a {@link McpSchema.ReadResourceRequest}.
+	 * first argument is an {@link McpTransportContext}. The second argument is a
+	 * {@link McpSchema.ReadResourceRequest}.
 	 */
 	public record AsyncResourceSpecification(McpSchema.Resource resource,
 			BiFunction<McpTransportContext, McpSchema.ReadResourceRequest, Mono<McpSchema.ReadResourceResult>> readHandler) {
@@ -308,7 +354,7 @@ public class McpStatelessServerFeatures {
 	}
 
 	/**
-	 * Specification of a resource template with its synchronous handler function.
+	 * Specification of a resource template with its asynchronous handler function.
 	 * Resource templates allow servers to expose parameterized resources using URI
 	 * templates: <a href=https://datatracker.ietf.org/doc/html/rfc6570> URI
 	 * templates.</a>. Arguments may be auto-completed through <a href=
@@ -324,10 +370,9 @@ public class McpStatelessServerFeatures {
 	 * </ul>
 	 *
 	 * @param resourceTemplate The resource template definition including name,
-	 * description, and parameter schema
+	 * description, and URI template
 	 * @param readHandler The function that handles resource read requests. The function's
-	 * first argument is an {@link McpTransportContext} upon which the server can interact
-	 * with the connected client. The second arguments is a
+	 * first argument is an {@link McpTransportContext}. The second argument is a
 	 * {@link McpSchema.ReadResourceRequest}. {@link McpSchema.ResourceTemplate}
 	 * {@link McpSchema.ReadResourceResult}
 	 */
@@ -360,8 +405,8 @@ public class McpStatelessServerFeatures {
 	 *
 	 * @param prompt The prompt definition including name and description
 	 * @param promptHandler The function that processes prompt requests and returns
-	 * formatted templates. The function's argument is a
-	 * {@link McpSchema.GetPromptRequest}.
+	 * formatted templates. The first argument is an {@link McpTransportContext}. The
+	 * second argument is a {@link McpSchema.GetPromptRequest}.
 	 */
 	public record AsyncPromptSpecification(McpSchema.Prompt prompt,
 			BiFunction<McpTransportContext, McpSchema.GetPromptRequest, Mono<McpSchema.GetPromptResult>> promptHandler) {
@@ -390,8 +435,8 @@ public class McpStatelessServerFeatures {
 	 *
 	 * @param referenceKey The unique key representing the completion reference.
 	 * @param completionHandler The asynchronous function that processes completion
-	 * requests and returns results. The function's argument is a
-	 * {@link McpSchema.CompleteRequest}.
+	 * requests and returns results. The first argument is an {@link McpTransportContext}.
+	 * The second argument is a {@link McpSchema.CompleteRequest}.
 	 */
 	public record AsyncCompletionSpecification(McpSchema.CompleteReference referenceKey,
 			BiFunction<McpTransportContext, McpSchema.CompleteRequest, Mono<McpSchema.CompleteResult>> completionHandler) {
@@ -423,7 +468,7 @@ public class McpStatelessServerFeatures {
 	 *
 	 * @param tool The tool definition including name, description, and parameter schema
 	 * @param callHandler The function that implements the tool's logic, receiving a
-	 * {@link CallToolRequest} and returning results.
+	 * {@link McpTransportContext} and a {@link CallToolRequest}, and returning results.
 	 */
 	public record SyncToolSpecification(McpSchema.Tool tool,
 			BiFunction<McpTransportContext, CallToolRequest, McpSchema.CallToolResult> callHandler) {
@@ -491,7 +536,8 @@ public class McpStatelessServerFeatures {
 	 *
 	 * @param resource The resource definition including name, description, and MIME type
 	 * @param readHandler The function that handles resource read requests. The function's
-	 * argument is a {@link McpSchema.ReadResourceRequest}.
+	 * first argument is an {@link McpTransportContext}. The second argument is a
+	 * {@link McpSchema.ReadResourceRequest}.
 	 */
 	public record SyncResourceSpecification(McpSchema.Resource resource,
 			BiFunction<McpTransportContext, McpSchema.ReadResourceRequest, McpSchema.ReadResourceResult> readHandler) {
@@ -514,10 +560,9 @@ public class McpStatelessServerFeatures {
 	 * </ul>
 	 *
 	 * @param resourceTemplate The resource template definition including name,
-	 * description, and parameter schema
+	 * description, and URI template
 	 * @param readHandler The function that handles resource read requests. The function's
-	 * first argument is an {@link McpTransportContext} upon which the server can interact
-	 * with the connected client. The second arguments is a
+	 * first argument is an {@link McpTransportContext}. The second argument is a
 	 * {@link McpSchema.ReadResourceRequest}. {@link McpSchema.ResourceTemplate}
 	 * {@link McpSchema.ReadResourceResult}
 	 */
@@ -538,8 +583,8 @@ public class McpStatelessServerFeatures {
 	 *
 	 * @param prompt The prompt definition including name and description
 	 * @param promptHandler The function that processes prompt requests and returns
-	 * formatted templates. The function's argument is a
-	 * {@link McpSchema.GetPromptRequest}.
+	 * formatted templates. The first argument is an {@link McpTransportContext}. The
+	 * second argument is a {@link McpSchema.GetPromptRequest}.
 	 */
 	public record SyncPromptSpecification(McpSchema.Prompt prompt,
 			BiFunction<McpTransportContext, McpSchema.GetPromptRequest, McpSchema.GetPromptResult> promptHandler) {
@@ -550,7 +595,8 @@ public class McpStatelessServerFeatures {
 	 *
 	 * @param referenceKey The unique key representing the completion reference.
 	 * @param completionHandler The synchronous function that processes completion
-	 * requests and returns results. The argument is a {@link McpSchema.CompleteRequest}.
+	 * requests and returns results. The first argument is an {@link McpTransportContext}.
+	 * The second argument is a {@link McpSchema.CompleteRequest}.
 	 */
 	public record SyncCompletionSpecification(McpSchema.CompleteReference referenceKey,
 			BiFunction<McpTransportContext, McpSchema.CompleteRequest, McpSchema.CompleteResult> completionHandler) {

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessSyncServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessSyncServer.java
@@ -75,8 +75,8 @@ public class McpStatelessSyncServer {
 	}
 
 	/**
-	 * List all registered tools.
-	 * @return A list of all registered tools
+	 * List tools from the repository without a transport request context.
+	 * @return A list of context-free visible tools
 	 */
 	public List<McpSchema.Tool> listTools() {
 		return this.asyncServer.listTools().collectList().block();
@@ -102,8 +102,8 @@ public class McpStatelessSyncServer {
 	}
 
 	/**
-	 * List all registered resources.
-	 * @return A list of all registered resources
+	 * List resources from the repository without a transport request context.
+	 * @return A list of context-free visible resources
 	 */
 	public List<McpSchema.Resource> listResources() {
 		return this.asyncServer.listResources().collectList().block();
@@ -130,8 +130,8 @@ public class McpStatelessSyncServer {
 	}
 
 	/**
-	 * List all registered resource templates.
-	 * @return A list of all registered resource templates
+	 * List resource templates from the repository without a transport request context.
+	 * @return A list of context-free visible resource templates
 	 */
 	public List<McpSchema.ResourceTemplate> listResourceTemplates() {
 		return this.asyncServer.listResourceTemplates().collectList().block();
@@ -157,8 +157,8 @@ public class McpStatelessSyncServer {
 	}
 
 	/**
-	 * List all registered prompts.
-	 * @return A list of all registered prompts
+	 * List prompts from the repository without a transport request context.
+	 * @return A list of context-free visible prompts
 	 */
 	public List<McpSchema.Prompt> listPrompts() {
 		return this.asyncServer.listPrompts().collectList().block();

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpSyncServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpSyncServer.java
@@ -7,7 +7,6 @@ package io.modelcontextprotocol.server;
 import java.util.List;
 
 import io.modelcontextprotocol.spec.McpSchema;
-import io.modelcontextprotocol.spec.McpSchema.LoggingMessageNotification;
 import io.modelcontextprotocol.util.Assert;
 
 /**
@@ -90,8 +89,8 @@ public class McpSyncServer {
 	}
 
 	/**
-	 * List all registered tools.
-	 * @return A list of all registered tools
+	 * List tools from the repository without a client request exchange.
+	 * @return A list of context-free visible tools
 	 */
 	public List<McpSchema.Tool> listTools() {
 		return this.asyncServer.listTools().collectList().block();
@@ -117,8 +116,8 @@ public class McpSyncServer {
 	}
 
 	/**
-	 * List all registered resources.
-	 * @return A list of all registered resources
+	 * List resources from the repository without a client request exchange.
+	 * @return A list of context-free visible resources
 	 */
 	public List<McpSchema.Resource> listResources() {
 		return this.asyncServer.listResources().collectList().block();
@@ -144,8 +143,8 @@ public class McpSyncServer {
 	}
 
 	/**
-	 * List all registered resource templates.
-	 * @return A list of all registered resource templates
+	 * List resource templates from the repository without a client request exchange.
+	 * @return A list of context-free visible resource templates
 	 */
 	public List<McpSchema.ResourceTemplate> listResourceTemplates() {
 		return this.asyncServer.listResourceTemplates().collectList().block();
@@ -153,6 +152,11 @@ public class McpSyncServer {
 
 	/**
 	 * Remove a resource template.
+	 * <p>
+	 * This method does not automatically send a
+	 * {@code notifications/resources/list_changed} notification. Call
+	 * {@link #notifyResourcesListChanged()} explicitly when clients should refresh the
+	 * resource and resource-template lists.
 	 * @param uriTemplate The URI template of the resource template to remove
 	 */
 	public void removeResourceTemplate(String uriTemplate) {
@@ -171,8 +175,8 @@ public class McpSyncServer {
 	}
 
 	/**
-	 * List all registered prompts.
-	 * @return A list of all registered prompts
+	 * List prompts from the repository without a client request exchange.
+	 * @return A list of context-free visible prompts
 	 */
 	public List<McpSchema.Prompt> listPrompts() {
 		return this.asyncServer.listPrompts().collectList().block();

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/PromptsRepository.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/PromptsRepository.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import reactor.core.publisher.Mono;
+
+/**
+ * Repository for context-aware MCP prompt discovery and resolution.
+ *
+ * @author Taewoong Kim
+ */
+public interface PromptsRepository {
+
+	/**
+	 * List prompts visible to the current exchange.
+	 * @param exchange the current client exchange, or {@code null} for context-free
+	 * listing
+	 * @param request the paginated request parameters
+	 * @return the visible prompts and optional next cursor
+	 */
+	Mono<McpSchema.ListPromptsResult> listPrompts(McpAsyncServerExchange exchange, McpSchema.PaginatedRequest request);
+
+	/**
+	 * Resolve a prompt that is visible in the current exchange.
+	 * @param name the prompt name
+	 * @param exchange the current client exchange
+	 * @return the prompt specification, or empty if the prompt is not found or not
+	 * allowed
+	 */
+	Mono<McpServerFeatures.AsyncPromptSpecification> resolvePrompt(String name, McpAsyncServerExchange exchange);
+
+	/**
+	 * Add a prompt to the repository.
+	 * <p>
+	 * Custom repositories that support {@link McpAsyncServer#addPrompt} must override
+	 * this method. If not overridden, this method throws
+	 * {@link UnsupportedOperationException}.
+	 * @param promptSpecification the prompt specification
+	 */
+	default void addPrompt(McpServerFeatures.AsyncPromptSpecification promptSpecification) {
+		throw new UnsupportedOperationException("This PromptsRepository does not support adding prompts");
+	}
+
+	/**
+	 * Remove a prompt from the repository.
+	 * <p>
+	 * Custom repositories that support {@link McpAsyncServer#removePrompt} must override
+	 * this method. If not overridden, this method throws
+	 * {@link UnsupportedOperationException}.
+	 * @param name the prompt name
+	 * @return {@code true} if a prompt was removed
+	 */
+	default boolean removePrompt(String name) {
+		throw new UnsupportedOperationException("This PromptsRepository does not support removing prompts");
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/ResourcesRepository.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/ResourcesRepository.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import reactor.core.publisher.Mono;
+
+/**
+ * Repository for context-aware MCP resource and resource template discovery and
+ * resolution.
+ *
+ * @author Taewoong Kim
+ */
+public interface ResourcesRepository {
+
+	/**
+	 * List resources visible to the current exchange.
+	 * @param exchange the current client exchange, or {@code null} for context-free
+	 * listing
+	 * @param request the paginated request parameters
+	 * @return the visible resources and optional next cursor
+	 */
+	Mono<McpSchema.ListResourcesResult> listResources(McpAsyncServerExchange exchange,
+			McpSchema.PaginatedRequest request);
+
+	/**
+	 * List resource templates visible to the current exchange.
+	 * @param exchange the current client exchange, or {@code null} for context-free
+	 * listing
+	 * @param request the paginated request parameters
+	 * @return the visible resource templates and optional next cursor
+	 */
+	Mono<McpSchema.ListResourceTemplatesResult> listResourceTemplates(McpAsyncServerExchange exchange,
+			McpSchema.PaginatedRequest request);
+
+	/**
+	 * Resolve a resource for a read request.
+	 * @param uri the requested resource URI
+	 * @param exchange the current client exchange
+	 * @return the resource specification, or empty if no visible resource matches
+	 */
+	Mono<McpServerFeatures.AsyncResourceSpecification> resolveResource(String uri, McpAsyncServerExchange exchange);
+
+	/**
+	 * Resolve a resource template for a read request.
+	 * @param uri the requested resource URI
+	 * @param exchange the current client exchange
+	 * @return the resource template specification, or empty if no visible template
+	 * matches
+	 */
+	Mono<McpServerFeatures.AsyncResourceTemplateSpecification> resolveResourceTemplate(String uri,
+			McpAsyncServerExchange exchange);
+
+	/**
+	 * Add a resource to the repository.
+	 * <p>
+	 * Custom repositories that support {@link McpAsyncServer#addResource} must override
+	 * this method. If not overridden, this method throws
+	 * {@link UnsupportedOperationException}.
+	 * @param resourceSpecification the resource specification
+	 */
+	default void addResource(McpServerFeatures.AsyncResourceSpecification resourceSpecification) {
+		throw new UnsupportedOperationException("This ResourcesRepository does not support adding resources");
+	}
+
+	/**
+	 * Remove a resource from the repository.
+	 * <p>
+	 * Custom repositories that support {@link McpAsyncServer#removeResource} must
+	 * override this method. If not overridden, this method throws
+	 * {@link UnsupportedOperationException}.
+	 * @param uri the resource URI
+	 * @return {@code true} if a resource was removed
+	 */
+	default boolean removeResource(String uri) {
+		throw new UnsupportedOperationException("This ResourcesRepository does not support removing resources");
+	}
+
+	/**
+	 * Add a resource template to the repository.
+	 * <p>
+	 * Custom repositories that support {@link McpAsyncServer#addResourceTemplate} must
+	 * override this method. If not overridden, this method throws
+	 * {@link UnsupportedOperationException}.
+	 * @param resourceTemplateSpecification the resource template specification
+	 */
+	default void addResourceTemplate(
+			McpServerFeatures.AsyncResourceTemplateSpecification resourceTemplateSpecification) {
+		throw new UnsupportedOperationException("This ResourcesRepository does not support adding resource templates");
+	}
+
+	/**
+	 * Remove a resource template from the repository.
+	 * <p>
+	 * Custom repositories that support {@link McpAsyncServer#removeResourceTemplate} must
+	 * override this method. If not overridden, this method throws
+	 * {@link UnsupportedOperationException}.
+	 * @param uriTemplate the resource template URI template
+	 * @return {@code true} if a resource template was removed
+	 */
+	default boolean removeResourceTemplate(String uriTemplate) {
+		throw new UnsupportedOperationException(
+				"This ResourcesRepository does not support removing resource templates");
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/StatelessCompletionsRepository.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/StatelessCompletionsRepository.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpSchema;
+import reactor.core.publisher.Mono;
+
+/**
+ * Repository for context-aware MCP completion handler resolution in stateless servers.
+ *
+ * @author Taewoong Kim
+ */
+public interface StatelessCompletionsRepository {
+
+	Mono<McpStatelessServerFeatures.AsyncCompletionSpecification> resolveCompletion(
+			McpSchema.CompleteReference reference, McpTransportContext transportContext);
+
+	/**
+	 * Add a completion to the repository.
+	 * <p>
+	 * Custom repositories that support adding completions through this repository
+	 * contract must override this method. If not overridden, this method throws
+	 * {@link UnsupportedOperationException}.
+	 * @param completionSpecification the completion specification
+	 */
+	default void addCompletion(McpStatelessServerFeatures.AsyncCompletionSpecification completionSpecification) {
+		throw new UnsupportedOperationException(
+				"This StatelessCompletionsRepository does not support adding completions");
+	}
+
+	/**
+	 * Remove a completion from the repository.
+	 * <p>
+	 * Custom repositories that support removing completions through this repository
+	 * contract must override this method. If not overridden, this method throws
+	 * {@link UnsupportedOperationException}.
+	 * @param reference the completion reference
+	 * @return {@code true} if a completion was removed
+	 */
+	default boolean removeCompletion(McpSchema.CompleteReference reference) {
+		throw new UnsupportedOperationException(
+				"This StatelessCompletionsRepository does not support removing completions");
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/StatelessPromptsRepository.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/StatelessPromptsRepository.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpSchema;
+import reactor.core.publisher.Mono;
+
+/**
+ * Repository for context-aware MCP prompt discovery and resolution in stateless servers.
+ *
+ * @author Taewoong Kim
+ */
+public interface StatelessPromptsRepository {
+
+	Mono<McpSchema.ListPromptsResult> listPrompts(McpTransportContext transportContext,
+			McpSchema.PaginatedRequest request);
+
+	Mono<McpStatelessServerFeatures.AsyncPromptSpecification> resolvePrompt(String name,
+			McpTransportContext transportContext);
+
+	/**
+	 * Add a prompt to the repository.
+	 * <p>
+	 * Custom repositories that support {@link McpStatelessAsyncServer#addPrompt} must
+	 * override this method. If not overridden, this method throws
+	 * {@link UnsupportedOperationException}.
+	 * @param promptSpecification the prompt specification
+	 */
+	default void addPrompt(McpStatelessServerFeatures.AsyncPromptSpecification promptSpecification) {
+		throw new UnsupportedOperationException("This StatelessPromptsRepository does not support adding prompts");
+	}
+
+	/**
+	 * Remove a prompt from the repository.
+	 * <p>
+	 * Custom repositories that support {@link McpStatelessAsyncServer#removePrompt} must
+	 * override this method. If not overridden, this method throws
+	 * {@link UnsupportedOperationException}.
+	 * @param name the prompt name
+	 * @return {@code true} if a prompt was removed
+	 */
+	default boolean removePrompt(String name) {
+		throw new UnsupportedOperationException("This StatelessPromptsRepository does not support removing prompts");
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/StatelessResourcesRepository.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/StatelessResourcesRepository.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpSchema;
+import reactor.core.publisher.Mono;
+
+/**
+ * Repository for context-aware MCP resource and resource template discovery and
+ * resolution in stateless servers.
+ *
+ * @author Taewoong Kim
+ */
+public interface StatelessResourcesRepository {
+
+	Mono<McpSchema.ListResourcesResult> listResources(McpTransportContext transportContext,
+			McpSchema.PaginatedRequest request);
+
+	Mono<McpSchema.ListResourceTemplatesResult> listResourceTemplates(McpTransportContext transportContext,
+			McpSchema.PaginatedRequest request);
+
+	Mono<McpStatelessServerFeatures.AsyncResourceSpecification> resolveResource(String uri,
+			McpTransportContext transportContext);
+
+	Mono<McpStatelessServerFeatures.AsyncResourceTemplateSpecification> resolveResourceTemplate(String uri,
+			McpTransportContext transportContext);
+
+	/**
+	 * Add a resource to the repository.
+	 * <p>
+	 * Custom repositories that support {@link McpStatelessAsyncServer#addResource} must
+	 * override this method. If not overridden, this method throws
+	 * {@link UnsupportedOperationException}.
+	 * @param resourceSpecification the resource specification
+	 */
+	default void addResource(McpStatelessServerFeatures.AsyncResourceSpecification resourceSpecification) {
+		throw new UnsupportedOperationException("This StatelessResourcesRepository does not support adding resources");
+	}
+
+	/**
+	 * Remove a resource from the repository.
+	 * <p>
+	 * Custom repositories that support {@link McpStatelessAsyncServer#removeResource}
+	 * must override this method. If not overridden, this method throws
+	 * {@link UnsupportedOperationException}.
+	 * @param uri the resource URI
+	 * @return {@code true} if a resource was removed
+	 */
+	default boolean removeResource(String uri) {
+		throw new UnsupportedOperationException(
+				"This StatelessResourcesRepository does not support removing resources");
+	}
+
+	/**
+	 * Add a resource template to the repository.
+	 * <p>
+	 * Custom repositories that support
+	 * {@link McpStatelessAsyncServer#addResourceTemplate} must override this method. If
+	 * not overridden, this method throws {@link UnsupportedOperationException}.
+	 * @param resourceTemplateSpecification the resource template specification
+	 */
+	default void addResourceTemplate(
+			McpStatelessServerFeatures.AsyncResourceTemplateSpecification resourceTemplateSpecification) {
+		throw new UnsupportedOperationException(
+				"This StatelessResourcesRepository does not support adding resource templates");
+	}
+
+	/**
+	 * Remove a resource template from the repository.
+	 * <p>
+	 * Custom repositories that support
+	 * {@link McpStatelessAsyncServer#removeResourceTemplate} must override this method.
+	 * If not overridden, this method throws {@link UnsupportedOperationException}.
+	 * @param uriTemplate the resource template URI template
+	 * @return {@code true} if a resource template was removed
+	 */
+	default boolean removeResourceTemplate(String uriTemplate) {
+		throw new UnsupportedOperationException(
+				"This StatelessResourcesRepository does not support removing resource templates");
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/StatelessToolsRepository.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/StatelessToolsRepository.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpSchema;
+import reactor.core.publisher.Mono;
+
+/**
+ * Repository for context-aware MCP tool discovery and resolution in stateless servers.
+ *
+ * @author Taewoong Kim
+ */
+public interface StatelessToolsRepository {
+
+	Mono<McpSchema.ListToolsResult> listTools(McpTransportContext transportContext, McpSchema.PaginatedRequest request);
+
+	Mono<McpStatelessServerFeatures.AsyncToolSpecification> resolveTool(String name,
+			McpTransportContext transportContext);
+
+	/**
+	 * Add a tool to the repository.
+	 * <p>
+	 * Custom repositories that support {@link McpStatelessAsyncServer#addTool} must
+	 * override this method. If not overridden, this method throws
+	 * {@link UnsupportedOperationException}.
+	 * @param toolSpecification the tool specification
+	 */
+	default void addTool(McpStatelessServerFeatures.AsyncToolSpecification toolSpecification) {
+		throw new UnsupportedOperationException("This StatelessToolsRepository does not support adding tools");
+	}
+
+	/**
+	 * Remove a tool from the repository.
+	 * <p>
+	 * Custom repositories that support {@link McpStatelessAsyncServer#removeTool} must
+	 * override this method. If not overridden, this method throws
+	 * {@link UnsupportedOperationException}.
+	 * @param name the tool name
+	 * @return {@code true} if a tool was removed
+	 */
+	default boolean removeTool(String name) {
+		throw new UnsupportedOperationException("This StatelessToolsRepository does not support removing tools");
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/ToolsRepository.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/ToolsRepository.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import reactor.core.publisher.Mono;
+
+/**
+ * Repository for context-aware MCP tool discovery and resolution.
+ *
+ * @author Taewoong Kim
+ */
+public interface ToolsRepository {
+
+	/**
+	 * List tools visible to the current exchange.
+	 * @param exchange the current client exchange, or {@code null} for context-free
+	 * listing
+	 * @param request the paginated request parameters
+	 * @return the visible tools and optional next cursor
+	 */
+	Mono<McpSchema.ListToolsResult> listTools(McpAsyncServerExchange exchange, McpSchema.PaginatedRequest request);
+
+	/**
+	 * Resolve a tool that is allowed to be called in the current exchange.
+	 * @param name the tool name
+	 * @param exchange the current client exchange
+	 * @return the tool specification, or empty if the tool is not found or not allowed
+	 */
+	Mono<McpServerFeatures.AsyncToolSpecification> resolveTool(String name, McpAsyncServerExchange exchange);
+
+	/**
+	 * Add a tool to the repository.
+	 * <p>
+	 * Custom repositories that support {@link McpAsyncServer#addTool} must override this
+	 * method. If not overridden, this method throws
+	 * {@link UnsupportedOperationException}.
+	 * @param toolSpecification the tool specification
+	 */
+	default void addTool(McpServerFeatures.AsyncToolSpecification toolSpecification) {
+		throw new UnsupportedOperationException("This ToolsRepository does not support adding tools");
+	}
+
+	/**
+	 * Remove a tool from the repository.
+	 * <p>
+	 * Custom repositories that support {@link McpAsyncServer#removeTool} must override
+	 * this method. If not overridden, this method throws
+	 * {@link UnsupportedOperationException}.
+	 * @param name the tool name
+	 * @return {@code true} if a tool was removed
+	 */
+	default boolean removeTool(String name) {
+		throw new UnsupportedOperationException("This ToolsRepository does not support removing tools");
+	}
+
+}

--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/PrimitiveRepositoryTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/PrimitiveRepositoryTests.java
@@ -1,0 +1,681 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
+import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.spec.json.gson.GsonMcpJsonMapper;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.JSONRPCMessage;
+import io.modelcontextprotocol.spec.McpSchema.JSONRPCNotification;
+import io.modelcontextprotocol.spec.McpSchema.JSONRPCRequest;
+import io.modelcontextprotocol.spec.McpSchema.JSONRPCResponse;
+import io.modelcontextprotocol.spec.McpServerSession;
+import io.modelcontextprotocol.spec.McpServerTransport;
+import io.modelcontextprotocol.spec.McpServerTransportProvider;
+import io.modelcontextprotocol.spec.McpStatelessServerTransport;
+import io.modelcontextprotocol.spec.ProtocolVersions;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import static io.modelcontextprotocol.util.ToolsUtils.EMPTY_JSON_SCHEMA;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for dynamic MCP primitive repositories.
+ *
+ * @author Taewoong Kim
+ */
+class PrimitiveRepositoryTests {
+
+	private static final String USER_KEY = "user";
+
+	@Test
+	void toolsRepositoryControlsListAndCallVisibilityPerRequestContext() {
+		CapturingServerTransportProvider provider = new CapturingServerTransportProvider();
+		McpServer.async(provider)
+			.jsonMapper(new GsonMcpJsonMapper())
+			.jsonSchemaValidator(VALID_SCHEMA_VALIDATOR)
+			.toolsRepository(new UserAwareToolsRepository())
+			.build();
+		MockServerTransport transport = new MockServerTransport();
+		McpServerSession session = initializedSession(provider, transport);
+
+		JSONRPCResponse aliceListResponse = handleWithUser(session, transport,
+				new JSONRPCRequest(McpSchema.METHOD_TOOLS_LIST, "alice-tools", new McpSchema.PaginatedRequest()),
+				"alice");
+		assertThat(aliceListResponse.error()).isNull();
+		assertThat((McpSchema.ListToolsResult) aliceListResponse.result()).satisfies(result -> {
+			assertThat(result.tools()).extracting(McpSchema.Tool::name).containsExactly("alice-tool");
+		});
+
+		JSONRPCResponse bobListResponse = handleWithUser(session, transport,
+				new JSONRPCRequest(McpSchema.METHOD_TOOLS_LIST, "bob-tools", new McpSchema.PaginatedRequest()), "bob");
+		assertThat(bobListResponse.error()).isNull();
+		assertThat((McpSchema.ListToolsResult) bobListResponse.result()).satisfies(result -> {
+			assertThat(result.tools()).extracting(McpSchema.Tool::name).containsExactly("bob-tool");
+		});
+
+		JSONRPCResponse forbiddenCallResponse = handleWithUser(session, transport,
+				new JSONRPCRequest(McpSchema.METHOD_TOOLS_CALL, "alice-calls-bob",
+						McpSchema.CallToolRequest.builder("bob-tool").build()),
+				"alice");
+		assertThat(forbiddenCallResponse.error()).isNotNull();
+
+		JSONRPCResponse bobCallResponse = handleWithUser(session, transport,
+				new JSONRPCRequest(McpSchema.METHOD_TOOLS_CALL, "bob-calls-bob",
+						McpSchema.CallToolRequest.builder("bob-tool").build()),
+				"bob");
+		assertThat(bobCallResponse.error()).isNull();
+		assertThat((McpSchema.CallToolResult) bobCallResponse.result()).satisfies(result -> {
+			assertThat(text(result.content().get(0))).isEqualTo("bob-tool");
+		});
+	}
+
+	@Test
+	void resourcesRepositoryControlsListAndReadVisibilityPerRequestContext() {
+		CapturingServerTransportProvider provider = new CapturingServerTransportProvider();
+		McpServer.async(provider)
+			.jsonMapper(new GsonMcpJsonMapper())
+			.jsonSchemaValidator(VALID_SCHEMA_VALIDATOR)
+			.resourcesRepository(new UserAwareResourcesRepository())
+			.build();
+		MockServerTransport transport = new MockServerTransport();
+		McpServerSession session = initializedSession(provider, transport);
+
+		JSONRPCResponse aliceListResponse = handleWithUser(session, transport, new JSONRPCRequest(
+				McpSchema.METHOD_RESOURCES_LIST, "alice-resources", new McpSchema.PaginatedRequest()), "alice");
+		assertThat(aliceListResponse.error()).isNull();
+		assertThat((McpSchema.ListResourcesResult) aliceListResponse.result()).satisfies(result -> {
+			assertThat(result.resources()).extracting(McpSchema.Resource::uri).containsExactly(resourceUri("alice"));
+		});
+
+		JSONRPCResponse aliceTemplateListResponse = handleWithUser(session, transport,
+				new JSONRPCRequest(McpSchema.METHOD_RESOURCES_TEMPLATES_LIST, "alice-resource-templates",
+						new McpSchema.PaginatedRequest()),
+				"alice");
+		assertThat(aliceTemplateListResponse.error()).isNull();
+		assertThat((McpSchema.ListResourceTemplatesResult) aliceTemplateListResponse.result()).satisfies(result -> {
+			assertThat(result.resourceTemplates()).extracting(McpSchema.ResourceTemplate::uriTemplate)
+				.containsExactly(resourceTemplateUri("alice"));
+		});
+
+		JSONRPCResponse forbiddenReadResponse = handleWithUser(session, transport,
+				new JSONRPCRequest(McpSchema.METHOD_RESOURCES_READ, "alice-reads-bob",
+						McpSchema.ReadResourceRequest.builder(resourceUri("bob")).build()),
+				"alice");
+		assertThat(forbiddenReadResponse.error()).isNotNull();
+
+		JSONRPCResponse forbiddenTemplateReadResponse = handleWithUser(session, transport,
+				new JSONRPCRequest(McpSchema.METHOD_RESOURCES_READ, "alice-reads-bob-template",
+						McpSchema.ReadResourceRequest.builder(resourceTemplateReadUri("bob")).build()),
+				"alice");
+		assertThat(forbiddenTemplateReadResponse.error()).isNotNull();
+
+		JSONRPCResponse bobReadResponse = handleWithUser(session, transport,
+				new JSONRPCRequest(McpSchema.METHOD_RESOURCES_READ, "bob-reads-bob",
+						McpSchema.ReadResourceRequest.builder(resourceUri("bob")).build()),
+				"bob");
+		assertThat(bobReadResponse.error()).isNull();
+		assertThat((McpSchema.ReadResourceResult) bobReadResponse.result()).satisfies(result -> {
+			assertThat(((McpSchema.TextResourceContents) result.contents().get(0)).text()).isEqualTo("bob-resource");
+		});
+
+		JSONRPCResponse bobTemplateReadResponse = handleWithUser(session, transport,
+				new JSONRPCRequest(McpSchema.METHOD_RESOURCES_READ, "bob-reads-bob-template",
+						McpSchema.ReadResourceRequest.builder(resourceTemplateReadUri("bob")).build()),
+				"bob");
+		assertThat(bobTemplateReadResponse.error()).isNull();
+		assertThat((McpSchema.ReadResourceResult) bobTemplateReadResponse.result()).satisfies(result -> {
+			assertThat(((McpSchema.TextResourceContents) result.contents().get(0)).text())
+				.isEqualTo("bob-resource-template");
+		});
+	}
+
+	@Test
+	void promptsRepositoryControlsListAndGetVisibilityPerRequestContext() {
+		CapturingServerTransportProvider provider = new CapturingServerTransportProvider();
+		McpServer.async(provider)
+			.jsonMapper(new GsonMcpJsonMapper())
+			.jsonSchemaValidator(VALID_SCHEMA_VALIDATOR)
+			.promptsRepository(new UserAwarePromptsRepository())
+			.build();
+		MockServerTransport transport = new MockServerTransport();
+		McpServerSession session = initializedSession(provider, transport);
+
+		JSONRPCResponse aliceListResponse = handleWithUser(session, transport,
+				new JSONRPCRequest(McpSchema.METHOD_PROMPT_LIST, "alice-prompts", new McpSchema.PaginatedRequest()),
+				"alice");
+		assertThat(aliceListResponse.error()).isNull();
+		assertThat((McpSchema.ListPromptsResult) aliceListResponse.result()).satisfies(result -> {
+			assertThat(result.prompts()).extracting(McpSchema.Prompt::name).containsExactly(promptName("alice"));
+		});
+
+		JSONRPCResponse forbiddenGetResponse = handleWithUser(session, transport,
+				new JSONRPCRequest(McpSchema.METHOD_PROMPT_GET, "alice-gets-bob",
+						McpSchema.GetPromptRequest.builder(promptName("bob")).build()),
+				"alice");
+		assertThat(forbiddenGetResponse.error()).isNotNull();
+
+		JSONRPCResponse bobGetResponse = handleWithUser(session, transport,
+				new JSONRPCRequest(McpSchema.METHOD_PROMPT_GET, "bob-gets-bob",
+						McpSchema.GetPromptRequest.builder(promptName("bob")).build()),
+				"bob");
+		assertThat(bobGetResponse.error()).isNull();
+		assertThat((McpSchema.GetPromptResult) bobGetResponse.result()).satisfies(result -> {
+			assertThat(text(result.messages().get(0).content())).isEqualTo("bob-prompt");
+		});
+	}
+
+	@Test
+	void inMemoryToolsRepositoryReplacesDuplicateTools() {
+		InMemoryToolsRepository repository = new InMemoryToolsRepository();
+
+		repository.addTool(toolSpec("duplicate-tool", "first"));
+		repository.addTool(toolSpec("duplicate-tool", "second"));
+
+		McpSchema.ListToolsResult result = repository.listTools(null, new McpSchema.PaginatedRequest()).block();
+
+		assertThat(result).isNotNull();
+		assertThat(result.tools()).hasSize(1);
+		assertThat(result.tools().get(0).description()).isEqualTo("second");
+		assertThat(repository.removeTool("duplicate-tool")).isTrue();
+		assertThat(repository.removeTool("duplicate-tool")).isFalse();
+	}
+
+	@Test
+	void inMemoryResourcesRepositoryResolvesResourcesAndTemplates() {
+		InMemoryResourcesRepository repository = new InMemoryResourcesRepository();
+		var resource = McpSchema.Resource.builder("file:///docs/static.txt", "Static doc").build();
+		var templatedDirectResource = McpSchema.Resource
+			.builder("file:///direct/{name}.txt", "Direct template-like doc")
+			.build();
+		var template = McpSchema.ResourceTemplate.builder("file:///docs/{name}.txt", "Doc template").build();
+
+		repository.addResource(new McpServerFeatures.AsyncResourceSpecification(resource,
+				(exchange, request) -> Mono.just(McpSchema.ReadResourceResult.builder(List.of()).build())));
+		repository.addResource(new McpServerFeatures.AsyncResourceSpecification(templatedDirectResource,
+				(exchange, request) -> Mono.just(McpSchema.ReadResourceResult.builder(List.of()).build())));
+		repository.addResourceTemplate(new McpServerFeatures.AsyncResourceTemplateSpecification(template,
+				(exchange, request) -> Mono.just(McpSchema.ReadResourceResult.builder(List.of()).build())));
+
+		assertThat(repository.resolveResource("file:///docs/static.txt", null).block()).isNotNull();
+		assertThat(repository.resolveResource("file:///docs/static.txt/extra", null).block()).isNull();
+		assertThat(repository.resolveResource("file:///direct/readme.txt", null).block()).isNotNull();
+		assertThat(repository.resolveResourceTemplate("file:///docs/guide.txt", null).block()).isNotNull();
+		assertThat(repository.listResourceTemplates(null, new McpSchema.PaginatedRequest()).block().resourceTemplates())
+			.extracting(McpSchema.ResourceTemplate::uriTemplate)
+			.containsExactly("file:///docs/{name}.txt");
+	}
+
+	@Test
+	void serverPassesCursorToCustomToolsRepository() {
+		CapturingServerTransportProvider provider = new CapturingServerTransportProvider();
+		CursorAwareToolsRepository repository = new CursorAwareToolsRepository();
+
+		McpServer.async(provider)
+			.jsonMapper(new GsonMcpJsonMapper())
+			.jsonSchemaValidator(VALID_SCHEMA_VALIDATOR)
+			.toolsRepository(repository)
+			.build();
+
+		MockServerTransport transport = new MockServerTransport();
+		McpServerSession session = initializedSession(provider, transport);
+		session
+			.handle(new JSONRPCRequest(McpSchema.METHOD_TOOLS_LIST, "tools",
+					new McpSchema.PaginatedRequest("cursor-1")))
+			.block();
+
+		JSONRPCResponse response = (JSONRPCResponse) transport.sent.get(transport.sent.size() - 1);
+
+		assertThat(repository.receivedCursor.get()).isEqualTo("cursor-1");
+		assertThat(response.error()).isNull();
+		assertThat((McpSchema.ListToolsResult) response.result()).satisfies(result -> {
+			assertThat(result.tools()).extracting(McpSchema.Tool::name).containsExactly("visible-tool");
+			assertThat(result.nextCursor()).isEqualTo("cursor-2");
+		});
+	}
+
+	@Test
+	void runtimeToolMutationRequiresRepositoryMutationSupport() {
+		McpAsyncServer server = McpServer.async(new CapturingServerTransportProvider())
+			.jsonMapper(new GsonMcpJsonMapper())
+			.jsonSchemaValidator(VALID_SCHEMA_VALIDATOR)
+			.toolsRepository(new CursorAwareToolsRepository())
+			.build();
+
+		assertThatThrownBy(() -> server.addTool(toolSpec("runtime-tool", "Runtime tool")).block())
+			.isInstanceOf(UnsupportedOperationException.class)
+			.hasMessageContaining("does not support adding tools");
+		assertThatThrownBy(() -> server.removeTool("runtime-tool").block())
+			.isInstanceOf(UnsupportedOperationException.class)
+			.hasMessageContaining("does not support removing tools");
+	}
+
+	@Test
+	void statefulRuntimeRepositoryMutationsSendListChangedNotificationsForSupportedOperations() {
+		CapturingServerTransportProvider provider = new CapturingServerTransportProvider();
+		McpAsyncServer server = McpServer.async(provider)
+			.jsonMapper(new GsonMcpJsonMapper())
+			.jsonSchemaValidator(VALID_SCHEMA_VALIDATOR)
+			.capabilities(
+					McpSchema.ServerCapabilities.builder().tools(true).resources(false, true).prompts(true).build())
+			.toolsRepository(new InMemoryToolsRepository())
+			.resourcesRepository(new InMemoryResourcesRepository())
+			.promptsRepository(new InMemoryPromptsRepository())
+			.build();
+
+		server.addTool(toolSpec("runtime-tool", "Runtime tool")).block();
+		server.removeTool("runtime-tool").block();
+		server.addResource(UserAwareResourcesRepository.resourceSpecification("runtime")).block();
+		server.removeResource(resourceUri("runtime")).block();
+		server.addResourceTemplate(UserAwareResourcesRepository.resourceTemplateSpecification("runtime")).block();
+		server.removeResourceTemplate(resourceTemplateUri("runtime")).block();
+		server.addPrompt(UserAwarePromptsRepository.promptSpecification("runtime")).block();
+		server.removePrompt(promptName("runtime")).block();
+
+		assertThat(provider.notifiedMethods).containsExactly(McpSchema.METHOD_NOTIFICATION_TOOLS_LIST_CHANGED,
+				McpSchema.METHOD_NOTIFICATION_TOOLS_LIST_CHANGED, McpSchema.METHOD_NOTIFICATION_RESOURCES_LIST_CHANGED,
+				McpSchema.METHOD_NOTIFICATION_RESOURCES_LIST_CHANGED,
+				McpSchema.METHOD_NOTIFICATION_RESOURCES_LIST_CHANGED,
+				McpSchema.METHOD_NOTIFICATION_PROMPTS_LIST_CHANGED, McpSchema.METHOD_NOTIFICATION_PROMPTS_LIST_CHANGED);
+	}
+
+	@Test
+	void statefulCompletionRepositoryEnablesCompletionCapability() {
+		var serverInfo = McpSchema.Implementation.builder("test-server", "1.0.0").build();
+		var features = new McpServerFeatures.Async(serverInfo, null, List.of(), null, Map.of(), Map.of(), null,
+				Map.of(), null, Map.of(), new InMemoryCompletionsRepository(), List.of(), null);
+
+		assertThat(features.serverCapabilities().completions()).isNotNull();
+	}
+
+	@Test
+	void statelessCompletionRepositoryEnablesCompletionCapability() {
+		var serverInfo = McpSchema.Implementation.builder("test-server", "1.0.0").build();
+		var features = new McpStatelessServerFeatures.Async(serverInfo, null, List.of(), null, Map.of(), Map.of(), null,
+				Map.of(), null, Map.of(), new InMemoryStatelessCompletionsRepository(), null);
+
+		assertThat(features.serverCapabilities().completions()).isNotNull();
+	}
+
+	@Test
+	void statefulSyncBuilderAcceptsCustomRepositories() {
+		CapturingServerTransportProvider provider = new CapturingServerTransportProvider();
+
+		McpSyncServer server = McpServer.sync(provider)
+			.jsonMapper(new GsonMcpJsonMapper())
+			.jsonSchemaValidator(VALID_SCHEMA_VALIDATOR)
+			.toolsRepository(new InMemoryToolsRepository())
+			.build();
+
+		assertThat(server.getServerCapabilities().tools()).isNotNull();
+	}
+
+	@Test
+	void statelessSyncBuilderAcceptsCustomRepositories() {
+		MockStatelessServerTransport transport = new MockStatelessServerTransport();
+
+		McpStatelessSyncServer server = McpServer.sync(transport)
+			.jsonMapper(new GsonMcpJsonMapper())
+			.jsonSchemaValidator(VALID_SCHEMA_VALIDATOR)
+			.toolsRepository(new InMemoryStatelessToolsRepository())
+			.build();
+
+		assertThat(server.getServerCapabilities().tools()).isNotNull();
+	}
+
+	@Test
+	void statefulBuilderRejectsToolsRepositoryMixedWithStaticTools() {
+		var tool = toolSpec("static-tool", "Static tool").tool();
+
+		assertThatThrownBy(() -> McpServer.async(new CapturingServerTransportProvider())
+			.jsonSchemaValidator(VALID_SCHEMA_VALIDATOR)
+			.toolsRepository(new InMemoryToolsRepository())
+			.toolCall(tool, (exchange, request) -> Mono.just(emptyCallToolResult())))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("toolsRepository");
+
+		assertThatThrownBy(() -> McpServer.async(new CapturingServerTransportProvider())
+			.jsonSchemaValidator(VALID_SCHEMA_VALIDATOR)
+			.toolCall(tool, (exchange, request) -> Mono.just(emptyCallToolResult()))
+			.toolsRepository(new InMemoryToolsRepository())).isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("toolsRepository");
+	}
+
+	@Test
+	void statefulBuilderRejectsResourcesRepositoryMixedWithStaticResources() {
+		var resource = McpSchema.Resource.builder("file:///docs/static.txt", "Static doc").build();
+		var resourceSpec = new McpServerFeatures.AsyncResourceSpecification(resource,
+				(exchange, request) -> Mono.just(McpSchema.ReadResourceResult.builder(List.of()).build()));
+		var template = McpSchema.ResourceTemplate.builder("file:///docs/{name}.txt", "Doc template").build();
+		var templateSpec = new McpServerFeatures.AsyncResourceTemplateSpecification(template,
+				(exchange, request) -> Mono.just(McpSchema.ReadResourceResult.builder(List.of()).build()));
+
+		assertThatThrownBy(() -> McpServer.async(new CapturingServerTransportProvider())
+			.resourcesRepository(new InMemoryResourcesRepository())
+			.resources(resourceSpec)).isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("resourcesRepository");
+
+		assertThatThrownBy(() -> McpServer.async(new CapturingServerTransportProvider())
+			.resourceTemplates(templateSpec)
+			.resourcesRepository(new InMemoryResourcesRepository())).isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("resourcesRepository");
+	}
+
+	@Test
+	void statelessBuilderRejectsToolsRepositoryMixedWithStaticTools() {
+		var tool = McpSchema.Tool.builder().name("stateless-static-tool").inputSchema(EMPTY_JSON_SCHEMA).build();
+
+		assertThatThrownBy(() -> McpServer.async(new MockStatelessServerTransport())
+			.jsonSchemaValidator(VALID_SCHEMA_VALIDATOR)
+			.toolsRepository(new InMemoryStatelessToolsRepository())
+			.toolCall(tool, (context, request) -> Mono.just(emptyCallToolResult())))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("toolsRepository");
+	}
+
+	private McpServerFeatures.AsyncToolSpecification toolSpec(String name, String description) {
+		McpSchema.Tool tool = McpSchema.Tool.builder()
+			.name(name)
+			.description(description)
+			.inputSchema(EMPTY_JSON_SCHEMA)
+			.build();
+		return McpServerFeatures.AsyncToolSpecification.builder()
+			.tool(tool)
+			.callHandler((exchange, request) -> Mono.just(emptyCallToolResult()))
+			.build();
+	}
+
+	private static CallToolResult emptyCallToolResult() {
+		return CallToolResult.builder().content(List.of()).isError(false).build();
+	}
+
+	private static McpServerSession initializedSession(CapturingServerTransportProvider provider,
+			MockServerTransport transport) {
+		McpServerSession session = provider.sessionFactory.create(transport);
+		session
+			.handle(new JSONRPCRequest(McpSchema.METHOD_INITIALIZE, "init",
+					McpSchema.InitializeRequest.builder(ProtocolVersions.MCP_2025_11_25,
+							new McpSchema.ClientCapabilities(null, null, null, null),
+							McpSchema.Implementation.builder("test-client", "1.0.0").build())
+						.build()))
+			.block();
+		session.handle(new JSONRPCNotification(McpSchema.METHOD_NOTIFICATION_INITIALIZED)).block();
+		return session;
+	}
+
+	private static JSONRPCResponse handleWithUser(McpServerSession session, MockServerTransport transport,
+			JSONRPCRequest request, String user) {
+		session.handle(request)
+			.contextWrite(ctx -> ctx.put(McpTransportContext.KEY, McpTransportContext.create(Map.of(USER_KEY, user))))
+			.block();
+		return (JSONRPCResponse) transport.sent.get(transport.sent.size() - 1);
+	}
+
+	private static String user(McpAsyncServerExchange exchange) {
+		return user((exchange != null) ? exchange.transportContext() : McpTransportContext.EMPTY);
+	}
+
+	private static String user(McpTransportContext transportContext) {
+		Object user = transportContext.get(USER_KEY);
+		return (user != null) ? user.toString() : "anonymous";
+	}
+
+	private static String toolName(String user) {
+		return user + "-tool";
+	}
+
+	private static String resourceUri(String user) {
+		return "test://resources/" + user;
+	}
+
+	private static String resourceTemplateUri(String user) {
+		return "test://resource-templates/" + user + "/{name}";
+	}
+
+	private static String resourceTemplateReadUri(String user) {
+		return "test://resource-templates/" + user + "/guide";
+	}
+
+	private static String promptName(String user) {
+		return user + "-prompt";
+	}
+
+	private static String text(McpSchema.Content content) {
+		return ((McpSchema.TextContent) content).text();
+	}
+
+	private static final JsonSchemaValidator VALID_SCHEMA_VALIDATOR = new JsonSchemaValidator() {
+
+		@Override
+		public ValidationResponse validate(Map<String, Object> schema, Object structuredContent) {
+			return ValidationResponse.asValid(null);
+		}
+
+	};
+
+	private static final class UserAwareToolsRepository implements ToolsRepository {
+
+		@Override
+		public Mono<McpSchema.ListToolsResult> listTools(McpAsyncServerExchange exchange,
+				McpSchema.PaginatedRequest request) {
+			return Mono
+				.just(McpSchema.ListToolsResult.builder(List.of(toolSpecification(user(exchange)).tool())).build());
+		}
+
+		@Override
+		public Mono<McpServerFeatures.AsyncToolSpecification> resolveTool(String name,
+				McpAsyncServerExchange exchange) {
+			String user = user(exchange);
+			if (!toolName(user).equals(name)) {
+				return Mono.empty();
+			}
+			return Mono.just(toolSpecification(user));
+		}
+
+		private static McpServerFeatures.AsyncToolSpecification toolSpecification(String user) {
+			McpSchema.Tool tool = McpSchema.Tool.builder().name(toolName(user)).inputSchema(EMPTY_JSON_SCHEMA).build();
+			return new McpServerFeatures.AsyncToolSpecification(tool, (exchange, request) -> Mono
+				.just(CallToolResult.builder().addTextContent(toolName(user(exchange))).build()));
+		}
+
+	}
+
+	private static final class UserAwareResourcesRepository implements ResourcesRepository {
+
+		@Override
+		public Mono<McpSchema.ListResourcesResult> listResources(McpAsyncServerExchange exchange,
+				McpSchema.PaginatedRequest request) {
+			return Mono.just(McpSchema.ListResourcesResult.builder(List.of(resource(user(exchange)))).build());
+		}
+
+		@Override
+		public Mono<McpSchema.ListResourceTemplatesResult> listResourceTemplates(McpAsyncServerExchange exchange,
+				McpSchema.PaginatedRequest request) {
+			return Mono
+				.just(McpSchema.ListResourceTemplatesResult.builder(List.of(resourceTemplate(user(exchange)))).build());
+		}
+
+		@Override
+		public Mono<McpServerFeatures.AsyncResourceSpecification> resolveResource(String uri,
+				McpAsyncServerExchange exchange) {
+			String user = user(exchange);
+			if (!resourceUri(user).equals(uri)) {
+				return Mono.empty();
+			}
+			return Mono.just(resourceSpecification(user));
+		}
+
+		@Override
+		public Mono<McpServerFeatures.AsyncResourceTemplateSpecification> resolveResourceTemplate(String uri,
+				McpAsyncServerExchange exchange) {
+			String user = user(exchange);
+			if (!uri.startsWith("test://resource-templates/" + user + "/")) {
+				return Mono.empty();
+			}
+			return Mono.just(resourceTemplateSpecification(user));
+		}
+
+		private static McpServerFeatures.AsyncResourceSpecification resourceSpecification(String user) {
+			return new McpServerFeatures.AsyncResourceSpecification(resource(user), (exchange, request) -> {
+				var content = McpSchema.TextResourceContents.builder(request.uri(), user(exchange) + "-resource")
+					.mimeType("text/plain")
+					.build();
+				return Mono.just(McpSchema.ReadResourceResult.builder(List.of(content)).build());
+			});
+		}
+
+		private static McpSchema.Resource resource(String user) {
+			return McpSchema.Resource.builder(resourceUri(user), user + " resource").build();
+		}
+
+		private static McpServerFeatures.AsyncResourceTemplateSpecification resourceTemplateSpecification(String user) {
+			return new McpServerFeatures.AsyncResourceTemplateSpecification(resourceTemplate(user),
+					(exchange, request) -> {
+						var content = McpSchema.TextResourceContents
+							.builder(request.uri(), user(exchange) + "-resource-template")
+							.mimeType("text/plain")
+							.build();
+						return Mono.just(McpSchema.ReadResourceResult.builder(List.of(content)).build());
+					});
+		}
+
+		private static McpSchema.ResourceTemplate resourceTemplate(String user) {
+			return McpSchema.ResourceTemplate.builder(resourceTemplateUri(user), user + " resource template").build();
+		}
+
+	}
+
+	private static final class UserAwarePromptsRepository implements PromptsRepository {
+
+		@Override
+		public Mono<McpSchema.ListPromptsResult> listPrompts(McpAsyncServerExchange exchange,
+				McpSchema.PaginatedRequest request) {
+			return Mono.just(McpSchema.ListPromptsResult.builder(List.of(prompt(user(exchange)))).build());
+		}
+
+		@Override
+		public Mono<McpServerFeatures.AsyncPromptSpecification> resolvePrompt(String name,
+				McpAsyncServerExchange exchange) {
+			String user = user(exchange);
+			if (!promptName(user).equals(name)) {
+				return Mono.empty();
+			}
+			return Mono.just(promptSpecification(user));
+		}
+
+		private static McpServerFeatures.AsyncPromptSpecification promptSpecification(String user) {
+			return new McpServerFeatures.AsyncPromptSpecification(prompt(user), (exchange, request) -> {
+				var message = McpSchema.PromptMessage
+					.builder(McpSchema.Role.USER, McpSchema.TextContent.builder(user(exchange) + "-prompt").build())
+					.build();
+				return Mono.just(McpSchema.GetPromptResult.builder(List.of(message)).build());
+			});
+		}
+
+		private static McpSchema.Prompt prompt(String user) {
+			return McpSchema.Prompt.builder(promptName(user)).build();
+		}
+
+	}
+
+	private static final class CursorAwareToolsRepository implements ToolsRepository {
+
+		private final AtomicReference<String> receivedCursor = new AtomicReference<>();
+
+		@Override
+		public Mono<McpSchema.ListToolsResult> listTools(McpAsyncServerExchange exchange,
+				McpSchema.PaginatedRequest request) {
+			this.receivedCursor.set(request.cursor());
+			var tool = McpSchema.Tool.builder().name("visible-tool").inputSchema(EMPTY_JSON_SCHEMA).build();
+			return Mono.just(McpSchema.ListToolsResult.builder(List.of(tool)).nextCursor("cursor-2").build());
+		}
+
+		@Override
+		public Mono<McpServerFeatures.AsyncToolSpecification> resolveTool(String name,
+				McpAsyncServerExchange exchange) {
+			return Mono.empty();
+		}
+
+	}
+
+	private static final class CapturingServerTransportProvider implements McpServerTransportProvider {
+
+		private McpServerSession.Factory sessionFactory;
+
+		private final List<String> notifiedMethods = new ArrayList<>();
+
+		@Override
+		public void setSessionFactory(McpServerSession.Factory sessionFactory) {
+			this.sessionFactory = sessionFactory;
+		}
+
+		@Override
+		public Mono<Void> notifyClients(String method, Object params) {
+			this.notifiedMethods.add(method);
+			return Mono.empty();
+		}
+
+		@Override
+		public Mono<Void> closeGracefully() {
+			return Mono.empty();
+		}
+
+		@Override
+		public List<String> protocolVersions() {
+			return List.of(ProtocolVersions.MCP_2025_11_25);
+		}
+
+	}
+
+	private static final class MockServerTransport implements McpServerTransport {
+
+		private final List<JSONRPCMessage> sent = new ArrayList<>();
+
+		@Override
+		public Mono<Void> closeGracefully() {
+			return Mono.empty();
+		}
+
+		@Override
+		public Mono<Void> sendMessage(JSONRPCMessage message) {
+			this.sent.add(message);
+			return Mono.empty();
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+			return (T) data;
+		}
+
+	}
+
+	private static final class MockStatelessServerTransport implements McpStatelessServerTransport {
+
+		private McpStatelessServerHandler handler;
+
+		@Override
+		public void setMcpHandler(McpStatelessServerHandler mcpHandler) {
+			this.handler = mcpHandler;
+		}
+
+		@Override
+		public Mono<Void> closeGracefully() {
+			return Mono.empty();
+		}
+
+	}
+
+}


### PR DESCRIPTION
Adds request-aware, pluggable repository APIs for dynamic MCP server primitives: tools, resources, prompts, and completions.

This allows server implementations to resolve visible primitives from request/session context, while preserving the existing static in-memory registration behavior by default.

Fixes #578

## Motivation and Context

Some MCP servers need to expose different tools, resources, prompts, or completion handlers depending on the authenticated user, tenant, token, or request context.

This change makes primitive discovery and resolution request-aware:

- `*/list` responses can be scoped per request context
- follow-up operations such as `tools/call`, `resources/read`, `prompts/get`, and `completion/complete` resolve through the same request-aware repositories
- custom implementations can choose their own pagination and cursor handling
- existing static registration methods continue to work through default in-memory repositories

## How Has This Been Tested?

Added unit and in-process server tests for the new repository path, including request-context based tool/resource/prompt visibility, completion capability wiring, cursor forwarding, runtime add/remove behavior, repository/static registration conflict validation, and stateful list-changed notifications for supported runtime mutations.

I tested the change locally end-to-end with a small servlet server and a Postman collection.

The test server returns different tools, resources, prompts, and completions based on the `X-User` request header, so I could verify that listing and resolution both go through the repository layer. I also checked runtime add/remove behavior and stateful list-changed notifications.

---

<img width="1240" height="635" alt="dynamic_mcp_test" src="https://github.com/user-attachments/assets/4008a5c6-af62-479d-a2b6-7bc074747c1b" />

---

Files used for the local test:

[DynamicRepositoryDemoServlet.java](https://github.com/user-attachments/files/27605665/DynamicRepositoryDemoServlet.java)

[dynamic-repository-demo.postman_collection.json](https://github.com/user-attachments/files/27604740/dynamic-repository-demo.postman_collection.json)

I attached the servlet and Postman collection so the same checks can be reproduced locally.


## Breaking Changes

None intended.

Existing static registrations continue to work. When no custom repository is provided, registrations are loaded into default in-memory repositories.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Design notes:

- Static registrations and custom repositories cannot be mixed for the same primitive family. This avoids implicit SDK-level merge semantics.
- Repository list methods receive `McpSchema.PaginatedRequest`, so custom implementations can choose whether and how to apply pagination and cursor handling.
