### PR TITLE
fix(server): serialize servlet errors as JSON-RPC envelopes

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletJsonRpcErrorWriter.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletJsonRpcErrorWriter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server.transport;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Writes JSON-RPC error response bodies for servlet transports.
+ *
+ * @author Taewoong Kim
+ */
+final class HttpServletJsonRpcErrorWriter {
+
+	private static final String UTF_8 = "UTF-8";
+
+	private static final String APPLICATION_JSON = "application/json";
+
+	private HttpServletJsonRpcErrorWriter() {
+	}
+
+	static void writeError(McpJsonMapper jsonMapper, HttpServletResponse response, int httpStatus, Object requestId,
+			McpError mcpError) throws IOException {
+		writeError(jsonMapper, response, httpStatus, requestId, mcpError.getJsonRpcError());
+	}
+
+	static void writeError(McpJsonMapper jsonMapper, HttpServletResponse response, int httpStatus, Object requestId,
+			McpSchema.JSONRPCResponse.JSONRPCError error) throws IOException {
+		response.setContentType(APPLICATION_JSON);
+		response.setCharacterEncoding(UTF_8);
+		response.setStatus(httpStatus);
+
+		String jsonErrorResponse = jsonMapper.writeValueAsString(jsonRpcErrorResponse(requestId, error));
+		PrintWriter writer = response.getWriter();
+		writer.write(jsonErrorResponse);
+		writer.flush();
+	}
+
+	private static Object jsonRpcErrorResponse(Object requestId, McpSchema.JSONRPCResponse.JSONRPCError error) {
+		if (requestId != null) {
+			return McpSchema.JSONRPCResponse.error(requestId, error);
+		}
+
+		// McpSchema.JSONRPCResponse requires a non-null id, but servlet transport
+		// errors can be generated before a JSON-RPC request id is available. The MCP
+		// JSONRPCErrorResponse schema permits omitting id in that case.
+		return new JsonRpcErrorResponse(McpSchema.JSONRPC_VERSION, error);
+	}
+
+	private record JsonRpcErrorResponse(String jsonrpc, McpSchema.JSONRPCResponse.JSONRPCError error) {
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
@@ -358,33 +358,24 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 		// Get the session ID from the request parameter
 		String sessionId = request.getParameter("sessionId");
 		if (sessionId == null) {
-			response.setContentType(APPLICATION_JSON);
-			response.setCharacterEncoding(UTF_8);
-			response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-			String jsonError = jsonMapper.writeValueAsString(McpError.builder(McpSchema.ErrorCodes.METHOD_NOT_FOUND)
-				.message("Session ID missing in message endpoint")
-				.build());
-			PrintWriter writer = response.getWriter();
-			writer.write(jsonError);
-			writer.flush();
+			this.responseError(response, HttpServletResponse.SC_BAD_REQUEST, null,
+					McpError.builder(McpSchema.ErrorCodes.METHOD_NOT_FOUND)
+						.message("Session ID missing in message endpoint")
+						.build());
 			return;
 		}
 
 		// Get the session from the sessions map
 		McpServerSession session = sessions.get(sessionId);
 		if (session == null) {
-			response.setContentType(APPLICATION_JSON);
-			response.setCharacterEncoding(UTF_8);
-			response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-			String jsonError = jsonMapper.writeValueAsString(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-				.message("Session not found: " + sessionId)
-				.build());
-			PrintWriter writer = response.getWriter();
-			writer.write(jsonError);
-			writer.flush();
+			this.responseError(response, HttpServletResponse.SC_NOT_FOUND, null,
+					McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+						.message("Session not found: " + sessionId)
+						.build());
 			return;
 		}
 
+		Object requestId = null;
 		try {
 			BufferedReader reader = request.getReader();
 			StringBuilder body = new StringBuilder();
@@ -395,6 +386,7 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 
 			final McpTransportContext transportContext = this.contextExtractor.extract(request);
 			McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(jsonMapper, body.toString());
+			requestId = requestId(message);
 
 			// Process the message through the session's handle method
 			// Block for Servlet compatibility
@@ -408,13 +400,7 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 				McpError mcpError = McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
 					.message(e.getMessage())
 					.build();
-				response.setContentType(APPLICATION_JSON);
-				response.setCharacterEncoding(UTF_8);
-				response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-				String jsonError = jsonMapper.writeValueAsString(mcpError);
-				PrintWriter writer = response.getWriter();
-				writer.write(jsonError);
-				writer.flush();
+				this.responseError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, requestId, mcpError);
 			}
 			catch (IOException ex) {
 				logger.error(FAILED_TO_SEND_ERROR_RESPONSE, ex.getMessage());
@@ -459,6 +445,15 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 		if (writer.checkError()) {
 			throw new IOException("Client disconnected");
 		}
+	}
+
+	private void responseError(HttpServletResponse response, int httpCode, Object requestId, McpError mcpError)
+			throws IOException {
+		HttpServletJsonRpcErrorWriter.writeError(this.jsonMapper, response, httpCode, requestId, mcpError);
+	}
+
+	private static Object requestId(McpSchema.JSONRPCMessage message) {
+		return (message instanceof McpSchema.JSONRPCRequest request) ? request.id() : null;
 	}
 
 	/**

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStatelessServerTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStatelessServerTransport.java
@@ -181,10 +181,15 @@ public class HttpServletStatelessServerTransport extends HttpServlet implements 
 				}
 				catch (Exception e) {
 					logger.error("Failed to handle request: {}", e.getMessage());
-					this.responseError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-							McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-								.message("Failed to handle request: " + e.getMessage())
-								.build());
+					if (e instanceof McpError mcpError) {
+						this.responseError(response, HttpServletResponse.SC_OK, jsonrpcRequest.id(), mcpError);
+					}
+					else {
+						this.responseError(response, HttpServletResponse.SC_OK, jsonrpcRequest.id(),
+								McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+									.message("Failed to handle request: " + e.getMessage())
+									.build());
+					}
 				}
 			}
 			else if (message instanceof McpSchema.JSONRPCNotification jsonrpcNotification) {
@@ -231,13 +236,12 @@ public class HttpServletStatelessServerTransport extends HttpServlet implements 
 	 * @throws IOException If an I/O error occurs
 	 */
 	private void responseError(HttpServletResponse response, int httpCode, McpError mcpError) throws IOException {
-		response.setContentType(APPLICATION_JSON);
-		response.setCharacterEncoding(UTF_8);
-		response.setStatus(httpCode);
-		String jsonError = jsonMapper.writeValueAsString(mcpError);
-		PrintWriter writer = response.getWriter();
-		writer.write(jsonError);
-		writer.flush();
+		this.responseError(response, httpCode, null, mcpError);
+	}
+
+	private void responseError(HttpServletResponse response, int httpCode, Object requestId, McpError mcpError)
+			throws IOException {
+		HttpServletJsonRpcErrorWriter.writeError(this.jsonMapper, response, httpCode, requestId, mcpError);
 	}
 
 	/**

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStatelessServerTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStatelessServerTransport.java
@@ -204,15 +204,10 @@ public class HttpServletStatelessServerTransport extends HttpServlet implements 
 				}
 				catch (Exception e) {
 					logger.error("Failed to handle request: {}", e.getMessage());
-					if (e instanceof McpError mcpError) {
-						this.responseError(response, HttpServletResponse.SC_OK, jsonrpcRequest.id(), mcpError);
-					}
-					else {
-						this.responseError(response, HttpServletResponse.SC_OK, jsonrpcRequest.id(),
-								McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
-									.message("Failed to handle request: " + e.getMessage())
-									.build());
-					}
+					this.responseError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, jsonrpcRequest.id(),
+							McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+								.message("Failed to handle request: " + e.getMessage())
+								.build());
 				}
 			}
 			else if (message instanceof McpSchema.JSONRPCNotification jsonrpcNotification) {

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
@@ -427,6 +427,7 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 
 		McpTransportContext transportContext = this.contextExtractor.extract(request);
 
+		McpSchema.JSONRPCMessage message = null;
 		try {
 			BufferedReader reader = request.getReader();
 			StringBuilder body = new StringBuilder();
@@ -435,14 +436,14 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 				body.append(line);
 			}
 
-			McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(jsonMapper, body.toString());
+			message = McpSchema.deserializeJsonRpcMessage(jsonMapper, body.toString());
 
 			// Handle initialization request
 			if (message instanceof McpSchema.JSONRPCRequest jsonrpcRequest
 					&& jsonrpcRequest.method().equals(McpSchema.METHOD_INITIALIZE)) {
 				if (!badRequestErrors.isEmpty()) {
 					String combinedMessage = String.join("; ", badRequestErrors);
-					this.responseError(response, HttpServletResponse.SC_BAD_REQUEST,
+					this.responseError(response, HttpServletResponse.SC_BAD_REQUEST, jsonrpcRequest.id(),
 							McpError.builder(McpSchema.ErrorCodes.METHOD_NOT_FOUND).message(combinedMessage).build());
 					return;
 				}
@@ -472,7 +473,7 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 				}
 				catch (Exception e) {
 					logger.error("Failed to initialize session: {}", e.getMessage());
-					this.responseError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+					this.responseError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, jsonrpcRequest.id(),
 							McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
 								.message("Failed to initialize session: " + e.getMessage())
 								.build());
@@ -488,7 +489,7 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 
 			if (!badRequestErrors.isEmpty()) {
 				String combinedMessage = String.join("; ", badRequestErrors);
-				this.responseError(response, HttpServletResponse.SC_BAD_REQUEST,
+				this.responseError(response, HttpServletResponse.SC_BAD_REQUEST, requestId(message),
 						McpError.builder(McpSchema.ErrorCodes.METHOD_NOT_FOUND).message(combinedMessage).build());
 				return;
 			}
@@ -496,7 +497,7 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 			McpStreamableServerSession session = this.sessions.get(sessionId);
 
 			if (session == null) {
-				this.responseError(response, HttpServletResponse.SC_NOT_FOUND,
+				this.responseError(response, HttpServletResponse.SC_NOT_FOUND, requestId(message),
 						McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
 							.message("Session not found: " + sessionId)
 							.build());
@@ -539,13 +540,13 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 				}
 			}
 			else {
-				this.responseError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+				this.responseError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, requestId(message),
 						McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST).message("Unknown message type").build());
 			}
 		}
 		catch (IllegalArgumentException | IOException e) {
 			logger.error("Failed to deserialize message: {}", e.getMessage());
-			this.responseError(response, HttpServletResponse.SC_BAD_REQUEST,
+			this.responseError(response, HttpServletResponse.SC_BAD_REQUEST, requestId(message),
 					McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST)
 						.message("Invalid message format: " + e.getMessage())
 						.build());
@@ -553,7 +554,7 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 		catch (Exception e) {
 			logger.error("Error handling message: {}", e.getMessage());
 			try {
-				this.responseError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+				this.responseError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, requestId(message),
 						McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
 							.message("Error processing message: " + e.getMessage())
 							.build());
@@ -638,14 +639,16 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 	}
 
 	public void responseError(HttpServletResponse response, int httpCode, McpError mcpError) throws IOException {
-		response.setContentType(APPLICATION_JSON);
-		response.setCharacterEncoding(UTF_8);
-		response.setStatus(httpCode);
-		String jsonError = jsonMapper.writeValueAsString(mcpError);
-		PrintWriter writer = response.getWriter();
-		writer.write(jsonError);
-		writer.flush();
-		return;
+		this.responseError(response, httpCode, null, mcpError);
+	}
+
+	private void responseError(HttpServletResponse response, int httpCode, Object requestId, McpError mcpError)
+			throws IOException {
+		HttpServletJsonRpcErrorWriter.writeError(this.jsonMapper, response, httpCode, requestId, mcpError);
+	}
+
+	private static Object requestId(McpSchema.JSONRPCMessage message) {
+		return (message instanceof McpSchema.JSONRPCRequest request) ? request.id() : null;
 	}
 
 	/**

--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/transport/HttpServletJsonRpcErrorTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/transport/HttpServletJsonRpcErrorTests.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server.transport;
+
+import java.io.BufferedReader;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.server.McpStatelessServerHandler;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.HttpHeaders;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpServerSession;
+import io.modelcontextprotocol.spec.json.gson.GsonMcpJsonMapper;
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Taewoong Kim
+ */
+class HttpServletJsonRpcErrorTests {
+
+	private static final McpJsonMapper JSON_MAPPER = new GsonMcpJsonMapper();
+
+	@Test
+	void statelessTransportPreservesMcpErrorCodeAndRequestId() throws Exception {
+		HttpServletStatelessServerTransport transport = HttpServletStatelessServerTransport.builder()
+			.jsonMapper(JSON_MAPPER)
+			.build();
+		transport.setMcpHandler(
+				handlerReturning(request -> Mono.error(McpError.builder(McpSchema.ErrorCodes.METHOD_NOT_FOUND)
+					.message("Missing handler for request type: " + request.method())
+					.build())));
+		StringWriter responseBody = new StringWriter();
+		HttpServletResponse response = response(responseBody);
+
+		transport.doPost(request("""
+				{"jsonrpc":"2.0","id":"missing-handler","method":"missing/method"}
+				""", HttpServletStatelessServerTransport.APPLICATION_JSON + ", "
+				+ HttpServletStatelessServerTransport.TEXT_EVENT_STREAM), response);
+
+		verify(response).setStatus(HttpServletResponse.SC_OK);
+		McpSchema.JSONRPCResponse jsonResponse = readResponse(responseBody);
+		assertThat(jsonResponse.id()).isEqualTo("missing-handler");
+		assertThat(jsonResponse.error()).isNotNull();
+		assertThat(jsonResponse.error().code()).isEqualTo(McpSchema.ErrorCodes.METHOD_NOT_FOUND);
+		assertNoThrowableFields(responseBody);
+	}
+
+	@Test
+	void statelessTransportMapsUnexpectedRequestErrorsToJsonRpcInternalError() throws Exception {
+		HttpServletStatelessServerTransport transport = HttpServletStatelessServerTransport.builder()
+			.jsonMapper(JSON_MAPPER)
+			.build();
+		transport.setMcpHandler(handlerReturning(request -> Mono.error(new IllegalStateException("boom"))));
+		StringWriter responseBody = new StringWriter();
+		HttpServletResponse response = response(responseBody);
+
+		transport.doPost(request("""
+				{"jsonrpc":"2.0","id":"boom-request","method":"tools/list"}
+				""", HttpServletStatelessServerTransport.APPLICATION_JSON + ", "
+				+ HttpServletStatelessServerTransport.TEXT_EVENT_STREAM), response);
+
+		verify(response).setStatus(HttpServletResponse.SC_OK);
+		McpSchema.JSONRPCResponse jsonResponse = readResponse(responseBody);
+		assertThat(jsonResponse.id()).isEqualTo("boom-request");
+		assertThat(jsonResponse.error()).isNotNull();
+		assertThat(jsonResponse.error().code()).isEqualTo(McpSchema.ErrorCodes.INTERNAL_ERROR);
+		assertNoThrowableFields(responseBody);
+	}
+
+	@Test
+	void statelessTransportSerializesTransportErrorsAsJsonRpcResponses() throws Exception {
+		HttpServletStatelessServerTransport transport = HttpServletStatelessServerTransport.builder()
+			.jsonMapper(JSON_MAPPER)
+			.build();
+		StringWriter responseBody = new StringWriter();
+		HttpServletResponse response = response(responseBody);
+
+		transport.doPost(request("""
+				{"jsonrpc":"2.0","id":"missing-accept","method":"tools/list"}
+				""", null), response);
+
+		verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+		Map<String, Object> jsonResponse = readResponseMap(responseBody);
+		assertThat(jsonResponse).containsEntry("jsonrpc", McpSchema.JSONRPC_VERSION);
+		assertThat(jsonResponse).doesNotContainKey("id");
+		assertThat(errorMap(jsonResponse)).containsEntry("code", (long) McpSchema.ErrorCodes.METHOD_NOT_FOUND);
+		assertNoThrowableFields(responseBody);
+	}
+
+	@Test
+	void streamableTransportPreservesParsedRequestIdForTransportErrors() throws Exception {
+		HttpServletStreamableServerTransportProvider transport = HttpServletStreamableServerTransportProvider.builder()
+			.jsonMapper(JSON_MAPPER)
+			.build();
+		StringWriter responseBody = new StringWriter();
+		HttpServletResponse response = response(responseBody);
+
+		transport.doPost(request("""
+				{"jsonrpc":"2.0","id":"init-request","method":"initialize"}
+				""", HttpServletStreamableServerTransportProvider.APPLICATION_JSON), response);
+
+		verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+		McpSchema.JSONRPCResponse jsonResponse = readResponse(responseBody);
+		assertThat(jsonResponse.id()).isEqualTo("init-request");
+		assertThat(jsonResponse.error()).isNotNull();
+		assertThat(jsonResponse.error().code()).isEqualTo(McpSchema.ErrorCodes.METHOD_NOT_FOUND);
+		assertNoThrowableFields(responseBody);
+	}
+
+	@Test
+	void streamableTransportPreservesParsedRequestIdForErrorsAfterParsing() throws Exception {
+		HttpServletStreamableServerTransportProvider transport = HttpServletStreamableServerTransportProvider.builder()
+			.jsonMapper(JSON_MAPPER)
+			.build();
+		StringWriter responseBody = new StringWriter();
+		HttpServletResponse response = response(responseBody);
+
+		transport.doPost(request("""
+				{"jsonrpc":"2.0","id":"bad-initialize","method":"initialize","params":[]}
+				""", HttpServletStreamableServerTransportProvider.APPLICATION_JSON + ", "
+				+ HttpServletStreamableServerTransportProvider.TEXT_EVENT_STREAM), response);
+
+		verify(response).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+		McpSchema.JSONRPCResponse jsonResponse = readResponse(responseBody);
+		assertThat(jsonResponse.id()).isEqualTo("bad-initialize");
+		assertThat(jsonResponse.error()).isNotNull();
+		assertThat(jsonResponse.error().code()).isEqualTo(McpSchema.ErrorCodes.INTERNAL_ERROR);
+		assertNoThrowableFields(responseBody);
+	}
+
+	@Test
+	void streamableTransportResponseErrorSerializesJsonRpcResponse() throws Exception {
+		HttpServletStreamableServerTransportProvider transport = HttpServletStreamableServerTransportProvider.builder()
+			.jsonMapper(JSON_MAPPER)
+			.build();
+		StringWriter responseBody = new StringWriter();
+		HttpServletResponse response = response(responseBody);
+
+		transport.responseError(response, HttpServletResponse.SC_BAD_REQUEST,
+				McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST).message("Invalid request").build());
+
+		verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+		Map<String, Object> jsonResponse = readResponseMap(responseBody);
+		assertThat(jsonResponse).containsEntry("jsonrpc", McpSchema.JSONRPC_VERSION);
+		assertThat(jsonResponse).doesNotContainKey("id");
+		assertThat(errorMap(jsonResponse)).containsEntry("code", (long) McpSchema.ErrorCodes.INVALID_REQUEST);
+		assertNoThrowableFields(responseBody);
+	}
+
+	@Test
+	void legacySseTransportPreservesParsedRequestIdForProcessingErrors() throws Exception {
+		HttpServletSseServerTransportProvider transport = HttpServletSseServerTransportProvider.builder()
+			.jsonMapper(JSON_MAPPER)
+			.messageEndpoint("/message")
+			.sseEndpoint("/sse")
+			.build();
+		McpServerSession session = mock(McpServerSession.class);
+		when(session.handle(any())).thenReturn(Mono.error(new IllegalStateException("boom")));
+		transport.setSessionFactory(sessionTransport -> session);
+		String sessionId = connectLegacySseSession(transport);
+		StringWriter responseBody = new StringWriter();
+		HttpServletResponse response = response(responseBody);
+		HttpServletRequest request = request("/message", """
+				{"jsonrpc":"2.0","id":"sse-request","method":"tools/list"}
+				""", HttpServletStatelessServerTransport.APPLICATION_JSON);
+		when(request.getParameter(HttpServletSseServerTransportProvider.SESSION_ID)).thenReturn(sessionId);
+
+		transport.doPost(request, response);
+
+		verify(response).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+		McpSchema.JSONRPCResponse jsonResponse = readResponse(responseBody);
+		assertThat(jsonResponse.id()).isEqualTo("sse-request");
+		assertThat(jsonResponse.error()).isNotNull();
+		assertThat(jsonResponse.error().code()).isEqualTo(McpSchema.ErrorCodes.INTERNAL_ERROR);
+		assertNoThrowableFields(responseBody);
+	}
+
+	private static HttpServletRequest request(String body, String acceptHeader) throws Exception {
+		return request("/mcp", body, acceptHeader);
+	}
+
+	private static HttpServletRequest request(String uri, String body, String acceptHeader) throws Exception {
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		when(request.getRequestURI()).thenReturn(uri);
+		when(request.getReader()).thenReturn(new BufferedReader(new StringReader(body)));
+		if (acceptHeader == null) {
+			when(request.getHeaderNames()).thenReturn(Collections.emptyEnumeration());
+		}
+		else {
+			when(request.getHeader(HttpHeaders.ACCEPT)).thenReturn(acceptHeader);
+			when(request.getHeaderNames()).thenReturn(Collections.enumeration(List.of(HttpHeaders.ACCEPT)));
+			when(request.getHeaders(HttpHeaders.ACCEPT)).thenReturn(Collections.enumeration(List.of(acceptHeader)));
+		}
+		return request;
+	}
+
+	private static String connectLegacySseSession(HttpServletSseServerTransportProvider transport) throws Exception {
+		StringWriter endpointEvent = new StringWriter();
+		HttpServletRequest request = request("/sse", "", null);
+		when(request.startAsync()).thenReturn(mock(AsyncContext.class));
+
+		transport.doGet(request, response(endpointEvent));
+
+		String data = endpointEvent.toString();
+		assertThat(data).contains("?sessionId=");
+		String sessionId = data.substring(data.indexOf("?sessionId=") + "?sessionId=".length()).trim();
+		assertThat(sessionId).isNotBlank();
+		return sessionId;
+	}
+
+	private static HttpServletResponse response(StringWriter responseBody) throws Exception {
+		HttpServletResponse response = mock(HttpServletResponse.class);
+		when(response.getWriter()).thenReturn(new PrintWriter(responseBody));
+		return response;
+	}
+
+	private static McpStatelessServerHandler handlerReturning(
+			Function<McpSchema.JSONRPCRequest, Mono<McpSchema.JSONRPCResponse>> requestHandler) {
+		return new McpStatelessServerHandler() {
+
+			@Override
+			public Mono<McpSchema.JSONRPCResponse> handleRequest(McpTransportContext transportContext,
+					McpSchema.JSONRPCRequest request) {
+				return requestHandler.apply(request);
+			}
+
+			@Override
+			public Mono<Void> handleNotification(McpTransportContext transportContext,
+					McpSchema.JSONRPCNotification notification) {
+				return Mono.empty();
+			}
+
+		};
+	}
+
+	private static McpSchema.JSONRPCResponse readResponse(StringWriter responseBody) throws Exception {
+		return JSON_MAPPER.readValue(responseBody.toString(), McpSchema.JSONRPCResponse.class);
+	}
+
+	private static Map<String, Object> readResponseMap(StringWriter responseBody) throws Exception {
+		return JSON_MAPPER.readValue(responseBody.toString(), new TypeRef<Map<String, Object>>() {
+		});
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Map<String, Object> errorMap(Map<String, Object> response) {
+		return (Map<String, Object>) response.get("error");
+	}
+
+	private static void assertNoThrowableFields(StringWriter responseBody) {
+		assertThat(responseBody.toString()).doesNotContain("stackTrace", "cause", "localizedMessage", "jsonRpcError");
+	}
+
+}

--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/transport/HttpServletJsonRpcErrorTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/transport/HttpServletJsonRpcErrorTests.java
@@ -44,7 +44,7 @@ class HttpServletJsonRpcErrorTests {
 	private static final McpJsonMapper JSON_MAPPER = new GsonMcpJsonMapper();
 
 	@Test
-	void statelessTransportPreservesMcpErrorCodeAndRequestId() throws Exception {
+	void statelessTransportMapsEscapedMcpErrorsToJsonRpcInternalError() throws Exception {
 		HttpServletStatelessServerTransport transport = HttpServletStatelessServerTransport.builder()
 			.jsonMapper(JSON_MAPPER)
 			.build();
@@ -60,11 +60,11 @@ class HttpServletJsonRpcErrorTests {
 				""", HttpServletStatelessServerTransport.APPLICATION_JSON + ", "
 				+ HttpServletStatelessServerTransport.TEXT_EVENT_STREAM), response);
 
-		verify(response).setStatus(HttpServletResponse.SC_OK);
+		verify(response).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
 		McpSchema.JSONRPCResponse jsonResponse = readResponse(responseBody);
 		assertThat(jsonResponse.id()).isEqualTo("missing-handler");
 		assertThat(jsonResponse.error()).isNotNull();
-		assertThat(jsonResponse.error().code()).isEqualTo(McpSchema.ErrorCodes.METHOD_NOT_FOUND);
+		assertThat(jsonResponse.error().code()).isEqualTo(McpSchema.ErrorCodes.INTERNAL_ERROR);
 		assertNoThrowableFields(responseBody);
 	}
 
@@ -82,7 +82,7 @@ class HttpServletJsonRpcErrorTests {
 				""", HttpServletStatelessServerTransport.APPLICATION_JSON + ", "
 				+ HttpServletStatelessServerTransport.TEXT_EVENT_STREAM), response);
 
-		verify(response).setStatus(HttpServletResponse.SC_OK);
+		verify(response).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
 		McpSchema.JSONRPCResponse jsonResponse = readResponse(responseBody);
 		assertThat(jsonResponse.id()).isEqualTo("boom-request");
 		assertThat(jsonResponse.error()).isNotNull();


### PR DESCRIPTION
Fixes servlet transport error serialization so servlet transports write JSON-RPC error responses for `McpError` instead of serializing the Java exception object.

Fixes #955

## Motivation and Context

Some servlet transport error paths currently serialize `McpError` directly. Since `McpError` extends `RuntimeException`, the response body can include exception-shaped fields such as `stackTrace`, `cause`, `localizedMessage`, and `jsonRpcError`.

This makes servlet error responses inconsistent with the JSON-RPC error response shape expected by MCP clients.

Before:

<img width="869" height="622" alt="servlet-error-before" src="https://github.com/user-attachments/assets/d0ac2f69-f102-419d-a5c5-442627e5cc13" />

After:

<img width="878" height="324" alt="servlet-error-after" src="https://github.com/user-attachments/assets/377ede8e-90ad-477e-8607-c0f5c87016ea" />

## How Has This Been Tested?

Added servlet transport tests covering JSON-RPC error serialization for:

- stateless servlet transport errors
- streamable servlet transport errors
- SSE servlet transport errors
- parsed request id preservation
- no-id transport-level rejection paths

I also verified the behavior locally with a small servlet server and Postman using the same request before and after the fix.

## Breaking Changes

None intended.

The existing HTTP status behavior for transport-level rejections is preserved. The response body is changed to the expected JSON-RPC error envelope instead of serializing the `McpError` exception object.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

This change keeps the existing servlet transport status-code behavior for transport-level rejections, but writes a JSON-RPC error response body consistently.

When the request id has already been parsed, the response preserves it. For transport-level rejection paths where no request id is available, the response omits the `id` field.

## References:

- MCP `JSONRPCErrorResponse` schema models error responses with `jsonrpc`, optional `id`, and `error`: https://modelcontextprotocol.io/specification/2025-11-25/schema#jsonrpcerrorresponse

