### PR TITLE
fix: reject unsupported MCP protocol version headers

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
@@ -279,6 +279,10 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 			return;
 		}
 
+		if (!validateProtocolVersion(request, response)) {
+			return;
+		}
+
 		List<String> badRequestErrors = new ArrayList<>();
 
 		String accept = request.getHeader(ACCEPT);
@@ -480,6 +484,10 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 				}
 			}
 
+			if (!validateProtocolVersion(request, response)) {
+				return;
+			}
+
 			String sessionId = request.getHeader(HttpHeaders.MCP_SESSION_ID);
 
 			if (sessionId == null || sessionId.isBlank()) {
@@ -596,6 +604,10 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 			return;
 		}
 
+		if (!validateProtocolVersion(request, response)) {
+			return;
+		}
+
 		if (this.disallowDelete) {
 			response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
 			return;
@@ -646,6 +658,22 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 		writer.write(jsonError);
 		writer.flush();
 		return;
+	}
+
+	private boolean validateProtocolVersion(HttpServletRequest request, HttpServletResponse response)
+			throws IOException {
+		String protocolVersion = request.getHeader(HttpHeaders.PROTOCOL_VERSION);
+		if (protocolVersion == null || protocolVersion.isBlank()) {
+			return true;
+		}
+		if (protocolVersions().contains(protocolVersion)) {
+			return true;
+		}
+		this.responseError(response, HttpServletResponse.SC_BAD_REQUEST,
+				McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST)
+					.message("Unsupported or invalid MCP protocol version: " + protocolVersion)
+					.build());
+		return false;
 	}
 
 	/**

--- a/mcp-test/src/test/java/io/modelcontextprotocol/common/HttpClientStreamableHttpVersionNegotiationIntegrationTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/common/HttpClientStreamableHttpVersionNegotiationIntegrationTests.java
@@ -4,6 +4,10 @@
 
 package io.modelcontextprotocol.common;
 
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -24,6 +28,8 @@ import org.apache.catalina.LifecycleState;
 import org.apache.catalina.startup.Tomcat;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -119,6 +125,55 @@ class HttpClientStreamableHttpVersionNegotiationIntegrationTests {
 			.extracting(McpSchema.TextContent.class::cast)
 			.extracting(McpSchema.TextContent::text)
 			.isEqualTo(ProtocolVersions.MCP_2025_11_25);
+		mcpServer.close();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "1900-01-01", "not-a-version" })
+	void rejectsUnsupportedProtocolVersionHeaders(String protocolVersion) throws Exception {
+		startTomcat();
+
+		HttpClient httpClient = HttpClient.newHttpClient();
+		String endpoint = "http://localhost:" + PORT + "/mcp";
+
+		HttpResponse<String> initializeResponse = httpClient.send(HttpRequest.newBuilder()
+			.uri(URI.create(endpoint))
+			.header("Content-Type", "application/json")
+			.header("Accept", "application/json, text/event-stream")
+			.header("MCP-Protocol-Version", ProtocolVersions.MCP_2025_11_25)
+			.POST(HttpRequest.BodyPublishers.ofString(
+					"""
+							{"jsonrpc":"2.0","id":"init-1","method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}
+							"""))
+			.build(), HttpResponse.BodyHandlers.ofString());
+
+		assertThat(initializeResponse.statusCode()).isEqualTo(200);
+		String sessionId = initializeResponse.headers().firstValue("Mcp-Session-Id").orElseThrow();
+
+		HttpResponse<String> initializedResponse = httpClient.send(HttpRequest.newBuilder()
+			.uri(URI.create(endpoint))
+			.header("Content-Type", "application/json")
+			.header("Accept", "application/json, text/event-stream")
+			.header("MCP-Protocol-Version", ProtocolVersions.MCP_2025_11_25)
+			.header("Mcp-Session-Id", sessionId)
+			.POST(HttpRequest.BodyPublishers
+				.ofString("{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\",\"params\":{}}"))
+			.build(), HttpResponse.BodyHandlers.ofString());
+
+		assertThat(initializedResponse.statusCode()).isEqualTo(202);
+
+		HttpResponse<String> badVersionResponse = httpClient.send(HttpRequest.newBuilder()
+			.uri(URI.create(endpoint))
+			.header("Content-Type", "application/json")
+			.header("Accept", "application/json, text/event-stream")
+			.header("MCP-Protocol-Version", protocolVersion)
+			.header("Mcp-Session-Id", sessionId)
+			.POST(HttpRequest.BodyPublishers
+				.ofString("{\"jsonrpc\":\"2.0\",\"id\":\"bad-version-1\",\"method\":\"tools/list\",\"params\":{}}"))
+			.build(), HttpResponse.BodyHandlers.ofString());
+
+		assertThat(badVersionResponse.statusCode()).isEqualTo(400);
+		assertThat(badVersionResponse.body()).contains("Unsupported or invalid MCP protocol version");
 		mcpServer.close();
 	}
 


### PR DESCRIPTION
Fixes #957.

This keeps `initialize` on the existing negotiation path. At that point the client can still be advertising its newest supported protocol version, so rejecting the header before negotiation would break the current fallback behavior.

For later Streamable HTTP requests, the servlet now rejects a non-empty `MCP-Protocol-Version` value unless it is one of the server supported versions. That covers POST requests on an established session as well as GET and DELETE session operations.

I added an integration test that initializes a session, sends `notifications/initialized`, then verifies that `tools/list` returns 400 for both an unsupported version and a malformed version.

Tested with:
`./mvnw.cmd -pl mcp-test -am -Dtest=HttpClientStreamableHttpVersionNegotiationIntegrationTests -Dsurefire.failIfNoSpecifiedTests=false test`