### PR TITLE
fix: use UTF-8 charset in StdioClientTransport stream readers

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/StdioClientTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/StdioClientTransport.java
@@ -180,7 +180,7 @@ public class StdioClientTransport implements McpClientTransport {
 	private void startErrorProcessing() {
 		this.errorScheduler.schedule(() -> {
 			try (BufferedReader processErrorReader = new BufferedReader(
-					new InputStreamReader(process.getErrorStream()))) {
+					new InputStreamReader(process.getErrorStream(), StandardCharsets.UTF_8))) {
 				String line;
 				while (!isClosing && (line = processErrorReader.readLine()) != null) {
 					try {
@@ -246,7 +246,8 @@ public class StdioClientTransport implements McpClientTransport {
 	 */
 	private void startInboundProcessing() {
 		this.inboundScheduler.schedule(() -> {
-			try (BufferedReader processReader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+			try (BufferedReader processReader = new BufferedReader(
+					new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
 				String line;
 				while (!isClosing && (line = processReader.readLine()) != null) {
 					try {


### PR DESCRIPTION
## Problem

`StdioClientTransport` uses `InputStreamReader` without an explicit charset in two places:
- `startInboundProcessing` (reads JSON-RPC messages from the process stdout)
- `startErrorProcessing` (reads stderr lines from the subprocess)

`InputStreamReader` defaults to the JVM's platform charset (`Charset.defaultCharset()`), which varies by OS and locale. On systems where the default is not UTF-8 (e.g., Windows with GBK, legacy Linux configurations), MCP messages with non-ASCII characters get corrupted on read.

`startOutboundProcessing` already writes with `StandardCharsets.UTF_8` — this PR makes the readers consistent.

## Fix

Pass `StandardCharsets.UTF_8` explicitly to both `InputStreamReader` constructors. `StandardCharsets` was already imported.

Fixes #898

## Test plan
- [ ] Existing stdio transport tests pass
- [ ] Change is symmetric with the UTF-8 writer in `startOutboundProcessing`