### PR TITLE
[codex] Validate ResourceLink required fields

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -5019,6 +5019,40 @@ public final class McpSchema {
 		@JsonProperty("annotations") Annotations annotations,
 		@JsonProperty("_meta") Map<String, Object> meta) implements Content, ResourceContent { // @formatter:on
 
+		public ResourceLink {
+			Assert.notNull(uri, "uri must not be null");
+			Assert.notNull(name, "name must not be null");
+		}
+
+		@JsonCreator
+		static ResourceLink fromJson(@JsonProperty("name") String name, @JsonProperty("title") String title,
+				@JsonProperty("uri") String uri, @JsonProperty("description") String description,
+				@JsonProperty("mimeType") String mimeType, @JsonProperty("size") Long size,
+				@JsonProperty("annotations") Annotations annotations, @JsonProperty("_meta") Map<String, Object> meta) {
+			if (name == null || uri == null) {
+				List<String> missing = new ArrayList<>();
+				if (name == null) {
+					missing.add("name -> ''");
+					name = "";
+				}
+				if (uri == null) {
+					missing.add("uri -> ''");
+					uri = "";
+				}
+				logger.warn("ResourceLink: missing required fields during deserialization: {}",
+						String.join(", ", missing));
+			}
+			return new ResourceLink(name, title, uri, description, mimeType, size, annotations, meta);
+		}
+
+		public static Builder builder(String uri, String name) {
+			return new Builder(uri, name);
+		}
+
+		/**
+		 * @deprecated Use {@link #builder(String, String)} instead.
+		 */
+		@Deprecated
 		public static Builder builder() {
 			return new Builder();
 		}
@@ -5041,6 +5075,24 @@ public final class McpSchema {
 
 			private Map<String, Object> meta;
 
+			/**
+			 * @deprecated Use {@link ResourceLink#builder(String, String)} instead.
+			 */
+			@Deprecated
+			public Builder() {
+			}
+
+			private Builder(String uri, String name) {
+				Assert.hasText(uri, "uri must not be empty");
+				Assert.hasText(name, "name must not be empty");
+				this.uri = uri;
+				this.name = name;
+			}
+
+			/**
+			 * @deprecated Use {@link ResourceLink#builder(String, String)} instead.
+			 */
+			@Deprecated
 			public Builder name(String name) {
 				this.name = name;
 				return this;
@@ -5051,6 +5103,10 @@ public final class McpSchema {
 				return this;
 			}
 
+			/**
+			 * @deprecated Use {@link ResourceLink#builder(String, String)} instead.
+			 */
+			@Deprecated
 			public Builder uri(String uri) {
 				this.uri = uri;
 				return this;

--- a/mcp-test/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
@@ -228,10 +228,8 @@ public class McpSchemaTests {
 
 	@Test
 	void testResourceLink() throws Exception {
-		McpSchema.ResourceLink resourceLink = McpSchema.ResourceLink.builder()
-			.name("main.rs")
+		McpSchema.ResourceLink resourceLink = McpSchema.ResourceLink.builder("file:///project/src/main.rs", "main.rs")
 			.title("Main file")
-			.uri("file:///project/src/main.rs")
 			.description("Primary application entry point")
 			.mimeType("text/x-rust")
 			.meta(Map.of("metaKey", "metaValue"))
@@ -259,6 +257,44 @@ public class McpSchemaTests {
 		assertThat(resourceLink.description()).isEqualTo("Primary application entry point");
 		assertThat(resourceLink.mimeType()).isEqualTo("text/x-rust");
 		assertThat(resourceLink.meta()).containsEntry("metaKey", "metaValue");
+	}
+
+	@Test
+	void testResourceLinkRejectsNullName() {
+		assertThatThrownBy(() -> new McpSchema.ResourceLink(null, null, "file:///project/src/main.rs", null, null, null,
+				null, null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("name must not be null");
+	}
+
+	@Test
+	void testResourceLinkRejectsNullUri() {
+		assertThatThrownBy(() -> new McpSchema.ResourceLink("main.rs", null, null, null, null, null, null, null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("uri must not be null");
+	}
+
+	@Test
+	void testResourceLinkDeserializationWithMissingRequiredFields() throws Exception {
+		McpSchema.ResourceLink resourceLink = JSON_MAPPER.readValue("""
+				{"type":"resource_link","description":"Primary application entry point"}""",
+				McpSchema.ResourceLink.class);
+
+		assertThat(resourceLink).isNotNull();
+		assertThat(resourceLink.name()).isEmpty();
+		assertThat(resourceLink.uri()).isEmpty();
+		assertThat(resourceLink.description()).isEqualTo("Primary application entry point");
+	}
+
+	@Test
+	void testResourceLinkUnknownFieldsIgnored() throws Exception {
+		McpSchema.ResourceLink resourceLink = JSON_MAPPER.readValue(
+				"""
+						{"type":"resource_link","name":"main.rs","uri":"file:///project/src/main.rs","futureField":"ignored"}""",
+				McpSchema.ResourceLink.class);
+
+		assertThat(resourceLink.name()).isEqualTo("main.rs");
+		assertThat(resourceLink.uri()).isEqualTo("file:///project/src/main.rs");
 	}
 
 	// JSON-RPC Message Types Tests


### PR DESCRIPTION
## Summary
- validate ResourceLink name and uri during programmatic construction
- add a lenient JSON creator for missing required ResourceLink fields, matching existing schema evolution behavior
- add a required-first ResourceLink builder and regression coverage for missing and unknown JSON fields

## Why
ResourceLink declares name and uri as required MCP fields, but direct construction and JSON deserialization previously allowed nulls. That made it inconsistent with Resource and with the schema evolution guidance in CONTRIBUTING.md.

## Validation
- JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./mvnw -q -pl mcp-test -am -Dtest=McpSchemaTests -Dsurefire.failIfNoSpecifiedTests=false test
- JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./mvnw -q -pl mcp-test -am -Pjackson2 -Dtest=McpSchemaTests -Dsurefire.failIfNoSpecifiedTests=false test
- JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./mvnw -q -pl mcp-core,mcp-json-jackson3,mcp-test -am -DskipTests verify
- git diff --check

Full test suite was not run locally because this worker environment does not have Docker available, and repository docs note Docker is required for tests.