### PR TITLE
[TOOLCM-4360] Enable dual publish to CodeArtifact and Nexus

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@ sproutMultiModuleBuild {
   nodeLabel = 'ephemeral'
   tribes = ['global']
   notifySlackGroupsOnFailure = ['@kevin']
+  runECRLogin = 'true'
   jdk = 17
   deployRCBranches = true
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,8 @@
+sproutMultiModuleBuild {
+  moduleToBuild = 'mcp-parent'
+  nodeLabel = 'ephemeral'
+  tribes = ['global']
+  notifySlackGroupsOnFailure = ['@kevin']
+  jdk = 17
+  deployRCBranches = true
+}

--- a/mcp-bom/pom.xml
+++ b/mcp-bom/pom.xml
@@ -28,28 +28,28 @@
         <dependencies>
             <!-- Core MCP -->
             <dependency>
-                <groupId>io.modelcontextprotocol.sdk</groupId>
+                <groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
                 <artifactId>mcp</artifactId>
-                <version>${project.version}</version>
+                <version>0.12.0-sprout</version>
             </dependency>
 
             <!-- MCP Test -->
             <dependency>
-                <groupId>io.modelcontextprotocol.sdk</groupId>
+                <groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
                 <artifactId>mcp-test</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <!-- MCP Transport - WebFlux SSE -->
             <dependency>
-                <groupId>io.modelcontextprotocol.sdk</groupId>
+                <groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
                 <artifactId>mcp-spring-webflux</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <!-- MCP Transport - WebMVC SSE -->
             <dependency>
-                <groupId>io.modelcontextprotocol.sdk</groupId>
+                <groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
                 <artifactId>mcp-spring-webmvc</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/mcp-bom/pom.xml
+++ b/mcp-bom/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.modelcontextprotocol.sdk</groupId>
+        <groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
         <artifactId>mcp-parent</artifactId>
         <version>0.12.0-SNAPSHOT</version>
     </parent>

--- a/mcp-bom/pom.xml
+++ b/mcp-bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
         <artifactId>mcp-parent</artifactId>
-        <version>0.12.0-SNAPSHOT</version>
+        <version>0.12.0-sprout</version>
     </parent>
 
     <artifactId>mcp-bom</artifactId>

--- a/mcp-bom/pom.xml
+++ b/mcp-bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
         <artifactId>mcp-parent</artifactId>
-        <version>0.12.0-sprout</version>
+        <version>0.13.0-sprout</version>
     </parent>
 
     <artifactId>mcp-bom</artifactId>
@@ -30,7 +30,7 @@
             <dependency>
                 <groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
                 <artifactId>mcp</artifactId>
-                <version>0.12.0-sprout</version>
+                <version>0.13.0-sprout</version>
             </dependency>
 
             <!-- MCP Test -->

--- a/mcp-spring/mcp-spring-webflux/pom.xml
+++ b/mcp-spring/mcp-spring-webflux/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 		<artifactId>mcp-parent</artifactId>
-		<version>0.12.0-SNAPSHOT</version>
+		<version>0.12.0-sprout</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>mcp-spring-webflux</artifactId>

--- a/mcp-spring/mcp-spring-webflux/pom.xml
+++ b/mcp-spring/mcp-spring-webflux/pom.xml
@@ -4,7 +4,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>io.modelcontextprotocol.sdk</groupId>
+		<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 		<artifactId>mcp-parent</artifactId>
 		<version>0.12.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>

--- a/mcp-spring/mcp-spring-webflux/pom.xml
+++ b/mcp-spring/mcp-spring-webflux/pom.xml
@@ -23,15 +23,15 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp</artifactId>
-			<version>0.12.0-SNAPSHOT</version>
+			<version>0.12.0-sprout</version>
 		</dependency>
 
 		<dependency>
-			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp-test</artifactId>
-			<version>0.12.0-SNAPSHOT</version>
+			<version>0.12.0-sprout</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/mcp-spring/mcp-spring-webflux/pom.xml
+++ b/mcp-spring/mcp-spring-webflux/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 		<artifactId>mcp-parent</artifactId>
-		<version>0.12.0-sprout</version>
+		<version>0.13.0-sprout</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>mcp-spring-webflux</artifactId>
@@ -25,13 +25,13 @@
 		<dependency>
 			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp</artifactId>
-			<version>0.12.0-sprout</version>
+			<version>0.13.0-sprout</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp-test</artifactId>
-			<version>0.12.0-sprout</version>
+			<version>0.13.0-sprout</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/WebClientStreamableHttpAsyncClientTests.java
+++ b/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/WebClientStreamableHttpAsyncClientTests.java
@@ -19,7 +19,8 @@ public class WebClientStreamableHttpAsyncClientTests extends AbstractMcpAsyncCli
 
 	// Uses the https://github.com/tzolov/mcp-everything-server-docker-image
 	@SuppressWarnings("resource")
-	GenericContainer<?> container = new GenericContainer<>("docker.io/tzolov/mcp-everything-server:v2")
+	GenericContainer<?> container = new GenericContainer<>(
+			"412335208158.dkr.ecr.us-east-1.amazonaws.com/docker-hub/tzolov/mcp-everything-server:v2")
 		.withCommand("node dist/index.js streamableHttp")
 		.withLogConsumer(outputFrame -> System.out.println(outputFrame.getUtf8String()))
 		.withExposedPorts(3001)

--- a/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/WebClientStreamableHttpSyncClientTests.java
+++ b/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/WebClientStreamableHttpSyncClientTests.java
@@ -19,7 +19,8 @@ public class WebClientStreamableHttpSyncClientTests extends AbstractMcpSyncClien
 
 	// Uses the https://github.com/tzolov/mcp-everything-server-docker-image
 	@SuppressWarnings("resource")
-	GenericContainer<?> container = new GenericContainer<>("docker.io/tzolov/mcp-everything-server:v2")
+	GenericContainer<?> container = new GenericContainer<>(
+			"412335208158.dkr.ecr.us-east-1.amazonaws.com/docker-hub/tzolov/mcp-everything-server:v2")
 		.withCommand("node dist/index.js streamableHttp")
 		.withLogConsumer(outputFrame -> System.out.println(outputFrame.getUtf8String()))
 		.withExposedPorts(3001)

--- a/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/WebFluxSseMcpAsyncClientTests.java
+++ b/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/WebFluxSseMcpAsyncClientTests.java
@@ -26,7 +26,8 @@ class WebFluxSseMcpAsyncClientTests extends AbstractMcpAsyncClientTests {
 
 	// Uses the https://github.com/tzolov/mcp-everything-server-docker-image
 	@SuppressWarnings("resource")
-	GenericContainer<?> container = new GenericContainer<>("docker.io/tzolov/mcp-everything-server:v2")
+	GenericContainer<?> container = new GenericContainer<>(
+			"412335208158.dkr.ecr.us-east-1.amazonaws.com/docker-hub/tzolov/mcp-everything-server:v2")
 		.withCommand("node dist/index.js sse")
 		.withLogConsumer(outputFrame -> System.out.println(outputFrame.getUtf8String()))
 		.withExposedPorts(3001)

--- a/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/WebFluxSseMcpSyncClientTests.java
+++ b/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/WebFluxSseMcpSyncClientTests.java
@@ -26,7 +26,8 @@ class WebFluxSseMcpSyncClientTests extends AbstractMcpSyncClientTests {
 
 	// Uses the https://github.com/tzolov/mcp-everything-server-docker-image
 	@SuppressWarnings("resource")
-	GenericContainer<?> container = new GenericContainer<>("docker.io/tzolov/mcp-everything-server:v2")
+	GenericContainer<?> container = new GenericContainer<>(
+			"412335208158.dkr.ecr.us-east-1.amazonaws.com/docker-hub/tzolov/mcp-everything-server:v2")
 		.withCommand("node dist/index.js sse")
 		.withLogConsumer(outputFrame -> System.out.println(outputFrame.getUtf8String()))
 		.withExposedPorts(3001)

--- a/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransportTests.java
+++ b/mcp-spring/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/transport/WebFluxSseClientTransportTests.java
@@ -42,7 +42,8 @@ class WebFluxSseClientTransportTests {
 	static String host = "http://localhost:3001";
 
 	@SuppressWarnings("resource")
-	GenericContainer<?> container = new GenericContainer<>("docker.io/tzolov/mcp-everything-server:v2")
+	GenericContainer<?> container = new GenericContainer<>(
+			"412335208158.dkr.ecr.us-east-1.amazonaws.com/docker-hub/tzolov/mcp-everything-server:v2")
 		.withCommand("node dist/index.js sse")
 		.withLogConsumer(outputFrame -> System.out.println(outputFrame.getUtf8String()))
 		.withExposedPorts(3001)

--- a/mcp-spring/mcp-spring-webmvc/pom.xml
+++ b/mcp-spring/mcp-spring-webmvc/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 		<artifactId>mcp-parent</artifactId>
-		<version>0.12.0-SNAPSHOT</version>
+		<version>0.12.0-sprout</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>mcp-spring-webmvc</artifactId>

--- a/mcp-spring/mcp-spring-webmvc/pom.xml
+++ b/mcp-spring/mcp-spring-webmvc/pom.xml
@@ -4,7 +4,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>io.modelcontextprotocol.sdk</groupId>
+		<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 		<artifactId>mcp-parent</artifactId>
 		<version>0.12.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>

--- a/mcp-spring/mcp-spring-webmvc/pom.xml
+++ b/mcp-spring/mcp-spring-webmvc/pom.xml
@@ -23,9 +23,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp</artifactId>
-			<version>0.12.0-SNAPSHOT</version>
+			<version>0.12.0-sprout</version>
 		</dependency>
 
 		<dependency>
@@ -35,16 +35,16 @@
 		</dependency>
 
 		<dependency>
-			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp-test</artifactId>
-			<version>0.12.0-SNAPSHOT</version>
+			<version>0.12.0-sprout</version>
 			<scope>test</scope>
 		</dependency>
 
 				<dependency>
-			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp-spring-webflux</artifactId>
-			<version>0.12.0-SNAPSHOT</version>
+			<version>0.12.0-sprout</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/mcp-spring/mcp-spring-webmvc/pom.xml
+++ b/mcp-spring/mcp-spring-webmvc/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 		<artifactId>mcp-parent</artifactId>
-		<version>0.12.0-sprout</version>
+		<version>0.13.0-sprout</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>mcp-spring-webmvc</artifactId>
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp</artifactId>
-			<version>0.12.0-sprout</version>
+			<version>0.13.0-sprout</version>
 		</dependency>
 
 		<dependency>
@@ -37,14 +37,14 @@
 		<dependency>
 			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp-test</artifactId>
-			<version>0.12.0-sprout</version>
+			<version>0.13.0-sprout</version>
 			<scope>test</scope>
 		</dependency>
 
 				<dependency>
 			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp-spring-webflux</artifactId>
-			<version>0.12.0-sprout</version>
+			<version>0.13.0-sprout</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/mcp-test/pom.xml
+++ b/mcp-test/pom.xml
@@ -4,7 +4,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>io.modelcontextprotocol.sdk</groupId>
+		<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 		<artifactId>mcp-parent</artifactId>
 		<version>0.12.0-SNAPSHOT</version>
 	</parent>

--- a/mcp-test/pom.xml
+++ b/mcp-test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 		<artifactId>mcp-parent</artifactId>
-		<version>0.12.0-SNAPSHOT</version>
+		<version>0.12.0-sprout</version>
 	</parent>
 	<artifactId>mcp-test</artifactId>
 	<packaging>jar</packaging>

--- a/mcp-test/pom.xml
+++ b/mcp-test/pom.xml
@@ -22,9 +22,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp</artifactId>
-			<version>0.12.0-SNAPSHOT</version>
+			<version>0.12.0-sprout</version>
 		</dependency>
 
 		<dependency>

--- a/mcp-test/pom.xml
+++ b/mcp-test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 		<artifactId>mcp-parent</artifactId>
-		<version>0.12.0-sprout</version>
+		<version>0.13.0-sprout</version>
 	</parent>
 	<artifactId>mcp-test</artifactId>
 	<packaging>jar</packaging>
@@ -24,7 +24,7 @@
 		<dependency>
 			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp</artifactId>
-			<version>0.12.0-sprout</version>
+			<version>0.13.0-sprout</version>
 		</dependency>
 
 		<dependency>

--- a/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientResiliencyTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientResiliencyTests.java
@@ -48,7 +48,8 @@ public abstract class AbstractMcpAsyncClientResiliencyTests {
 
 	// Uses the https://github.com/tzolov/mcp-everything-server-docker-image
 	@SuppressWarnings("resource")
-	static GenericContainer<?> container = new GenericContainer<>("docker.io/tzolov/mcp-everything-server:v2")
+	static GenericContainer<?> container = new GenericContainer<>(
+			"412335208158.dkr.ecr.us-east-1.amazonaws.com/docker-hub/tzolov/mcp-everything-server:v2")
 		.withCommand("node dist/index.js streamableHttp")
 		.withLogConsumer(outputFrame -> System.out.println(outputFrame.getUtf8String()))
 		.withNetwork(network)

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -4,7 +4,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>io.modelcontextprotocol.sdk</groupId>
+		<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 		<artifactId>mcp-parent</artifactId>
 		<version>0.12.0-SNAPSHOT</version>
 	</parent>

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 		<artifactId>mcp-parent</artifactId>
-		<version>0.12.0-SNAPSHOT</version>
+		<version>0.12.0-sprout</version>
 	</parent>
 	<artifactId>mcp</artifactId>
 	<packaging>jar</packaging>

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 		<artifactId>mcp-parent</artifactId>
-		<version>0.12.0-sprout</version>
+		<version>0.13.0-sprout</version>
 	</parent>
 	<artifactId>mcp</artifactId>
 	<packaging>jar</packaging>

--- a/mcp/src/main/java/io/modelcontextprotocol/server/DefaultMcpTransportContext.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/DefaultMcpTransportContext.java
@@ -5,6 +5,7 @@
 package io.modelcontextprotocol.server;
 
 import java.util.Map;
+import java.util.StringJoiner;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -44,6 +45,15 @@ public class DefaultMcpTransportContext implements McpTransportContext {
 	 */
 	public McpTransportContext copy() {
 		return new DefaultMcpTransportContext(new ConcurrentHashMap<>(this.storage));
+	}
+
+	// TODO for debugging
+
+	@Override
+	public String toString() {
+		return new StringJoiner(", ", DefaultMcpTransportContext.class.getSimpleName() + "[", "]")
+			.add("storage=" + storage)
+			.toString();
 	}
 
 }

--- a/mcp/src/main/java/io/modelcontextprotocol/server/DefaultMcpTransportContext.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/DefaultMcpTransportContext.java
@@ -5,7 +5,6 @@
 package io.modelcontextprotocol.server;
 
 import java.util.Map;
-import java.util.StringJoiner;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**

--- a/mcp/src/main/java/io/modelcontextprotocol/server/DefaultMcpTransportContext.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/DefaultMcpTransportContext.java
@@ -47,13 +47,4 @@ public class DefaultMcpTransportContext implements McpTransportContext {
 		return new DefaultMcpTransportContext(new ConcurrentHashMap<>(this.storage));
 	}
 
-	// TODO for debugging
-
-	@Override
-	public String toString() {
-		return new StringJoiner(", ", DefaultMcpTransportContext.class.getSimpleName() + "[", "]")
-			.add("storage=" + storage)
-			.toString();
-	}
-
 }

--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
@@ -180,7 +180,7 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 	 * @param messageEndpoint The endpoint path where clients will send their messages
 	 * @param sseEndpoint The endpoint path where clients will establish SSE connections
 	 * @param keepAliveInterval The interval for keep-alive pings, or null to disable
-     * keep-alive functionality
+	 * keep-alive functionality
 	 * @param contextExtractor The extractor for transport context from the request.
 	 * @deprecated Use the builder {@link #builder()} instead for better configuration
 	 * options.

--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
@@ -16,6 +16,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.server.DefaultMcpTransportContext;
+import io.modelcontextprotocol.server.McpTransportContext;
+import io.modelcontextprotocol.server.McpTransportContextExtractor;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpServerSession;
@@ -102,6 +105,8 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 	/** Map of active client sessions, keyed by session ID */
 	private final Map<String, McpServerSession> sessions = new ConcurrentHashMap<>();
 
+	private McpTransportContextExtractor<HttpServletRequest> contextExtractor;
+
 	/** Flag indicating if the transport is in the process of shutting down */
 	private final AtomicBoolean isClosing = new AtomicBoolean(false);
 
@@ -144,7 +149,7 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 	@Deprecated
 	public HttpServletSseServerTransportProvider(ObjectMapper objectMapper, String baseUrl, String messageEndpoint,
 			String sseEndpoint) {
-		this(objectMapper, baseUrl, messageEndpoint, sseEndpoint, null);
+		this(objectMapper, baseUrl, messageEndpoint, sseEndpoint, null, null);
 	}
 
 	/**
@@ -163,11 +168,33 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 	@Deprecated
 	public HttpServletSseServerTransportProvider(ObjectMapper objectMapper, String baseUrl, String messageEndpoint,
 			String sseEndpoint, Duration keepAliveInterval) {
+		this(objectMapper, baseUrl, messageEndpoint, sseEndpoint, keepAliveInterval, null);
+	}
+
+	/**
+	 * Creates a new HttpServletSseServerTransportProvider instance with a custom SSE
+	 * endpoint.
+	 * @param objectMapper The JSON object mapper to use for message
+	 * serialization/deserialization
+	 * @param baseUrl The base URL for the server transport
+	 * @param messageEndpoint The endpoint path where clients will send their messages
+	 * @param sseEndpoint The endpoint path where clients will establish SSE connections
+	 * @param keepAliveInterval The interval for keep-alive pings, or null to disable
+	 * @param contextExtractor The extractor for transport context from the request.
+	 * keep-alive functionality
+	 * @deprecated Use the builder {@link #builder()} instead for better configuration
+	 * options.
+	 */
+	@Deprecated
+	public HttpServletSseServerTransportProvider(ObjectMapper objectMapper, String baseUrl, String messageEndpoint,
+			String sseEndpoint, Duration keepAliveInterval,
+			McpTransportContextExtractor<HttpServletRequest> contextExtractor) {
 
 		this.objectMapper = objectMapper;
 		this.baseUrl = baseUrl;
 		this.messageEndpoint = messageEndpoint;
 		this.sseEndpoint = sseEndpoint;
+		this.contextExtractor = contextExtractor;
 
 		if (keepAliveInterval != null) {
 
@@ -339,10 +366,13 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 				body.append(line);
 			}
 
+			final McpTransportContext transportContext = contextExtractor.extract(request,
+					new DefaultMcpTransportContext());
 			McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(objectMapper, body.toString());
 
 			// Process the message through the session's handle method
-			session.handle(message).block(); // Block for Servlet compatibility
+			// Block for Servlet compatibility
+			session.handle(message).contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext)).block();
 
 			response.setStatus(HttpServletResponse.SC_OK);
 		}
@@ -534,6 +564,8 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 
 		private String sseEndpoint = DEFAULT_SSE_ENDPOINT;
 
+		private McpTransportContextExtractor<HttpServletRequest> contextExtractor = (serverRequest, context) -> context;
+
 		private Duration keepAliveInterval;
 
 		/**
@@ -584,6 +616,19 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 		}
 
 		/**
+		 * Sets the context extractor for extracting transport context from the request.
+		 * @param contextExtractor The context extractor to use. Must not be null.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if contextExtractor is null
+		 */
+		public HttpServletSseServerTransportProvider.Builder contextExtractor(
+				McpTransportContextExtractor<HttpServletRequest> contextExtractor) {
+			Assert.notNull(contextExtractor, "Context extractor must not be null");
+			this.contextExtractor = contextExtractor;
+			return this;
+		}
+
+		/**
 		 * Sets the interval for keep-alive pings.
 		 * <p>
 		 * If not specified, keep-alive pings will be disabled.
@@ -609,7 +654,7 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 				throw new IllegalStateException("MessageEndpoint must be set");
 			}
 			return new HttpServletSseServerTransportProvider(objectMapper, baseUrl, messageEndpoint, sseEndpoint,
-					keepAliveInterval);
+					keepAliveInterval, contextExtractor);
 		}
 
 	}

--- a/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
+++ b/mcp/src/main/java/io/modelcontextprotocol/server/transport/HttpServletSseServerTransportProvider.java
@@ -180,8 +180,8 @@ public class HttpServletSseServerTransportProvider extends HttpServlet implement
 	 * @param messageEndpoint The endpoint path where clients will send their messages
 	 * @param sseEndpoint The endpoint path where clients will establish SSE connections
 	 * @param keepAliveInterval The interval for keep-alive pings, or null to disable
+     * keep-alive functionality
 	 * @param contextExtractor The extractor for transport context from the request.
-	 * keep-alive functionality
 	 * @deprecated Use the builder {@link #builder()} instead for better configuration
 	 * options.
 	 */

--- a/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientResiliencyTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/AbstractMcpAsyncClientResiliencyTests.java
@@ -49,7 +49,8 @@ public abstract class AbstractMcpAsyncClientResiliencyTests {
 
 	// Uses the https://github.com/tzolov/mcp-everything-server-docker-image
 	@SuppressWarnings("resource")
-	static GenericContainer<?> container = new GenericContainer<>("docker.io/tzolov/mcp-everything-server:v2")
+	static GenericContainer<?> container = new GenericContainer<>(
+			"412335208158.dkr.ecr.us-east-1.amazonaws.com/docker-hub/tzolov/mcp-everything-server:v2")
 		.withCommand("node dist/index.js streamableHttp")
 		.withLogConsumer(outputFrame -> System.out.println(outputFrame.getUtf8String()))
 		.withNetwork(network)

--- a/mcp/src/test/java/io/modelcontextprotocol/client/HttpClientStreamableHttpAsyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/HttpClientStreamableHttpAsyncClientTests.java
@@ -18,7 +18,8 @@ public class HttpClientStreamableHttpAsyncClientTests extends AbstractMcpAsyncCl
 
 	// Uses the https://github.com/tzolov/mcp-everything-server-docker-image
 	@SuppressWarnings("resource")
-	GenericContainer<?> container = new GenericContainer<>("docker.io/tzolov/mcp-everything-server:v2")
+	GenericContainer<?> container = new GenericContainer<>(
+			"412335208158.dkr.ecr.us-east-1.amazonaws.com/docker-hub/tzolov/mcp-everything-server:v2")
 		.withCommand("node dist/index.js streamableHttp")
 		.withLogConsumer(outputFrame -> System.out.println(outputFrame.getUtf8String()))
 		.withExposedPorts(3001)

--- a/mcp/src/test/java/io/modelcontextprotocol/client/HttpClientStreamableHttpSyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/HttpClientStreamableHttpSyncClientTests.java
@@ -18,7 +18,8 @@ public class HttpClientStreamableHttpSyncClientTests extends AbstractMcpSyncClie
 
 	// Uses the https://github.com/tzolov/mcp-everything-server-docker-image
 	@SuppressWarnings("resource")
-	GenericContainer<?> container = new GenericContainer<>("docker.io/tzolov/mcp-everything-server:v2")
+	GenericContainer<?> container = new GenericContainer<>(
+			"412335208158.dkr.ecr.us-east-1.amazonaws.com/docker-hub/tzolov/mcp-everything-server:v2")
 		.withCommand("node dist/index.js streamableHttp")
 		.withLogConsumer(outputFrame -> System.out.println(outputFrame.getUtf8String()))
 		.withExposedPorts(3001)

--- a/mcp/src/test/java/io/modelcontextprotocol/client/HttpSseMcpAsyncClientLostConnectionTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/HttpSseMcpAsyncClientLostConnectionTests.java
@@ -38,7 +38,8 @@ public class HttpSseMcpAsyncClientLostConnectionTests {
 
 	// Uses the https://github.com/tzolov/mcp-everything-server-docker-image
 	@SuppressWarnings("resource")
-	static GenericContainer<?> container = new GenericContainer<>("docker.io/tzolov/mcp-everything-server:v2")
+	static GenericContainer<?> container = new GenericContainer<>(
+			"412335208158.dkr.ecr.us-east-1.amazonaws.com/docker-hub/tzolov/mcp-everything-server:v2")
 		.withCommand("node dist/index.js sse")
 		.withLogConsumer(outputFrame -> System.out.println(outputFrame.getUtf8String()))
 		.withNetwork(network)

--- a/mcp/src/test/java/io/modelcontextprotocol/client/HttpSseMcpAsyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/HttpSseMcpAsyncClientTests.java
@@ -23,7 +23,8 @@ class HttpSseMcpAsyncClientTests extends AbstractMcpAsyncClientTests {
 
 	// Uses the https://github.com/tzolov/mcp-everything-server-docker-image
 	@SuppressWarnings("resource")
-	GenericContainer<?> container = new GenericContainer<>("docker.io/tzolov/mcp-everything-server:v2")
+	GenericContainer<?> container = new GenericContainer<>(
+			"412335208158.dkr.ecr.us-east-1.amazonaws.com/docker-hub/tzolov/mcp-everything-server:v2")
 		.withCommand("node dist/index.js sse")
 		.withLogConsumer(outputFrame -> System.out.println(outputFrame.getUtf8String()))
 		.withExposedPorts(3001)

--- a/mcp/src/test/java/io/modelcontextprotocol/client/HttpSseMcpSyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/HttpSseMcpSyncClientTests.java
@@ -22,7 +22,8 @@ class HttpSseMcpSyncClientTests extends AbstractMcpSyncClientTests {
 
 	// Uses the https://github.com/tzolov/mcp-everything-server-docker-image
 	@SuppressWarnings("resource")
-	GenericContainer<?> container = new GenericContainer<>("docker.io/tzolov/mcp-everything-server:v2")
+	GenericContainer<?> container = new GenericContainer<>(
+			"412335208158.dkr.ecr.us-east-1.amazonaws.com/docker-hub/tzolov/mcp-everything-server:v2")
 		.withCommand("node dist/index.js sse")
 		.withLogConsumer(outputFrame -> System.out.println(outputFrame.getUtf8String()))
 		.withExposedPorts(3001)

--- a/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpAsyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpAsyncClientTests.java
@@ -23,15 +23,21 @@ class StdioMcpAsyncClientTests extends AbstractMcpAsyncClientTests {
 	@Override
 	protected McpClientTransport createMcpTransport() {
 		ServerParameters stdioParams;
-		if (System.getProperty("os.name").toLowerCase().contains("win")) {
-			stdioParams = ServerParameters.builder("cmd.exe")
-				.args("/c", "npx.cmd", "-y", "@modelcontextprotocol/server-everything", "stdio")
-				.build();
-		}
+        String currentPath = System.getenv("PATH");
+        String nodePath = System.getProperty("user.dir") + "/node";
+        String newPath = nodePath + (currentPath != null ? System.getProperty("path.separator") + currentPath : "");
+
+        if (System.getProperty("os.name").toLowerCase().contains("win")) {
+            stdioParams = ServerParameters.builder("./node/npx.cmd")
+                .args("-y", "@modelcontextprotocol/server-everything", "stdio")
+                .addEnvVar("PATH", newPath)
+                .build();
+        }
 		else {
-			stdioParams = ServerParameters.builder("npx")
-				.args("-y", "@modelcontextprotocol/server-everything", "stdio")
-				.build();
+            stdioParams = ServerParameters.builder("./node/npx")
+                .args("-y", "@modelcontextprotocol/server-everything", "stdio")
+                .addEnvVar("PATH", newPath)
+                .build();
 		}
 		return new StdioClientTransport(stdioParams);
 	}

--- a/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpAsyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpAsyncClientTests.java
@@ -23,21 +23,21 @@ class StdioMcpAsyncClientTests extends AbstractMcpAsyncClientTests {
 	@Override
 	protected McpClientTransport createMcpTransport() {
 		ServerParameters stdioParams;
-        String currentPath = System.getenv("PATH");
-        String nodePath = System.getProperty("user.dir") + "/node";
-        String newPath = nodePath + (currentPath != null ? System.getProperty("path.separator") + currentPath : "");
+		String currentPath = System.getenv("PATH");
+		String nodePath = System.getProperty("user.dir") + "/node";
+		String newPath = nodePath + (currentPath != null ? System.getProperty("path.separator") + currentPath : "");
 
-        if (System.getProperty("os.name").toLowerCase().contains("win")) {
-            stdioParams = ServerParameters.builder("./node/npx.cmd")
-                .args("-y", "@modelcontextprotocol/server-everything", "stdio")
-                .addEnvVar("PATH", newPath)
-                .build();
-        }
+		if (System.getProperty("os.name").toLowerCase().contains("win")) {
+			stdioParams = ServerParameters.builder("./node/npx.cmd")
+				.args("-y", "@modelcontextprotocol/server-everything", "stdio")
+				.addEnvVar("PATH", newPath)
+				.build();
+		}
 		else {
-            stdioParams = ServerParameters.builder("./node/npx")
-                .args("-y", "@modelcontextprotocol/server-everything", "stdio")
-                .addEnvVar("PATH", newPath)
-                .build();
+			stdioParams = ServerParameters.builder("./node/npx")
+				.args("-y", "@modelcontextprotocol/server-everything", "stdio")
+				.addEnvVar("PATH", newPath)
+				.build();
 		}
 		return new StdioClientTransport(stdioParams);
 	}

--- a/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpSyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpSyncClientTests.java
@@ -31,15 +31,21 @@ class StdioMcpSyncClientTests extends AbstractMcpSyncClientTests {
 	@Override
 	protected McpClientTransport createMcpTransport() {
 		ServerParameters stdioParams;
-		if (System.getProperty("os.name").toLowerCase().contains("win")) {
-			stdioParams = ServerParameters.builder("cmd.exe")
-				.args("/c", "npx.cmd", "-y", "@modelcontextprotocol/server-everything", "stdio")
+        String currentPath = System.getenv("PATH");
+        String nodePath = System.getProperty("user.dir") + "/node";
+        String newPath = nodePath + (currentPath != null ? System.getProperty("path.separator") + currentPath : "");
+
+        if (System.getProperty("os.name").toLowerCase().contains("win")) {
+            stdioParams = ServerParameters.builder("./node/npx.cmd")
+                .args("-y", "@modelcontextprotocol/server-everything", "stdio")
+                .addEnvVar("PATH", newPath)
 				.build();
 		}
 		else {
-			stdioParams = ServerParameters.builder("npx")
-				.args("-y", "@modelcontextprotocol/server-everything", "stdio")
-				.build();
+            stdioParams = ServerParameters.builder("./node/npx")
+                .args("-y", "@modelcontextprotocol/server-everything", "stdio")
+                .addEnvVar("PATH", newPath)
+                .build();
 		}
 		return new StdioClientTransport(stdioParams);
 	}

--- a/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpSyncClientTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/StdioMcpSyncClientTests.java
@@ -31,21 +31,21 @@ class StdioMcpSyncClientTests extends AbstractMcpSyncClientTests {
 	@Override
 	protected McpClientTransport createMcpTransport() {
 		ServerParameters stdioParams;
-        String currentPath = System.getenv("PATH");
-        String nodePath = System.getProperty("user.dir") + "/node";
-        String newPath = nodePath + (currentPath != null ? System.getProperty("path.separator") + currentPath : "");
+		String currentPath = System.getenv("PATH");
+		String nodePath = System.getProperty("user.dir") + "/node";
+		String newPath = nodePath + (currentPath != null ? System.getProperty("path.separator") + currentPath : "");
 
-        if (System.getProperty("os.name").toLowerCase().contains("win")) {
-            stdioParams = ServerParameters.builder("./node/npx.cmd")
-                .args("-y", "@modelcontextprotocol/server-everything", "stdio")
-                .addEnvVar("PATH", newPath)
+		if (System.getProperty("os.name").toLowerCase().contains("win")) {
+			stdioParams = ServerParameters.builder("./node/npx.cmd")
+				.args("-y", "@modelcontextprotocol/server-everything", "stdio")
+				.addEnvVar("PATH", newPath)
 				.build();
 		}
 		else {
-            stdioParams = ServerParameters.builder("./node/npx")
-                .args("-y", "@modelcontextprotocol/server-everything", "stdio")
-                .addEnvVar("PATH", newPath)
-                .build();
+			stdioParams = ServerParameters.builder("./node/npx")
+				.args("-y", "@modelcontextprotocol/server-everything", "stdio")
+				.addEnvVar("PATH", newPath)
+				.build();
 		}
 		return new StdioClientTransport(stdioParams);
 	}

--- a/mcp/src/test/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransportTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/transport/HttpClientSseClientTransportTests.java
@@ -54,7 +54,8 @@ class HttpClientSseClientTransportTests {
 	static String host = "http://localhost:3001";
 
 	@SuppressWarnings("resource")
-	static GenericContainer<?> container = new GenericContainer<>("docker.io/tzolov/mcp-everything-server:v2")
+	static GenericContainer<?> container = new GenericContainer<>(
+			"412335208158.dkr.ecr.us-east-1.amazonaws.com/docker-hub/tzolov/mcp-everything-server:v2")
 		.withCommand("node dist/index.js sse")
 		.withLogConsumer(outputFrame -> System.out.println(outputFrame.getUtf8String()))
 		.withExposedPorts(3001)

--- a/mcp/src/test/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransportTest.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransportTest.java
@@ -33,7 +33,8 @@ class HttpClientStreamableHttpTransportTest {
 	static String host = "http://localhost:3001";
 
 	@SuppressWarnings("resource")
-	static GenericContainer<?> container = new GenericContainer<>("docker.io/tzolov/mcp-everything-server:v2")
+	static GenericContainer<?> container = new GenericContainer<>(
+			"412335208158.dkr.ecr.us-east-1.amazonaws.com/docker-hub/tzolov/mcp-everything-server:v2")
 		.withCommand("node dist/index.js streamableHttp")
 		.withLogConsumer(outputFrame -> System.out.println(outputFrame.getUtf8String()))
 		.withExposedPorts(3001)

--- a/mcp/src/test/java/io/modelcontextprotocol/server/HttpServletSseIntegrationTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/HttpServletSseIntegrationTests.java
@@ -40,6 +40,7 @@ class HttpServletSseIntegrationTests extends AbstractMcpClientServerIntegrationT
 		// Create and configure the transport provider
 		mcpServerTransportProvider = HttpServletSseServerTransportProvider.builder()
 			.objectMapper(new ObjectMapper())
+			.contextExtractor(extractor)
 			.messageEndpoint(CUSTOM_MESSAGE_ENDPOINT)
 			.sseEndpoint(CUSTOM_SSE_ENDPOINT)
 			.build();

--- a/mcp/src/test/java/io/modelcontextprotocol/server/HttpServletStreamableIntegrationTests.java
+++ b/mcp/src/test/java/io/modelcontextprotocol/server/HttpServletStreamableIntegrationTests.java
@@ -38,6 +38,7 @@ class HttpServletStreamableIntegrationTests extends AbstractMcpClientServerInteg
 		// Create and configure the transport provider
 		mcpServerTransportProvider = HttpServletStreamableServerTransportProvider.builder()
 			.objectMapper(new ObjectMapper())
+			.contextExtractor(extractor)
 			.mcpEndpoint(MESSAGE_ENDPOINT)
 			.keepAliveInterval(Duration.ofSeconds(1))
 			.build();

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>io.modelcontextprotocol.sdk</groupId>
+	<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 	<artifactId>mcp-parent</artifactId>
 	<version>0.12.0-SNAPSHOT</version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 	<artifactId>mcp-parent</artifactId>
-	<version>0.12.0-SNAPSHOT</version>
+	<version>0.12.0-sprout</version>
 
 	<packaging>pom</packaging>
 	<url>https://github.com/modelcontextprotocol/java-sdk</url>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
 		<bnd-maven-plugin.version>7.1.0</bnd-maven-plugin.version>
 		<json-unit-assertj.version>4.1.0</json-unit-assertj.version>
 		<json-schema-validator.version>1.5.7</json-schema-validator.version>
+        <frontend-maven-plugin.version>1.15.1</frontend-maven-plugin.version>
 
 	</properties>
 
@@ -259,7 +260,26 @@
 				<artifactId>maven-deploy-plugin</artifactId>
 				<version>${maven-deploy-plugin.version}</version>
 			</plugin>
-		</plugins>
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <version>${frontend-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>install node and npm</id>
+                        <goals>
+                            <goal>install-node-and-npm</goal>
+                        </goals>
+                        <phase>generate-test-resources</phase>
+                        <configuration>
+                            <nodeVersion>v18.19.0</nodeVersion>
+                            <npmVersion>10.2.4</npmVersion>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
 	</build>
 
 	<profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -390,4 +390,15 @@
 		</repository>
 	</repositories>
 
+    <distributionManagement>
+        <repository>
+            <id>internal</id>
+            <url>https://nexus.int.sproutsocial.com/nexus/content/repositories/releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>snapshots</id>
+            <url>https://nexus.int.sproutsocial.com/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 	<artifactId>mcp-parent</artifactId>
-	<version>0.12.0-sprout</version>
+	<version>0.13.0-sprout</version>
 
 	<packaging>pom</packaging>
 	<url>https://github.com/modelcontextprotocol/java-sdk</url>
@@ -255,10 +255,23 @@
 					</execution>
 				</executions>
 			</plugin>
+			<!-- Deploy to US CodeArtifact -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
 				<version>${maven-deploy-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>us-deploy</id>
+						<phase>deploy</phase>
+						<goals>
+							<goal>deploy</goal>
+						</goals>
+						<configuration>
+							<altDeploymentRepository>sproutsocial-us-releases::https://sproutsocial-412335208158.d.codeartifact.us-east-1.amazonaws.com/maven/mvn_releases/</altDeploymentRepository>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
             <plugin>
                 <groupId>com.github.eirslett</groupId>
@@ -387,6 +400,16 @@
 			<releases>
 				<enabled>true</enabled>
 			</releases>
+		</repository>
+		<repository>
+			<id>sproutsocial-us-releases</id>
+			<url>https://sproutsocial-412335208158.d.codeartifact.us-east-1.amazonaws.com/maven/mvn_releases/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Enables dual publishing to AWS CodeArtifact on `java-mcp-sdk` while preserving the existing Nexus deployment. This is part of the Phase 1 Nexus → CodeArtifact migration (TOOLCM-4349). Artifacts will now be published to both registries during `mvn deploy`, allowing gradual consumer migration without disruption.

## Change Summary

- **pom.xml**: Version bumped 0.12.0-sprout → 0.13.0-sprout (minor). Added a `us-deploy` execution to the existing `maven-deploy-plugin` declaration with an `altDeploymentRepository` pointing at the `sproutsocial-us-releases` CodeArtifact registry. Added a matching `<repository>` entry for `sproutsocial-us-releases` under `<repositories>` so the registry is also available for dependency resolution. Existing Nexus `<distributionManagement>` is untouched.
- **mcp-bom/pom.xml**: Version bumped 0.12.0-sprout → 0.13.0-sprout (parent ref + internal module refs).
- **mcp/pom.xml**: Version bumped 0.12.0-sprout → 0.13.0-sprout (parent ref).
- **mcp-test/pom.xml**: Version bumped 0.12.0-sprout → 0.13.0-sprout (parent ref + internal `mcp` dep).
- **mcp-spring/mcp-spring-webflux/pom.xml**: Version bumped 0.12.0-sprout → 0.13.0-sprout (parent ref + internal module refs).
- **mcp-spring/mcp-spring-webmvc/pom.xml**: Version bumped 0.12.0-sprout → 0.13.0-sprout (parent ref + internal module refs).

No CHANGELOG.md exists in this repo, so none was added (per the skill: don't introduce new CHANGELOGs).

## Related Links

- [TOOLCM-4360](https://sprout.atlassian.net/browse/TOOLCM-4360)
- [TOOLCM-4349](https://sprout.atlassian.net/browse/TOOLCM-4349) (parent batch)