### PR TITLE
Fix nested path URI resolution

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/util/Utils.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/util/Utils.java
@@ -5,6 +5,7 @@
 package io.modelcontextprotocol.util;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Map;
 
@@ -76,9 +77,40 @@ public final class Utils {
 		if (endpointUri.isAbsolute() && !isUnderBaseUri(baseUrl, endpointUri)) {
 			throw new IllegalArgumentException("Absolute endpoint URL does not match the base URL.");
 		}
-		else {
-			return baseUrl.resolve(endpointUri);
+		else if (endpointUri.isAbsolute()) {
+			return endpointUri;
 		}
+
+		return baseUrlWithTrailingSlash(baseUrl).resolve(removeLeadingSlash(endpointUrl));
+	}
+
+	private static URI baseUrlWithTrailingSlash(URI baseUrl) {
+		String path = baseUrl.getPath();
+		if (path == null || path.isEmpty()) {
+			return createUriWithPath(baseUrl, "/");
+		}
+		if (path.endsWith("/")) {
+			return baseUrl;
+		}
+		return createUriWithPath(baseUrl, path + "/");
+	}
+
+	private static URI createUriWithPath(URI baseUrl, String path) {
+		try {
+			return new URI(baseUrl.getScheme(), baseUrl.getAuthority(), path, baseUrl.getQuery(),
+					baseUrl.getFragment());
+		}
+		catch (URISyntaxException ex) {
+			throw new IllegalArgumentException("Invalid base URL.", ex);
+		}
+	}
+
+	private static String removeLeadingSlash(String endpointUrl) {
+		String result = endpointUrl;
+		while (result.startsWith("/")) {
+			result = result.substring(1);
+		}
+		return result;
 	}
 
 	/**

--- a/mcp-core/src/test/java/io/modelcontextprotocol/util/UtilsTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/util/UtilsTests.java
@@ -45,9 +45,11 @@ class UtilsTests {
 	@ParameterizedTest
 	@CsvSource({
 			// relative endpoints
-			"http://localhost:8080/root, /api/v1, http://localhost:8080/api/v1",
+			"http://localhost:8080/root, /api/v1, http://localhost:8080/root/api/v1",
+			"http://localhost:8080/root, api/v1, http://localhost:8080/root/api/v1",
 			"http://localhost:8080/root/, api, http://localhost:8080/root/api",
 			"http://localhost:8080, /api, http://localhost:8080/api",
+			"http://localhost:8080/root, /api/v1?key=value, http://localhost:8080/root/api/v1?key=value",
 			// absolute endpoints matching base
 			"http://localhost:8080/root, http://localhost:8080/root/api/v1, http://localhost:8080/root/api/v1",
 			"http://localhost:8080/root, http://localhost:8080/root, http://localhost:8080/root" })


### PR DESCRIPTION
## Summary

Fixes #257

`Utils.resolveUri` incorrectly handled nested base paths — relative endpoints with a leading slash (e.g. `/api/v1`) would replace the base path entirely instead of being appended to it. This affected `HttpClientSseClientTransport` and `HttpClientStreamableHttpTransport` when the base URL had a non-root path (e.g. `https://example.com/some`).

### Root cause

`URI.resolve()` follows RFC 3986 §5.2.3: when the relative reference starts with `/`, it replaces the entire path of the base URI. So `URI.create("https://example.com/some").resolve("/path")` yields `https://example.com/path`, dropping `/some`.

### Fix approach

- Ensure the base URL always has a trailing slash (e.g. `/root` → `/root/`)
- Strip leading slashes from the endpoint (e.g. `/api/v1` → `api/v1`)
- `URI.resolve()` then performs path concatenation (`/root/` + `api/v1` = `/root/api/v1`), consistent with RFC 3986
- Absolute endpoint validation behavior is preserved unchanged

## Testing

- `./mvnw.cmd -pl mcp-core -Dtest=UtilsTests test`
- `./mvnw.cmd -pl mcp-core test`
- Added parameterized test cases covering: nested base paths, leading/trailing slashes, and query strings