### PR TITLE
fix: replace Mono.zip with Mono.when in StdioServerTransportProvider#sendMessage

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
@@ -160,7 +160,7 @@ public class StdioServerTransportProvider implements McpServerTransportProvider 
 		@Override
 		public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
 
-			return Mono.zip(inboundReady.asMono(), outboundReady.asMono()).then(Mono.defer(() -> {
+			return Mono.when(inboundReady.asMono(), outboundReady.asMono()).then(Mono.defer(() -> {
 				if (outboundSink.tryEmitNext(message).isSuccess()) {
 					return Mono.empty();
 				}


### PR DESCRIPTION
## Summary
- `Mono.zip()` in `sendMessage()` never completes because `inboundReady` and `outboundReady` are `Sinks.One<Void>` that emit `null` via `tryEmitValue(null)` — `zip` requires actual non-null values to produce a `Tuple2`
- Replaced with `Mono.when()` which correctly waits for completion signals without requiring values

## Test plan
- [x] All 9 existing `StdioServerTransportProviderTests` pass
- [ ] CI pipeline passes

Closes #303