### PR TITLE
feat: add duplicateStructuredContent option to server builders

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -101,6 +101,8 @@ public class McpAsyncServer {
 
 	private final boolean validateToolInputs;
 
+	private final boolean duplicateStructuredContent;
+
 	private final McpSchema.ServerCapabilities serverCapabilities;
 
 	private final McpSchema.Implementation serverInfo;
@@ -133,13 +135,14 @@ public class McpAsyncServer {
 	McpAsyncServer(McpServerTransportProvider mcpTransportProvider, McpJsonMapper jsonMapper,
 			McpServerFeatures.Async features, Duration requestTimeout,
 			McpUriTemplateManagerFactory uriTemplateManagerFactory, JsonSchemaValidator jsonSchemaValidator,
-			boolean validateToolInputs) {
+			boolean validateToolInputs, boolean duplicateStructuredContent) {
 		this.mcpTransportProvider = mcpTransportProvider;
 		this.jsonMapper = jsonMapper;
 		this.serverInfo = features.serverInfo();
 		this.serverCapabilities = features.serverCapabilities().mutate().logging().build();
 		this.instructions = features.instructions();
-		this.tools.addAll(withStructuredOutputHandling(jsonSchemaValidator, features.tools()));
+		this.tools
+			.addAll(withStructuredOutputHandling(jsonSchemaValidator, duplicateStructuredContent, features.tools()));
 		this.resources.putAll(features.resources());
 		this.resourceTemplates.putAll(features.resourceTemplates());
 		this.prompts.putAll(features.prompts());
@@ -147,6 +150,7 @@ public class McpAsyncServer {
 		this.uriTemplateManagerFactory = uriTemplateManagerFactory;
 		this.jsonSchemaValidator = jsonSchemaValidator;
 		this.validateToolInputs = validateToolInputs;
+		this.duplicateStructuredContent = duplicateStructuredContent;
 
 		Map<String, McpRequestHandler<?>> requestHandlers = prepareRequestHandlers();
 		Map<String, McpNotificationHandler> notificationHandlers = prepareNotificationHandlers(features);
@@ -164,13 +168,14 @@ public class McpAsyncServer {
 	McpAsyncServer(McpStreamableServerTransportProvider mcpTransportProvider, McpJsonMapper jsonMapper,
 			McpServerFeatures.Async features, Duration requestTimeout,
 			McpUriTemplateManagerFactory uriTemplateManagerFactory, JsonSchemaValidator jsonSchemaValidator,
-			boolean validateToolInputs) {
+			boolean validateToolInputs, boolean duplicateStructuredContent) {
 		this.mcpTransportProvider = mcpTransportProvider;
 		this.jsonMapper = jsonMapper;
 		this.serverInfo = features.serverInfo();
 		this.serverCapabilities = features.serverCapabilities().mutate().logging().build();
 		this.instructions = features.instructions();
-		this.tools.addAll(withStructuredOutputHandling(jsonSchemaValidator, features.tools()));
+		this.tools
+			.addAll(withStructuredOutputHandling(jsonSchemaValidator, duplicateStructuredContent, features.tools()));
 		this.resources.putAll(features.resources());
 		this.resourceTemplates.putAll(features.resourceTemplates());
 		this.prompts.putAll(features.prompts());
@@ -178,6 +183,7 @@ public class McpAsyncServer {
 		this.uriTemplateManagerFactory = uriTemplateManagerFactory;
 		this.jsonSchemaValidator = jsonSchemaValidator;
 		this.validateToolInputs = validateToolInputs;
+		this.duplicateStructuredContent = duplicateStructuredContent;
 
 		Map<String, McpRequestHandler<?>> requestHandlers = prepareRequestHandlers();
 		Map<String, McpNotificationHandler> notificationHandlers = prepareNotificationHandlers(features);
@@ -357,7 +363,8 @@ public class McpAsyncServer {
 			return Mono.error(e);
 		}
 
-		var wrappedToolSpecification = withStructuredOutputHandling(this.jsonSchemaValidator, toolSpecification);
+		var wrappedToolSpecification = withStructuredOutputHandling(this.jsonSchemaValidator,
+				this.duplicateStructuredContent, toolSpecification);
 
 		return Mono.defer(() -> {
 			// Remove tools with duplicate tool names first
@@ -384,8 +391,10 @@ public class McpAsyncServer {
 
 		private final Map<String, Object> outputSchema;
 
+		private final boolean duplicateStructuredContent;
+
 		public StructuredOutputCallToolHandler(JsonSchemaValidator jsonSchemaValidator,
-				Map<String, Object> outputSchema,
+				Map<String, Object> outputSchema, boolean duplicateStructuredContent,
 				BiFunction<McpAsyncServerExchange, McpSchema.CallToolRequest, Mono<McpSchema.CallToolResult>> delegateHandler) {
 
 			Assert.notNull(jsonSchemaValidator, "JsonSchemaValidator must not be null");
@@ -393,6 +402,7 @@ public class McpAsyncServer {
 
 			this.delegateCallToolResult = delegateHandler;
 			this.outputSchema = outputSchema;
+			this.duplicateStructuredContent = duplicateStructuredContent;
 			this.jsonSchemaValidator = jsonSchemaValidator;
 		}
 
@@ -440,7 +450,7 @@ public class McpAsyncServer {
 						.build();
 				}
 
-				if (Utils.isEmpty(result.content())) {
+				if (this.duplicateStructuredContent && Utils.isEmpty(result.content())) {
 					// For backwards compatibility, a tool that returns structured
 					// content SHOULD also return functionally equivalent unstructured
 					// content. (For example, serialized JSON can be returned in a
@@ -461,17 +471,21 @@ public class McpAsyncServer {
 	}
 
 	private static List<McpServerFeatures.AsyncToolSpecification> withStructuredOutputHandling(
-			JsonSchemaValidator jsonSchemaValidator, List<McpServerFeatures.AsyncToolSpecification> tools) {
+			JsonSchemaValidator jsonSchemaValidator, boolean duplicateStructuredContent,
+			List<McpServerFeatures.AsyncToolSpecification> tools) {
 
 		if (Utils.isEmpty(tools)) {
 			return tools;
 		}
 
-		return tools.stream().map(tool -> withStructuredOutputHandling(jsonSchemaValidator, tool)).toList();
+		return tools.stream()
+			.map(tool -> withStructuredOutputHandling(jsonSchemaValidator, duplicateStructuredContent, tool))
+			.toList();
 	}
 
 	private static McpServerFeatures.AsyncToolSpecification withStructuredOutputHandling(
-			JsonSchemaValidator jsonSchemaValidator, McpServerFeatures.AsyncToolSpecification toolSpecification) {
+			JsonSchemaValidator jsonSchemaValidator, boolean duplicateStructuredContent,
+			McpServerFeatures.AsyncToolSpecification toolSpecification) {
 
 		if (toolSpecification.callHandler() instanceof StructuredOutputCallToolHandler) {
 			// If the tool is already wrapped, return it as is
@@ -485,8 +499,9 @@ public class McpAsyncServer {
 
 		return McpServerFeatures.AsyncToolSpecification.builder()
 			.tool(toolSpecification.tool())
-			.callHandler(new StructuredOutputCallToolHandler(jsonSchemaValidator,
-					toolSpecification.tool().outputSchema(), toolSpecification.callHandler()))
+			.callHandler(
+					new StructuredOutputCallToolHandler(jsonSchemaValidator, toolSpecification.tool().outputSchema(),
+							duplicateStructuredContent, toolSpecification.callHandler()))
 			.build();
 	}
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServer.java
@@ -246,7 +246,8 @@ public interface McpServer {
 			validateAsyncToolSchemas(jsonSchemaValidator, this.tools);
 
 			return new McpAsyncServer(transportProvider, jsonMapper == null ? McpJsonDefaults.getMapper() : jsonMapper,
-					features, requestTimeout, uriTemplateManagerFactory, jsonSchemaValidator, validateToolInputs);
+					features, requestTimeout, uriTemplateManagerFactory, jsonSchemaValidator, validateToolInputs,
+					duplicateStructuredContent);
 		}
 
 	}
@@ -275,7 +276,8 @@ public interface McpServer {
 			validateAsyncToolSchemas(jsonSchemaValidator, this.tools);
 
 			return new McpAsyncServer(transportProvider, jsonMapper == null ? McpJsonDefaults.getMapper() : jsonMapper,
-					features, requestTimeout, uriTemplateManagerFactory, jsonSchemaValidator, validateToolInputs);
+					features, requestTimeout, uriTemplateManagerFactory, jsonSchemaValidator, validateToolInputs,
+					duplicateStructuredContent);
 		}
 
 	}
@@ -300,6 +302,8 @@ public interface McpServer {
 		boolean strictToolNameValidation = ToolNameValidator.isStrictByDefault();
 
 		boolean validateToolInputs = true;
+
+		boolean duplicateStructuredContent = true;
 
 		/**
 		 * The Model Context Protocol (MCP) allows servers to expose tools that can be
@@ -437,6 +441,25 @@ public interface McpServer {
 		 */
 		public AsyncSpecification<S> validateToolInputs(boolean validate) {
 			this.validateToolInputs = validate;
+			return this;
+		}
+
+		/**
+		 * Sets whether to automatically duplicate structured content into text content
+		 * for backwards compatibility. When enabled (the default), tools that return
+		 * structured content will also have the serialized JSON added as a
+		 * {@link McpSchema.TextContent} block in the {@code content} field, as
+		 * recommended by the MCP specification. Disabling this can reduce response
+		 * payload size when clients fully support {@code structuredContent}.
+		 * @param duplicate true to duplicate structured content into text content
+		 * (default), false to skip duplication
+		 * @return This builder instance for method chaining
+		 * @see <a href=
+		 * "https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content">MCP
+		 * Structured Content</a>
+		 */
+		public AsyncSpecification<S> duplicateStructuredContent(boolean duplicate) {
+			this.duplicateStructuredContent = duplicate;
 			return this;
 		}
 
@@ -841,7 +864,7 @@ public interface McpServer {
 
 			var asyncServer = new McpAsyncServer(transportProvider,
 					jsonMapper == null ? McpJsonDefaults.getMapper() : jsonMapper, asyncFeatures, requestTimeout,
-					uriTemplateManagerFactory, jsonSchemaValidator, validateToolInputs);
+					uriTemplateManagerFactory, jsonSchemaValidator, validateToolInputs, duplicateStructuredContent);
 			return new McpSyncServer(asyncServer, this.immediateExecution);
 		}
 
@@ -875,7 +898,8 @@ public interface McpServer {
 
 			var asyncServer = new McpAsyncServer(transportProvider,
 					jsonMapper == null ? McpJsonDefaults.getMapper() : jsonMapper, asyncFeatures, this.requestTimeout,
-					this.uriTemplateManagerFactory, jsonSchemaValidator, validateToolInputs);
+					this.uriTemplateManagerFactory, jsonSchemaValidator, validateToolInputs,
+					duplicateStructuredContent);
 			return new McpSyncServer(asyncServer, this.immediateExecution);
 		}
 
@@ -899,6 +923,8 @@ public interface McpServer {
 		boolean strictToolNameValidation = ToolNameValidator.isStrictByDefault();
 
 		boolean validateToolInputs = true;
+
+		boolean duplicateStructuredContent = true;
 
 		/**
 		 * The Model Context Protocol (MCP) allows servers to expose tools that can be
@@ -1040,6 +1066,25 @@ public interface McpServer {
 		 */
 		public SyncSpecification<S> validateToolInputs(boolean validate) {
 			this.validateToolInputs = validate;
+			return this;
+		}
+
+		/**
+		 * Sets whether to automatically duplicate structured content into text content
+		 * for backwards compatibility. When enabled (the default), tools that return
+		 * structured content will also have the serialized JSON added as a
+		 * {@link McpSchema.TextContent} block in the {@code content} field, as
+		 * recommended by the MCP specification. Disabling this can reduce response
+		 * payload size when clients fully support {@code structuredContent}.
+		 * @param duplicate true to duplicate structured content into text content
+		 * (default), false to skip duplication
+		 * @return This builder instance for method chaining
+		 * @see <a href=
+		 * "https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content">MCP
+		 * Structured Content</a>
+		 */
+		public SyncSpecification<S> duplicateStructuredContent(boolean duplicate) {
+			this.duplicateStructuredContent = duplicate;
 			return this;
 		}
 
@@ -1442,6 +1487,8 @@ public interface McpServer {
 
 		boolean validateToolInputs = true;
 
+		boolean duplicateStructuredContent = true;
+
 		/**
 		 * The Model Context Protocol (MCP) allows servers to expose tools that can be
 		 * invoked by language models. Tools enable models to interact with external
@@ -1579,6 +1626,25 @@ public interface McpServer {
 		 */
 		public StatelessAsyncSpecification validateToolInputs(boolean validate) {
 			this.validateToolInputs = validate;
+			return this;
+		}
+
+		/**
+		 * Sets whether to automatically duplicate structured content into text content
+		 * for backwards compatibility. When enabled (the default), tools that return
+		 * structured content will also have the serialized JSON added as a
+		 * {@link McpSchema.TextContent} block in the {@code content} field, as
+		 * recommended by the MCP specification. Disabling this can reduce response
+		 * payload size when clients fully support {@code structuredContent}.
+		 * @param duplicate true to duplicate structured content into text content
+		 * (default), false to skip duplication
+		 * @return This builder instance for method chaining
+		 * @see <a href=
+		 * "https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content">MCP
+		 * Structured Content</a>
+		 */
+		public StatelessAsyncSpecification duplicateStructuredContent(boolean duplicate) {
+			this.duplicateStructuredContent = duplicate;
 			return this;
 		}
 
@@ -1915,7 +1981,8 @@ public interface McpServer {
 			validateStatelessAsyncToolSchemas(jsonSchemaValidator, this.tools);
 
 			return new McpStatelessAsyncServer(transport, jsonMapper == null ? McpJsonDefaults.getMapper() : jsonMapper,
-					features, requestTimeout, uriTemplateManagerFactory, jsonSchemaValidator, validateToolInputs);
+					features, requestTimeout, uriTemplateManagerFactory, jsonSchemaValidator, validateToolInputs,
+					duplicateStructuredContent);
 		}
 
 	}
@@ -1941,6 +2008,8 @@ public interface McpServer {
 		boolean strictToolNameValidation = ToolNameValidator.isStrictByDefault();
 
 		boolean validateToolInputs = true;
+
+		boolean duplicateStructuredContent = true;
 
 		/**
 		 * The Model Context Protocol (MCP) allows servers to expose tools that can be
@@ -2079,6 +2148,25 @@ public interface McpServer {
 		 */
 		public StatelessSyncSpecification validateToolInputs(boolean validate) {
 			this.validateToolInputs = validate;
+			return this;
+		}
+
+		/**
+		 * Sets whether to automatically duplicate structured content into text content
+		 * for backwards compatibility. When enabled (the default), tools that return
+		 * structured content will also have the serialized JSON added as a
+		 * {@link McpSchema.TextContent} block in the {@code content} field, as
+		 * recommended by the MCP specification. Disabling this can reduce response
+		 * payload size when clients fully support {@code structuredContent}.
+		 * @param duplicate true to duplicate structured content into text content
+		 * (default), false to skip duplication
+		 * @return This builder instance for method chaining
+		 * @see <a href=
+		 * "https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content">MCP
+		 * Structured Content</a>
+		 */
+		public StatelessSyncSpecification duplicateStructuredContent(boolean duplicate) {
+			this.duplicateStructuredContent = duplicate;
 			return this;
 		}
 
@@ -2433,7 +2521,7 @@ public interface McpServer {
 
 			var asyncServer = new McpStatelessAsyncServer(transport,
 					jsonMapper == null ? McpJsonDefaults.getMapper() : jsonMapper, asyncFeatures, requestTimeout,
-					uriTemplateManagerFactory, jsonSchemaValidator, validateToolInputs);
+					uriTemplateManagerFactory, jsonSchemaValidator, validateToolInputs, duplicateStructuredContent);
 			return new McpStatelessSyncServer(asyncServer, this.immediateExecution);
 		}
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
@@ -80,16 +80,19 @@ public class McpStatelessAsyncServer {
 
 	private final boolean validateToolInputs;
 
+	private final boolean duplicateStructuredContent;
+
 	McpStatelessAsyncServer(McpStatelessServerTransport mcpTransport, McpJsonMapper jsonMapper,
 			McpStatelessServerFeatures.Async features, Duration requestTimeout,
 			McpUriTemplateManagerFactory uriTemplateManagerFactory, JsonSchemaValidator jsonSchemaValidator,
-			boolean validateToolInputs) {
+			boolean validateToolInputs, boolean duplicateStructuredContent) {
 		this.mcpTransportProvider = mcpTransport;
 		this.jsonMapper = jsonMapper;
 		this.serverInfo = features.serverInfo();
 		this.serverCapabilities = features.serverCapabilities();
 		this.instructions = features.instructions();
-		this.tools.addAll(withStructuredOutputHandling(jsonSchemaValidator, features.tools()));
+		this.tools
+			.addAll(withStructuredOutputHandling(jsonSchemaValidator, duplicateStructuredContent, features.tools()));
 		this.resources.putAll(features.resources());
 		this.resourceTemplates.putAll(features.resourceTemplates());
 		this.prompts.putAll(features.prompts());
@@ -97,6 +100,7 @@ public class McpStatelessAsyncServer {
 		this.uriTemplateManagerFactory = uriTemplateManagerFactory;
 		this.jsonSchemaValidator = jsonSchemaValidator;
 		this.validateToolInputs = validateToolInputs;
+		this.duplicateStructuredContent = duplicateStructuredContent;
 
 		Map<String, McpStatelessRequestHandler<?>> requestHandlers = new HashMap<>();
 
@@ -207,17 +211,20 @@ public class McpStatelessAsyncServer {
 	// ---------------------------------------
 
 	private static List<McpStatelessServerFeatures.AsyncToolSpecification> withStructuredOutputHandling(
-			JsonSchemaValidator jsonSchemaValidator, List<McpStatelessServerFeatures.AsyncToolSpecification> tools) {
+			JsonSchemaValidator jsonSchemaValidator, boolean duplicateStructuredContent,
+			List<McpStatelessServerFeatures.AsyncToolSpecification> tools) {
 
 		if (Utils.isEmpty(tools)) {
 			return tools;
 		}
 
-		return tools.stream().map(tool -> withStructuredOutputHandling(jsonSchemaValidator, tool)).toList();
+		return tools.stream()
+			.map(tool -> withStructuredOutputHandling(jsonSchemaValidator, duplicateStructuredContent, tool))
+			.toList();
 	}
 
 	private static McpStatelessServerFeatures.AsyncToolSpecification withStructuredOutputHandling(
-			JsonSchemaValidator jsonSchemaValidator,
+			JsonSchemaValidator jsonSchemaValidator, boolean duplicateStructuredContent,
 			McpStatelessServerFeatures.AsyncToolSpecification toolSpecification) {
 
 		if (toolSpecification.callHandler() instanceof StructuredOutputCallToolHandler) {
@@ -232,7 +239,7 @@ public class McpStatelessAsyncServer {
 
 		return new McpStatelessServerFeatures.AsyncToolSpecification(toolSpecification.tool(),
 				new StructuredOutputCallToolHandler(jsonSchemaValidator, toolSpecification.tool().outputSchema(),
-						toolSpecification.callHandler()));
+						duplicateStructuredContent, toolSpecification.callHandler()));
 	}
 
 	private static class StructuredOutputCallToolHandler
@@ -244,8 +251,10 @@ public class McpStatelessAsyncServer {
 
 		private final Map<String, Object> outputSchema;
 
+		private final boolean duplicateStructuredContent;
+
 		public StructuredOutputCallToolHandler(JsonSchemaValidator jsonSchemaValidator,
-				Map<String, Object> outputSchema,
+				Map<String, Object> outputSchema, boolean duplicateStructuredContent,
 				BiFunction<McpTransportContext, McpSchema.CallToolRequest, Mono<McpSchema.CallToolResult>> delegateHandler) {
 
 			Assert.notNull(jsonSchemaValidator, "JsonSchemaValidator must not be null");
@@ -253,6 +262,7 @@ public class McpStatelessAsyncServer {
 
 			this.delegateHandler = delegateHandler;
 			this.outputSchema = outputSchema;
+			this.duplicateStructuredContent = duplicateStructuredContent;
 			this.jsonSchemaValidator = jsonSchemaValidator;
 		}
 
@@ -300,7 +310,7 @@ public class McpStatelessAsyncServer {
 						.build();
 				}
 
-				if (Utils.isEmpty(result.content())) {
+				if (this.duplicateStructuredContent && Utils.isEmpty(result.content())) {
 					// For backwards compatibility, a tool that returns structured
 					// content SHOULD also return functionally equivalent unstructured
 					// content. (For example, serialized JSON can be returned in a
@@ -348,7 +358,8 @@ public class McpStatelessAsyncServer {
 			return Mono.error(e);
 		}
 
-		var wrappedToolSpecification = withStructuredOutputHandling(this.jsonSchemaValidator, toolSpecification);
+		var wrappedToolSpecification = withStructuredOutputHandling(this.jsonSchemaValidator,
+				this.duplicateStructuredContent, toolSpecification);
 
 		return Mono.defer(() -> {
 			// Remove tools with duplicate tool names first


### PR DESCRIPTION
## Summary

- Add `duplicateStructuredContent(boolean)` builder method to all server specifications (async, sync, stateless async, stateless sync)
- When `true` (default), structured content is auto-duplicated into a `TextContent` block in the `content` field for backwards compatibility — preserving existing behavior
- When `false`, the duplication is skipped, reducing response payload size for clients that fully support `structuredContent`
- Schema validation of structured output is always performed regardless of this setting

## Usage

```java
McpServer.async(transportProvider)
    .duplicateStructuredContent(false) // skip backwards-compat duplication
    .tool(myTool, myHandler)
    .build();
```

## Changes

- **`McpServer.java`** — Added `duplicateStructuredContent` field and builder method to `AsyncSpecification`, `SyncSpecification`, `StatelessAsyncSpecification`, and `StatelessSyncSpecification`; passed through to server constructors
- **`McpAsyncServer.java`** — Added field, updated constructors and `StructuredOutputCallToolHandler` to conditionally duplicate
- **`McpStatelessAsyncServer.java`** — Same changes as `McpAsyncServer`

## Test plan

- [x] All 315 mcp-core unit tests pass
- [x] `HttpServletStatelessIntegrationTests` structured output tests pass (1 pre-existing flaky `testToolCallSuccess` timeout)
- [ ] CI pipeline passes

Closes #688