### PR TITLE
fix: use Mono.when instead of Mono.zip for stdio readiness signals

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/StdioServerTransportProvider.java
@@ -160,7 +160,7 @@ public class StdioServerTransportProvider implements McpServerTransportProvider 
 		@Override
 		public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
 
-			return Mono.zip(inboundReady.asMono(), outboundReady.asMono()).then(Mono.defer(() -> {
+			return Mono.when(inboundReady.asMono(), outboundReady.asMono()).then(Mono.defer(() -> {
 				if (outboundSink.tryEmitNext(message).isSuccess()) {
 					return Mono.empty();
 				}


### PR DESCRIPTION
## Summary

Fixes #303.

`StdioServerTransportProvider.sendMessage` waited for the inbound and outbound streams to be ready using `Mono.zip`:

```java
return Mono.zip(inboundReady.asMono(), outboundReady.asMono()).then(Mono.defer(() -> { ... }));
```

Both `inboundReady` and `outboundReady` are `Sinks.One<Void>` that complete *empty* (`tryEmitValue(null)`). `Mono.zip` requires **every** source to emit a value, and when one source completes without a value it short-circuits and **cancels the remaining sources** — exactly the behavior IntelliJ flagged in the issue. The consequence is that `sendMessage` could proceed as soon as the first readiness signal fired, cancelling the wait on the other, rather than waiting for both streams.

`Mono.when` is the correct combinator for completion-only (`Mono<Void>`) signals: it subscribes to all sources and completes only once **all** of them complete.

This matches the analysis and the reproduction in the issue.

## Change

One-line operator swap: `Mono.zip` → `Mono.when`.

## Testing

- `mcp-core` compiles cleanly.
- Existing `StdioServerTransportProviderTests` (9 tests) pass.