### PR TITLE
Send Mcp-Method header on Streamable HTTP client requests (SEP-2243)

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
@@ -503,6 +503,13 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 							transportSession.sessionId().get());
 				}
 
+				if (sentMessage instanceof McpSchema.JSONRPCRequest request) {
+					requestBuilder = requestBuilder.header(HttpHeaders.MCP_METHOD, request.method());
+				}
+				else if (sentMessage instanceof McpSchema.JSONRPCNotification notification) {
+					requestBuilder = requestBuilder.header(HttpHeaders.MCP_METHOD, notification.method());
+				}
+
 				var builder = requestBuilder.uri(uri)
 					.header(HttpHeaders.ACCEPT, APPLICATION_JSON + ", " + TEXT_EVENT_STREAM)
 					.header(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON_UTF8)

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/HttpHeaders.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/HttpHeaders.java
@@ -27,6 +27,13 @@ public interface HttpHeaders {
 	String PROTOCOL_VERSION = "MCP-Protocol-Version";
 
 	/**
+	 * Mirrors the JSON-RPC method of the request or notification carried in the body.
+	 * @see <a href=
+	 * "https://modelcontextprotocol.io/seps/2243-http-standardization">SEP-2243</a>
+	 */
+	String MCP_METHOD = "Mcp-Method";
+
+	/**
 	 * The HTTP Content-Length header.
 	 * @see <a href=
 	 * "https://httpwg.org/specs/rfc9110.html#field.content-length">RFC9110</a>

--- a/mcp-test/src/test/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransportTest.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransportTest.java
@@ -7,11 +7,13 @@ package io.modelcontextprotocol.client.transport;
 import io.modelcontextprotocol.client.transport.customizer.McpAsyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.HttpHeaders;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpTransportSessionClosedException;
 import io.modelcontextprotocol.spec.ProtocolVersions;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.http.HttpRequest;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -19,11 +21,13 @@ import java.util.function.Function;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
@@ -164,6 +168,101 @@ class HttpClientStreamableHttpTransportTest {
 			.expectErrorMatches(err -> err instanceof McpTransportSessionClosedException
 					&& err.getMessage().contains("Transport has already been closed"))
 			.verify();
+	}
+
+	@Test
+	void testMcpMethodHeaderOnRequest() throws URISyntaxException {
+		var uri = new URI(host + "/mcp");
+		var mockRequestCustomizer = mock(McpSyncHttpClientRequestCustomizer.class);
+
+		var transport = HttpClientStreamableHttpTransport.builder(host)
+			.httpRequestCustomizer(mockRequestCustomizer)
+			.build();
+
+		withTransport(transport, (t) -> {
+			var initializeRequest = McpSchema.InitializeRequest
+				.builder(ProtocolVersions.MCP_2025_11_25, McpSchema.ClientCapabilities.builder().roots(true).build(),
+						McpSchema.Implementation.builder("MCP Client", "0.3.1").build())
+				.build();
+			var testMessage = new McpSchema.JSONRPCRequest(McpSchema.METHOD_INITIALIZE, "test-id", initializeRequest);
+
+			StepVerifier
+				.create(t.sendMessage(testMessage).contextWrite(ctx -> ctx.put(McpTransportContext.KEY, context)))
+				.verifyComplete();
+
+			var requestCaptor = ArgumentCaptor.forClass(HttpRequest.Builder.class);
+			verify(mockRequestCustomizer, atLeastOnce()).customize(requestCaptor.capture(), eq("POST"), eq(uri), any(),
+					eq(context));
+			assertThat(requestCaptor.getValue().build().headers().firstValue(HttpHeaders.MCP_METHOD))
+				.hasValue(McpSchema.METHOD_INITIALIZE);
+		});
+	}
+
+	@Test
+	void testMcpMethodHeaderOnNotification() throws URISyntaxException {
+		var uri = new URI(host + "/mcp");
+		var mockRequestCustomizer = mock(McpSyncHttpClientRequestCustomizer.class);
+
+		var transport = HttpClientStreamableHttpTransport.builder(host)
+			.httpRequestCustomizer(mockRequestCustomizer)
+			.build();
+
+		withTransport(transport, (t) -> {
+			var initializeRequest = McpSchema.InitializeRequest
+				.builder(ProtocolVersions.MCP_2025_11_25, McpSchema.ClientCapabilities.builder().roots(true).build(),
+						McpSchema.Implementation.builder("MCP Client", "0.3.1").build())
+				.build();
+			var initializeMessage = new McpSchema.JSONRPCRequest(McpSchema.METHOD_INITIALIZE, "test-id",
+					initializeRequest);
+			StepVerifier
+				.create(t.sendMessage(initializeMessage).contextWrite(ctx -> ctx.put(McpTransportContext.KEY, context)))
+				.verifyComplete();
+
+			var testMessage = new McpSchema.JSONRPCNotification(McpSchema.METHOD_NOTIFICATION_INITIALIZED);
+
+			StepVerifier
+				.create(t.sendMessage(testMessage).contextWrite(ctx -> ctx.put(McpTransportContext.KEY, context)))
+				.verifyComplete();
+
+			var requestCaptor = ArgumentCaptor.forClass(HttpRequest.Builder.class);
+			verify(mockRequestCustomizer, atLeastOnce()).customize(requestCaptor.capture(), eq("POST"), eq(uri), any(),
+					eq(context));
+			assertThat(requestCaptor.getValue().build().headers().firstValue(HttpHeaders.MCP_METHOD))
+				.hasValue(McpSchema.METHOD_NOTIFICATION_INITIALIZED);
+		});
+	}
+
+	@Test
+	void testNoMcpMethodHeaderOnResponse() throws URISyntaxException {
+		var uri = new URI(host + "/mcp");
+		var mockRequestCustomizer = mock(McpSyncHttpClientRequestCustomizer.class);
+
+		var transport = HttpClientStreamableHttpTransport.builder(host)
+			.httpRequestCustomizer(mockRequestCustomizer)
+			.build();
+
+		withTransport(transport, (t) -> {
+			var initializeRequest = McpSchema.InitializeRequest
+				.builder(ProtocolVersions.MCP_2025_11_25, McpSchema.ClientCapabilities.builder().roots(true).build(),
+						McpSchema.Implementation.builder("MCP Client", "0.3.1").build())
+				.build();
+			var initializeMessage = new McpSchema.JSONRPCRequest(McpSchema.METHOD_INITIALIZE, "test-id",
+					initializeRequest);
+			StepVerifier
+				.create(t.sendMessage(initializeMessage).contextWrite(ctx -> ctx.put(McpTransportContext.KEY, context)))
+				.verifyComplete();
+
+			var testMessage = McpSchema.JSONRPCResponse.result("test-id-2", Map.of());
+
+			StepVerifier
+				.create(t.sendMessage(testMessage).contextWrite(ctx -> ctx.put(McpTransportContext.KEY, context)))
+				.verifyComplete();
+
+			var requestCaptor = ArgumentCaptor.forClass(HttpRequest.Builder.class);
+			verify(mockRequestCustomizer, atLeastOnce()).customize(requestCaptor.capture(), eq("POST"), eq(uri), any(),
+					eq(context));
+			assertThat(requestCaptor.getValue().build().headers().firstValue(HttpHeaders.MCP_METHOD)).isEmpty();
+		});
 	}
 
 }


### PR DESCRIPTION
## Motivation and Context

Contributes the client-side Mcp-Method part of #990.

SEP-2243 (final, https://modelcontextprotocol.io/seps/2243-http-standardization) requires Streamable HTTP clients to mirror the JSON-RPC method of every request and notification into the `Mcp-Method` HTTP header, so proxies and load balancers can route MCP traffic without parsing the body. The client transport currently does not send this header.

#994 covers the `Mcp-Name` header. This PR is limited to client-side emission of `Mcp-Method`; server-side validation of header/body consistency is left as a follow-up, since #994 already touches that area for `Mcp-Name`. If #994 merges first, I will rebase on top of it.

## Description

- New `HttpHeaders.MCP_METHOD` constant.
- `HttpClientStreamableHttpTransport#sendMessage` sets `Mcp-Method` from the message method for `JSONRPCRequest` and `JSONRPCNotification`. `JSONRPCResponse` has no method and is sent without the header.

## How Has This Been Tested?

Three new tests in `HttpClientStreamableHttpTransportTest` (request, notification, response cases), using the existing request-customizer hook to capture the outgoing request. The two header-presence tests were verified to fail without the production change. All streamable HTTP client suites pass locally:

```
./mvnw test -pl mcp-test -am -Dtest="HttpClientStreamableHttp*" -Dsurefire.failIfNoSpecifiedTests=false
129 tests, 0 failures
```

## Breaking Changes

None. The header is additive and limited to Streamable HTTP client POSTs.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)