### PR TITLE
Close servlet streamable HTTP transports on async lifecycle events

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
@@ -27,6 +27,8 @@ import io.modelcontextprotocol.spec.ProtocolVersions;
 import io.modelcontextprotocol.util.Assert;
 import io.modelcontextprotocol.util.KeepAliveScheduler;
 import jakarta.servlet.AsyncContext;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
@@ -538,6 +540,7 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 
 				HttpServletStreamableMcpSessionTransport sessionTransport = new HttpServletStreamableMcpSessionTransport(
 						sessionId, asyncContext, response.getWriter());
+				registerAsyncLifecycle(asyncContext, sessionId, sessionTransport::close);
 
 				try {
 					session.responseStream(jsonrpcRequest, sessionTransport)
@@ -546,7 +549,7 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 				}
 				catch (Exception e) {
 					logger.error("Failed to handle request stream: {}", e.getMessage());
-					asyncContext.complete();
+					sessionTransport.close();
 				}
 			}
 			else {
@@ -577,6 +580,32 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 				response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Error processing message");
 			}
 		}
+	}
+
+	private void registerAsyncLifecycle(AsyncContext asyncContext, String sessionId, Runnable onClose) {
+		asyncContext.addListener(new AsyncListener() {
+			@Override
+			public void onComplete(AsyncEvent event) throws IOException {
+				logger.debug("SSE async context completed for session: {}", sessionId);
+				onClose.run();
+			}
+
+			@Override
+			public void onTimeout(AsyncEvent event) throws IOException {
+				logger.debug("SSE async context timed out for session: {}", sessionId);
+				onClose.run();
+			}
+
+			@Override
+			public void onError(AsyncEvent event) throws IOException {
+				logger.debug("SSE async context errored for session: {}", sessionId);
+				onClose.run();
+			}
+
+			@Override
+			public void onStartAsync(AsyncEvent event) throws IOException {
+			}
+		});
 	}
 
 	/**
@@ -768,8 +797,7 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 				}
 				catch (Exception e) {
 					logger.error("Failed to send message to session {}: {}", this.sessionId, e.getMessage());
-					HttpServletStreamableServerTransportProvider.this.sessions.remove(this.sessionId);
-					this.asyncContext.complete();
+					this.close();
 				}
 				finally {
 					lock.unlock();

--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProviderTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProviderTests.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server.transport;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import reactor.core.publisher.Mono;
+
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.server.McpNotificationHandler;
+import io.modelcontextprotocol.server.McpRequestHandler;
+import io.modelcontextprotocol.spec.HttpHeaders;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpStreamableServerSession;
+import io.modelcontextprotocol.spec.json.gson.GsonMcpJsonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class HttpServletStreamableServerTransportProviderTests {
+
+	private final McpJsonMapper jsonMapper = new GsonMcpJsonMapper();
+
+	@Test
+	void postStreamingRequestRegistersAsyncListenerAndClosesTransportOnDisconnect() throws Exception {
+		HttpServletStreamableServerTransportProvider provider = HttpServletStreamableServerTransportProvider.builder()
+			.jsonMapper(this.jsonMapper)
+			.mcpEndpoint("/mcp")
+			.build();
+
+		String sessionId = "session-post";
+		McpRequestHandler<Object> echoHandler = (exchange, params) -> Mono.just(params);
+		McpStreamableServerSession session = createSession(sessionId, Map.of("echo", echoHandler), Map.of());
+		provider.setSessionFactory(request -> new McpStreamableServerSession.McpStreamableServerSessionInit(session,
+				Mono.just(testInitializeResult())));
+
+		initializeSession(provider, sessionId);
+
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpServletResponse response = mock(HttpServletResponse.class);
+		AsyncContext asyncContext = mock(AsyncContext.class);
+		StringWriter output = new StringWriter();
+		PrintWriter writer = new PrintWriter(output, true);
+
+		when(request.getRequestURI()).thenReturn("/mcp");
+		when(request.getHeader("Accept")).thenReturn("text/event-stream, application/json");
+		when(request.getHeader(HttpHeaders.MCP_SESSION_ID)).thenReturn(sessionId);
+		when(request.getHeaderNames()).thenReturn(java.util.Collections.emptyEnumeration());
+		when(request.getInputStream()).thenReturn(servletInputStream(this.jsonMapper
+			.writeValueAsString(new McpSchema.JSONRPCRequest("echo", "request-1", Map.of("value", "ok")))
+			.getBytes(StandardCharsets.UTF_8)));
+		when(request.startAsync()).thenReturn(asyncContext);
+		when(response.getWriter()).thenReturn(writer);
+
+		provider.doPost(request, response);
+
+		assertThat(output.toString()).contains("\"result\":{\"value\":\"ok\"}");
+
+		ArgumentCaptor<AsyncListener> listenerCaptor = ArgumentCaptor.forClass(AsyncListener.class);
+		verify(asyncContext).addListener(listenerCaptor.capture());
+
+		listenerCaptor.getValue().onError(new AsyncEvent(asyncContext));
+
+		verify(asyncContext).complete();
+	}
+
+	@Test
+	void sendFailureClosesOnlyCurrentTransportWithoutRemovingSession() throws Exception {
+		HttpServletStreamableServerTransportProvider provider = HttpServletStreamableServerTransportProvider.builder()
+			.jsonMapper(this.jsonMapper)
+			.mcpEndpoint("/mcp")
+			.build();
+		String sessionId = "session-send-failure";
+		McpStreamableServerSession session = createSession(sessionId, Map.of(), Map.of());
+		provider.setSessionFactory(request -> new McpStreamableServerSession.McpStreamableServerSessionInit(session,
+				Mono.just(testInitializeResult())));
+		initializeSession(provider, sessionId);
+
+		HttpServletRequest getRequest = mock(HttpServletRequest.class);
+		HttpServletResponse getResponse = mock(HttpServletResponse.class);
+		AsyncContext getAsyncContext = mock(AsyncContext.class);
+		PrintWriter failingWriter = new PrintWriter(new FailingServletOutputStream(), true);
+
+		when(getRequest.getRequestURI()).thenReturn("/mcp");
+		when(getRequest.getHeader("Accept")).thenReturn("text/event-stream");
+		when(getRequest.getHeader(HttpHeaders.MCP_SESSION_ID)).thenReturn(sessionId);
+		when(getRequest.getHeader(HttpHeaders.LAST_EVENT_ID)).thenReturn(null);
+		when(getRequest.getHeaderNames()).thenReturn(java.util.Collections.emptyEnumeration());
+		when(getRequest.startAsync()).thenReturn(getAsyncContext);
+		when(getResponse.getWriter()).thenReturn(failingWriter);
+
+		provider.doGet(getRequest, getResponse);
+		provider.notifyClient(sessionId, "server/notification", Map.of("boom", true)).block();
+
+		verify(getAsyncContext).complete();
+
+		HttpServletRequest deleteRequest = mock(HttpServletRequest.class);
+		HttpServletResponse deleteResponse = mock(HttpServletResponse.class);
+		when(deleteRequest.getRequestURI()).thenReturn("/mcp");
+		when(deleteRequest.getHeader(HttpHeaders.MCP_SESSION_ID)).thenReturn(sessionId);
+		when(deleteRequest.getHeaderNames()).thenReturn(java.util.Collections.emptyEnumeration());
+
+		provider.doDelete(deleteRequest, deleteResponse);
+
+		verify(deleteResponse).setStatus(HttpServletResponse.SC_OK);
+	}
+
+	private void initializeSession(HttpServletStreamableServerTransportProvider provider, String expectedSessionId)
+			throws Exception {
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpServletResponse response = mock(HttpServletResponse.class);
+		StringWriter output = new StringWriter();
+		PrintWriter writer = new PrintWriter(output, true);
+		when(request.getRequestURI()).thenReturn("/mcp");
+		when(request.getHeader("Accept")).thenReturn("text/event-stream, application/json");
+		when(request.getHeaderNames()).thenReturn(java.util.Collections.emptyEnumeration());
+		when(request.getInputStream()).thenReturn(servletInputStream(this.jsonMapper
+			.writeValueAsString(
+					new McpSchema.JSONRPCRequest(McpSchema.METHOD_INITIALIZE, "init-1", testInitializeRequest()))
+			.getBytes(StandardCharsets.UTF_8)));
+		when(response.getWriter()).thenReturn(writer);
+
+		doAnswer(invocation -> {
+			assertThat(invocation.getArgument(1, String.class)).isEqualTo(expectedSessionId);
+			return null;
+		}).when(response).setHeader(eq(HttpHeaders.MCP_SESSION_ID), any(String.class));
+
+		provider.doPost(request, response);
+		verify(response).setStatus(HttpServletResponse.SC_OK);
+	}
+
+	private McpStreamableServerSession createSession(String sessionId,
+			Map<String, McpRequestHandler<?>> requestHandlers,
+			Map<String, McpNotificationHandler> notificationHandlers) {
+		return new McpStreamableServerSession(sessionId, testInitializeRequest().capabilities(),
+				testInitializeRequest().clientInfo(), Duration.ofSeconds(2), requestHandlers, notificationHandlers);
+	}
+
+	private McpSchema.InitializeRequest testInitializeRequest() {
+		return McpSchema.InitializeRequest
+			.builder("2025-11-25", new McpSchema.ClientCapabilities(null, null, null, null),
+					new McpSchema.Implementation("test-client", "1.0.0"))
+			.build();
+	}
+
+	private McpSchema.InitializeResult testInitializeResult() {
+		return McpSchema.InitializeResult
+			.builder("2025-11-25", new McpSchema.ServerCapabilities(null, null, null, null, null, null),
+					new McpSchema.Implementation("test-server", "1.0.0"))
+			.build();
+	}
+
+	private static ServletInputStream servletInputStream(byte[] data) {
+		ByteArrayInputStream delegate = new ByteArrayInputStream(data);
+		return new ServletInputStream() {
+
+			@Override
+			public boolean isFinished() {
+				return delegate.available() == 0;
+			}
+
+			@Override
+			public boolean isReady() {
+				return true;
+			}
+
+			@Override
+			public void setReadListener(ReadListener readListener) {
+			}
+
+			@Override
+			public int read() {
+				return delegate.read();
+			}
+
+			@Override
+			public int read(byte[] buf, int off, int len) {
+				return delegate.read(buf, off, len);
+			}
+		};
+	}
+
+	private static final class FailingServletOutputStream extends ServletOutputStream {
+
+		private final AtomicReference<IOException> failure = new AtomicReference<>(
+				new IOException("Client disconnected"));
+
+		@Override
+		public void write(int b) throws IOException {
+			throw this.failure.get();
+		}
+
+		@Override
+		public boolean isReady() {
+			return false;
+		}
+
+		@Override
+		public void setWriteListener(WriteListener writeListener) {
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Summary

Fixes #1021.

Closes servlet async lifecycle cleanup for Streamable HTTP **POST streaming responses** created by `HttpServletStreamableServerTransportProvider`, and routes SSE write failures through the transport `close()` path instead of removing the logical MCP session from the session registry.

GET listening/replay stream cleanup is now handled by [4186ca13](https://github.com/modelcontextprotocol/java-sdk/commit/4186ca13) ("Fix stream leak when resuming streams with `LAST_EVENT_ID`"); this PR covers the remaining `doPost` path and the write-failure behavior.

## Motivation and Context

The servlet Streamable HTTP transport creates async SSE responses for multiple request paths. When a client disconnects, the current HTTP/SSE response can become unusable while the SDK still keeps the async context and transport state alive. In production this can leave server-side sockets in `CLOSE-WAIT` and keep Tomcat resources tied up until an external timeout or kernel keepalive eventually reclaims them.

`4186ca13` fixed the GET (listening/replay) path. This PR applies the same `AsyncListener` approach to POST streaming responses, where the per-request transport is still not closed on client disconnect, timeout, or async error.

This issue was observed from Spring AI WebMVC usage first, but the lifecycle gap is in the MCP Java SDK core servlet transport.

## Related Issues and PRs

- Fixes #1021.
- Related to #952 and #972: a request-specific SSE write failure should not immediately remove the logical MCP session.
- Related to #920: first transient SSE write failure should not orphan the session.
- Related to #726 only by production symptom (`CLOSE-WAIT` / Tomcat resource growth). #726 targets the older `WebMvcSseServerTransportProvider` / `McpServerSession` path, while this PR targets the core `HttpServletStreamableServerTransportProvider` Streamable HTTP servlet path.
- Follow-up logical session eviction after repeated keep-alive failures is handled separately in #1028.

## Changes

- Register async lifecycle cleanup for POST streaming responses.
- Close the POST streaming transport through the transport `close()` path on handling failures.
- Close only the current transport on SSE write failure instead of removing the logical MCP session.
- Add focused regression coverage for POST streaming response cleanup and write-failure behavior.

## Rationale

A TCP/SSE stream lifecycle is not the same as an MCP logical session lifecycle.

A servlet async error, timeout, completion, or response write failure proves that the current HTTP/SSE transport is no longer usable. It does not necessarily prove that the logical MCP session should be removed from the session registry.

This distinction matters for Streamable HTTP because request-specific POST responses can fail or be closed after the response has already been delivered. Removing the logical session on that single transport failure causes the next request with the same `mcp-session-id` to fail with `Session not found`.

This PR therefore closes the current transport and completes the associated servlet async context, while leaving logical session eviction to existing protocol-level paths such as DELETE, server shutdown, or follow-up liveness policy such as #1028.

The async listener reuses the existing stream/transport close paths. These paths are guarded and idempotent, so cleanup can be triggered consistently from servlet async completion, timeout, error, and write-failure paths.

## Scope

This PR intentionally focuses on the MCP Java SDK core servlet Streamable HTTP transport:

- `HttpServletStreamableServerTransportProvider`

Out of scope:

- Keep-alive failed-ping logical session eviction, handled separately in #1028
- Explicit session TTL
- Session persistence / distributed session storage
- Last-Event-ID resumability / event store support
- Spring AI WebMVC-specific follow-up
- Deprecated `HttpServletSseServerTransportProvider`

## How Has This Been Tested?

```bash
mvn -pl mcp-core -Dtest=HttpServletStreamableServerTransportProviderTests -DforkCount=0 test
mvn -pl mcp-core test
```

The added tests cover:

- POST streaming response async error closes the current transport
- SSE write failure closes only the current transport and does not remove the logical MCP session

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io/)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
