### PR TITLE
Evict streamable HTTP sessions after failed keep-alive pings

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
@@ -24,6 +24,7 @@ import io.modelcontextprotocol.server.McpTransportContextExtractor;
 import io.modelcontextprotocol.spec.HttpHeaders;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSession;
 import io.modelcontextprotocol.spec.McpStreamableServerSession;
 import io.modelcontextprotocol.spec.McpStreamableServerTransport;
 import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
@@ -87,6 +88,8 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 
 	public static final String FAILED_TO_SEND_ERROR_RESPONSE = "Failed to send error response: {}";
 
+	private static final int KEEP_ALIVE_FAILURE_THRESHOLD = 3;
+
 	/**
 	 * The endpoint URI where clients should send their JSON-RPC messages. Defaults to
 	 * "/mcp".
@@ -106,6 +109,8 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 	 * Map of active client sessions, keyed by mcp-session-id.
 	 */
 	private final ConcurrentHashMap<String, McpStreamableServerSession> sessions = new ConcurrentHashMap<>();
+
+	private final ConcurrentHashMap<String, Integer> keepAliveFailureCounts = new ConcurrentHashMap<>();
 
 	private McpTransportContextExtractor<HttpServletRequest> contextExtractor;
 
@@ -158,6 +163,8 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 				.builder(() -> (isClosing) ? Flux.empty() : Flux.fromIterable(sessions.values()))
 				.initialDelay(keepAliveInterval)
 				.interval(keepAliveInterval)
+				.onSuccess(this::resetKeepAliveFailures)
+				.onFailure(this::handleKeepAliveFailure)
 				.build();
 
 			this.keepAliveScheduler.start();
@@ -231,8 +238,10 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 			});
 
 			this.sessions.clear();
+			this.keepAliveFailureCounts.clear();
 		}).then().doOnSuccess(v -> {
 			sessions.clear();
+			keepAliveFailureCounts.clear();
 			logger.debug("Graceful shutdown completed");
 			if (this.keepAliveScheduler != null) {
 				this.keepAliveScheduler.shutdown();
@@ -445,6 +454,7 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 				McpStreamableServerSession.McpStreamableServerSessionInit init = this.sessionFactory
 					.startSession(initializeRequest);
 				this.sessions.put(init.session().getId(), init.session());
+				this.keepAliveFailureCounts.remove(init.session().getId());
 
 				try {
 					McpSchema.InitializeResult initResult = init.initResult().block();
@@ -614,6 +624,7 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 		try {
 			session.delete().contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext)).block();
 			this.sessions.remove(sessionId);
+			this.keepAliveFailureCounts.remove(sessionId);
 			response.setStatus(HttpServletResponse.SC_OK);
 		}
 		catch (Exception e) {
@@ -638,6 +649,42 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 		writer.write(jsonError);
 		writer.flush();
 		return;
+	}
+
+	void resetKeepAliveFailures(McpSession session) {
+		if (session instanceof McpStreamableServerSession streamableSession) {
+			String sessionId = streamableSession.getId();
+			if (this.sessions.get(sessionId) == streamableSession) {
+				this.keepAliveFailureCounts.remove(sessionId);
+			}
+		}
+	}
+
+	void handleKeepAliveFailure(McpSession session, Throwable error) {
+		if (!(session instanceof McpStreamableServerSession streamableSession)) {
+			return;
+		}
+
+		String sessionId = streamableSession.getId();
+		if (this.sessions.get(sessionId) != streamableSession) {
+			return;
+		}
+
+		int failures = this.keepAliveFailureCounts.merge(sessionId, 1, Integer::sum);
+		if (failures < KEEP_ALIVE_FAILURE_THRESHOLD) {
+			logger.debug("Keep-alive ping failed for session {} ({}/{} consecutive failures): {}", sessionId, failures,
+					KEEP_ALIVE_FAILURE_THRESHOLD, error.getMessage());
+			return;
+		}
+
+		if (this.sessions.remove(sessionId, streamableSession)) {
+			this.keepAliveFailureCounts.remove(sessionId);
+			streamableSession.close();
+			logger.info("Evicted session {} after {} failed keep-alive attempts", sessionId, failures);
+		}
+		else {
+			this.keepAliveFailureCounts.remove(sessionId);
+		}
 	}
 
 	/**
@@ -748,6 +795,7 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 				catch (Exception e) {
 					logger.error("Failed to send message to session {}: {}", this.sessionId, e.getMessage());
 					HttpServletStreamableServerTransportProvider.this.sessions.remove(this.sessionId);
+					HttpServletStreamableServerTransportProvider.this.keepAliveFailureCounts.remove(this.sessionId);
 					this.asyncContext.complete();
 				}
 				finally {

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
@@ -21,6 +21,7 @@ import io.modelcontextprotocol.server.McpTransportContextExtractor;
 import io.modelcontextprotocol.spec.HttpHeaders;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSession;
 import io.modelcontextprotocol.spec.McpStreamableServerSession;
 import io.modelcontextprotocol.spec.McpStreamableServerTransport;
 import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
@@ -90,6 +91,8 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 
 	public static final String FAILED_TO_SEND_ERROR_RESPONSE = "Failed to send error response: {}";
 
+	private static final int KEEP_ALIVE_FAILURE_THRESHOLD = 3;
+
 	/**
 	 * The endpoint URI where clients should send their JSON-RPC messages. Defaults to
 	 * "/mcp".
@@ -114,6 +117,8 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 	 * Map of active client sessions, keyed by mcp-session-id.
 	 */
 	private final ConcurrentHashMap<String, McpStreamableServerSession> sessions = new ConcurrentHashMap<>();
+
+	private final ConcurrentHashMap<String, Integer> keepAliveFailureCounts = new ConcurrentHashMap<>();
 
 	private McpTransportContextExtractor<HttpServletRequest> contextExtractor;
 
@@ -170,6 +175,8 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 				.builder(() -> (isClosing) ? Flux.empty() : Flux.fromIterable(sessions.values()))
 				.initialDelay(keepAliveInterval)
 				.interval(keepAliveInterval)
+				.onSuccess(this::resetKeepAliveFailures)
+				.onFailure(this::handleKeepAliveFailure)
 				.build();
 
 			this.keepAliveScheduler.start();
@@ -243,8 +250,10 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 			});
 
 			this.sessions.clear();
+			this.keepAliveFailureCounts.clear();
 		}).then().doOnSuccess(v -> {
 			sessions.clear();
+			keepAliveFailureCounts.clear();
 			logger.debug("Graceful shutdown completed");
 			if (this.keepAliveScheduler != null) {
 				this.keepAliveScheduler.shutdown();
@@ -456,6 +465,7 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 				McpStreamableServerSession.McpStreamableServerSessionInit init = this.sessionFactory
 					.startSession(initializeRequest);
 				this.sessions.put(init.session().getId(), init.session());
+				this.keepAliveFailureCounts.remove(init.session().getId());
 
 				try {
 					McpSchema.InitializeResult initResult = init.initResult().block();
@@ -628,6 +638,7 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 		try {
 			session.delete().contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext)).block();
 			this.sessions.remove(sessionId);
+			this.keepAliveFailureCounts.remove(sessionId);
 			response.setStatus(HttpServletResponse.SC_OK);
 		}
 		catch (Exception e) {
@@ -652,6 +663,42 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 		writer.write(jsonError);
 		writer.flush();
 		return;
+	}
+
+	void resetKeepAliveFailures(McpSession session) {
+		if (session instanceof McpStreamableServerSession streamableSession) {
+			String sessionId = streamableSession.getId();
+			if (this.sessions.get(sessionId) == streamableSession) {
+				this.keepAliveFailureCounts.remove(sessionId);
+			}
+		}
+	}
+
+	void handleKeepAliveFailure(McpSession session, Throwable error) {
+		if (!(session instanceof McpStreamableServerSession streamableSession)) {
+			return;
+		}
+
+		String sessionId = streamableSession.getId();
+		if (this.sessions.get(sessionId) != streamableSession) {
+			return;
+		}
+
+		int failures = this.keepAliveFailureCounts.merge(sessionId, 1, Integer::sum);
+		if (failures < KEEP_ALIVE_FAILURE_THRESHOLD) {
+			logger.debug("Keep-alive ping failed for session {} ({}/{} consecutive failures): {}", sessionId, failures,
+					KEEP_ALIVE_FAILURE_THRESHOLD, error.getMessage());
+			return;
+		}
+
+		if (this.sessions.remove(sessionId, streamableSession)) {
+			this.keepAliveFailureCounts.remove(sessionId);
+			streamableSession.close();
+			logger.info("Evicted session {} after {} failed keep-alive attempts", sessionId, failures);
+		}
+		else {
+			this.keepAliveFailureCounts.remove(sessionId);
+		}
 	}
 
 	/**
@@ -762,6 +809,7 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 				catch (Exception e) {
 					logger.error("Failed to send message to session {}: {}", this.sessionId, e.getMessage());
 					HttpServletStreamableServerTransportProvider.this.sessions.remove(this.sessionId);
+					HttpServletStreamableServerTransportProvider.this.keepAliveFailureCounts.remove(this.sessionId);
 					this.asyncContext.complete();
 				}
 				finally {

--- a/mcp-core/src/main/java/io/modelcontextprotocol/util/KeepAliveScheduler.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/util/KeepAliveScheduler.java
@@ -6,6 +6,8 @@ package io.modelcontextprotocol.util;
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.slf4j.Logger;
@@ -57,6 +59,10 @@ public class KeepAliveScheduler {
 	/** Supplier for reactive McpSession instances */
 	private final Supplier<Flux<McpSession>> mcpSessions;
 
+	private final Consumer<McpSession> onSuccess;
+
+	private final BiConsumer<McpSession, Throwable> onFailure;
+
 	/**
 	 * Creates a KeepAliveScheduler with a custom scheduler, initial delay, interval and a
 	 * supplier for McpSession instances.
@@ -66,11 +72,14 @@ public class KeepAliveScheduler {
 	 * @param mcpSessions Supplier for McpSession instances
 	 */
 	KeepAliveScheduler(Scheduler scheduler, Duration initialDelay, Duration interval,
-			Supplier<Flux<McpSession>> mcpSessions) {
+			Supplier<Flux<McpSession>> mcpSessions, Consumer<McpSession> onSuccess,
+			BiConsumer<McpSession, Throwable> onFailure) {
 		this.scheduler = scheduler;
 		this.initialDelay = initialDelay;
 		this.interval = interval;
 		this.mcpSessions = mcpSessions;
+		this.onSuccess = onSuccess;
+		this.onFailure = onFailure;
 	}
 
 	/**
@@ -92,8 +101,12 @@ public class KeepAliveScheduler {
 				.doOnNext(tick -> {
 					this.mcpSessions.get()
 						.flatMap(session -> session.sendRequest(McpSchema.METHOD_PING, null, OBJECT_TYPE_REF)
-							.doOnError(e -> logger.warn("Failed to send keep-alive ping to session {}: {}", session,
-									e.getMessage()))
+							.doOnSuccess(result -> this.notifySuccess(session))
+							.doOnError(e -> {
+								logger.warn("Failed to send keep-alive ping to session {}: {}", session,
+										e.getMessage());
+								this.notifyFailure(session, e);
+							})
 							.onErrorComplete())
 						.subscribe();
 				})
@@ -131,6 +144,24 @@ public class KeepAliveScheduler {
 		return this.isRunning.get();
 	}
 
+	private void notifySuccess(McpSession session) {
+		try {
+			this.onSuccess.accept(session);
+		}
+		catch (Exception e) {
+			logger.warn("Keep-alive success callback failed for session {}: {}", session, e.getMessage());
+		}
+	}
+
+	private void notifyFailure(McpSession session, Throwable error) {
+		try {
+			this.onFailure.accept(session, error);
+		}
+		catch (Exception e) {
+			logger.warn("Keep-alive failure callback failed for session {}: {}", session, e.getMessage());
+		}
+	}
+
 	/**
 	 * Shuts down the scheduler and releases resources.
 	 */
@@ -153,6 +184,12 @@ public class KeepAliveScheduler {
 		private Duration interval = Duration.ofSeconds(30);
 
 		private Supplier<Flux<McpSession>> mcpSessions;
+
+		private Consumer<McpSession> onSuccess = session -> {
+		};
+
+		private BiConsumer<McpSession, Throwable> onFailure = (session, error) -> {
+		};
 
 		/**
 		 * Creates a new Builder instance with a supplier for McpSession instances.
@@ -205,11 +242,33 @@ public class KeepAliveScheduler {
 		}
 
 		/**
+		 * Sets the callback invoked after a keep-alive ping completes successfully.
+		 * @param onSuccess The success callback. Must not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public Builder onSuccess(Consumer<McpSession> onSuccess) {
+			Assert.notNull(onSuccess, "OnSuccess callback must not be null");
+			this.onSuccess = onSuccess;
+			return this;
+		}
+
+		/**
+		 * Sets the callback invoked after a keep-alive ping fails.
+		 * @param onFailure The failure callback. Must not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public Builder onFailure(BiConsumer<McpSession, Throwable> onFailure) {
+			Assert.notNull(onFailure, "OnFailure callback must not be null");
+			this.onFailure = onFailure;
+			return this;
+		}
+
+		/**
 		 * Builds and returns a new KeepAliveScheduler instance.
 		 * @return A new KeepAliveScheduler configured with the builder's settings
 		 */
 		public KeepAliveScheduler build() {
-			return new KeepAliveScheduler(scheduler, initialDelay, interval, mcpSessions);
+			return new KeepAliveScheduler(scheduler, initialDelay, interval, mcpSessions, onSuccess, onFailure);
 		}
 
 	}

--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProviderTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProviderTests.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server.transport;
+
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpStreamableServerSession;
+import io.modelcontextprotocol.spec.json.gson.GsonMcpJsonMapper;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for keep-alive failure eviction in
+ * {@link HttpServletStreamableServerTransportProvider}.
+ */
+class HttpServletStreamableServerTransportProviderTests {
+
+	@Test
+	void firstKeepAliveFailureDoesNotEvictSession() throws Exception {
+		HttpServletStreamableServerTransportProvider provider = createProvider();
+		TrackingStreamableSession session = createSession("session-1");
+		putSession(provider, session);
+
+		provider.handleKeepAliveFailure(session, new RuntimeException("ping failed"));
+
+		assertThat(sessions(provider)).containsEntry("session-1", session);
+		assertThat(keepAliveFailureCounts(provider)).containsEntry("session-1", 1);
+		assertThat(session.closeCount()).isZero();
+	}
+
+	@Test
+	void repeatedKeepAliveFailuresEvictSession() throws Exception {
+		HttpServletStreamableServerTransportProvider provider = createProvider();
+		TrackingStreamableSession session = createSession("session-1");
+		putSession(provider, session);
+
+		provider.handleKeepAliveFailure(session, new RuntimeException("first failure"));
+		provider.handleKeepAliveFailure(session, new RuntimeException("second failure"));
+		provider.handleKeepAliveFailure(session, new RuntimeException("third failure"));
+
+		assertThat(sessions(provider)).doesNotContainKey("session-1");
+		assertThat(keepAliveFailureCounts(provider)).doesNotContainKey("session-1");
+		assertThat(session.closeCount()).isOne();
+	}
+
+	@Test
+	void successfulKeepAliveResetsFailureCount() throws Exception {
+		HttpServletStreamableServerTransportProvider provider = createProvider();
+		TrackingStreamableSession session = createSession("session-1");
+		putSession(provider, session);
+
+		provider.handleKeepAliveFailure(session, new RuntimeException("first failure"));
+		provider.handleKeepAliveFailure(session, new RuntimeException("second failure"));
+		provider.resetKeepAliveFailures(session);
+		provider.handleKeepAliveFailure(session, new RuntimeException("failure after success"));
+
+		assertThat(sessions(provider)).containsEntry("session-1", session);
+		assertThat(keepAliveFailureCounts(provider)).containsEntry("session-1", 1);
+		assertThat(session.closeCount()).isZero();
+	}
+
+	@Test
+	void successfulKeepAliveFromReplacedSessionDoesNotResetReplacementFailureCount() throws Exception {
+		HttpServletStreamableServerTransportProvider provider = createProvider();
+		TrackingStreamableSession oldSession = createSession("session-1");
+		TrackingStreamableSession replacementSession = createSession("session-1");
+		putSession(provider, replacementSession);
+
+		provider.handleKeepAliveFailure(replacementSession, new RuntimeException("replacement failure"));
+		provider.resetKeepAliveFailures(oldSession);
+
+		assertThat(sessions(provider)).containsEntry("session-1", replacementSession);
+		assertThat(keepAliveFailureCounts(provider)).containsEntry("session-1", 1);
+		assertThat(oldSession.closeCount()).isZero();
+		assertThat(replacementSession.closeCount()).isZero();
+	}
+
+	@Test
+	void keepAliveFailureDoesNotCloseReplacedSession() throws Exception {
+		HttpServletStreamableServerTransportProvider provider = createProvider();
+		TrackingStreamableSession oldSession = createSession("session-1");
+		TrackingStreamableSession replacementSession = createSession("session-1");
+		putSession(provider, replacementSession);
+
+		provider.handleKeepAliveFailure(oldSession, new RuntimeException("first failure"));
+		provider.handleKeepAliveFailure(oldSession, new RuntimeException("second failure"));
+		provider.handleKeepAliveFailure(oldSession, new RuntimeException("third failure"));
+
+		assertThat(sessions(provider)).containsEntry("session-1", replacementSession);
+		assertThat(keepAliveFailureCounts(provider)).doesNotContainKey("session-1");
+		assertThat(oldSession.closeCount()).isZero();
+		assertThat(replacementSession.closeCount()).isZero();
+	}
+
+	private HttpServletStreamableServerTransportProvider createProvider() {
+		return HttpServletStreamableServerTransportProvider.builder().jsonMapper(new GsonMcpJsonMapper()).build();
+	}
+
+	private TrackingStreamableSession createSession(String sessionId) {
+		return new TrackingStreamableSession(sessionId);
+	}
+
+	private void putSession(HttpServletStreamableServerTransportProvider provider, TrackingStreamableSession session)
+			throws Exception {
+		sessions(provider).put(session.getId(), session);
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, McpStreamableServerSession> sessions(HttpServletStreamableServerTransportProvider provider)
+			throws Exception {
+		Field field = HttpServletStreamableServerTransportProvider.class.getDeclaredField("sessions");
+		field.setAccessible(true);
+		return (Map<String, McpStreamableServerSession>) field.get(provider);
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, Integer> keepAliveFailureCounts(HttpServletStreamableServerTransportProvider provider)
+			throws Exception {
+		Field field = HttpServletStreamableServerTransportProvider.class.getDeclaredField("keepAliveFailureCounts");
+		field.setAccessible(true);
+		return (Map<String, Integer>) field.get(provider);
+	}
+
+	private static class TrackingStreamableSession extends McpStreamableServerSession {
+
+		private final AtomicInteger closeCount = new AtomicInteger();
+
+		TrackingStreamableSession(String id) {
+			super(id, McpSchema.ClientCapabilities.builder().build(),
+					new McpSchema.Implementation("test-client", "1.0.0"), Duration.ofSeconds(5), Map.of(), Map.of(),
+					Mono::empty);
+		}
+
+		@Override
+		public void close() {
+			this.closeCount.incrementAndGet();
+		}
+
+		int closeCount() {
+			return this.closeCount.get();
+		}
+
+	}
+
+}

--- a/mcp-core/src/test/java/io/modelcontextprotocol/util/KeepAliveSchedulerTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/util/KeepAliveSchedulerTests.java
@@ -83,6 +83,20 @@ class KeepAliveSchedulerTests {
 	}
 
 	@Test
+	void testBuilderWithNullOnSuccess() {
+		assertThatThrownBy(() -> KeepAliveScheduler.builder(mockSessionsSupplier).onSuccess(null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("OnSuccess callback must not be null");
+	}
+
+	@Test
+	void testBuilderWithNullOnFailure() {
+		assertThatThrownBy(() -> KeepAliveScheduler.builder(mockSessionsSupplier).onFailure(null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("OnFailure callback must not be null");
+	}
+
+	@Test
 	void testBuilderDefaults() {
 		KeepAliveScheduler scheduler = KeepAliveScheduler.builder(mockSessionsSupplier).build();
 
@@ -157,6 +171,30 @@ class KeepAliveSchedulerTests {
 	}
 
 	@Test
+	void testPingSuccessInvokesSuccessHook() {
+		AtomicInteger successCount = new AtomicInteger();
+		AtomicInteger failureCount = new AtomicInteger();
+
+		KeepAliveScheduler scheduler = KeepAliveScheduler.builder(mockSessionsSupplier)
+			.scheduler(virtualTimeScheduler)
+			.initialDelay(Duration.ofSeconds(1))
+			.interval(Duration.ofSeconds(2))
+			.onSuccess(session -> successCount.incrementAndGet())
+			.onFailure((session, error) -> failureCount.incrementAndGet())
+			.build();
+
+		scheduler.start();
+
+		virtualTimeScheduler.advanceTimeBy(Duration.ofSeconds(1));
+
+		assertThat(mockSession1.getPingCount()).isEqualTo(1);
+		assertThat(successCount).hasValue(1);
+		assertThat(failureCount).hasValue(0);
+
+		scheduler.stop();
+	}
+
+	@Test
 	void testStartWhenAlreadyRunning() {
 		KeepAliveScheduler scheduler = KeepAliveScheduler.builder(mockSessionsSupplier)
 			.scheduler(virtualTimeScheduler)
@@ -226,6 +264,85 @@ class KeepAliveSchedulerTests {
 		assertThat(scheduler.isRunning()).isTrue();
 
 		// Clean up
+		scheduler.stop();
+	}
+
+	@Test
+	void testPingFailureInvokesFailureHook() {
+		mockSession1.setShouldFailPing(true);
+		AtomicInteger successCount = new AtomicInteger();
+		AtomicInteger failureCount = new AtomicInteger();
+
+		KeepAliveScheduler scheduler = KeepAliveScheduler.builder(mockSessionsSupplier)
+			.scheduler(virtualTimeScheduler)
+			.initialDelay(Duration.ofSeconds(1))
+			.interval(Duration.ofSeconds(2))
+			.onSuccess(session -> successCount.incrementAndGet())
+			.onFailure((session, error) -> failureCount.incrementAndGet())
+			.build();
+
+		scheduler.start();
+
+		virtualTimeScheduler.advanceTimeBy(Duration.ofSeconds(1));
+
+		assertThat(mockSession1.getPingCount()).isEqualTo(1);
+		assertThat(successCount).hasValue(0);
+		assertThat(failureCount).hasValue(1);
+		assertThat(scheduler.isRunning()).isTrue();
+
+		scheduler.stop();
+	}
+
+	@Test
+	void testSuccessHookExceptionDoesNotStopScheduler() {
+		AtomicInteger successAttempts = new AtomicInteger();
+
+		KeepAliveScheduler scheduler = KeepAliveScheduler.builder(mockSessionsSupplier)
+			.scheduler(virtualTimeScheduler)
+			.initialDelay(Duration.ofSeconds(1))
+			.interval(Duration.ofSeconds(2))
+			.onSuccess(session -> {
+				successAttempts.incrementAndGet();
+				throw new IllegalStateException("success callback failed");
+			})
+			.build();
+
+		scheduler.start();
+
+		virtualTimeScheduler.advanceTimeBy(Duration.ofSeconds(1));
+		virtualTimeScheduler.advanceTimeBy(Duration.ofSeconds(2));
+
+		assertThat(mockSession1.getPingCount()).isEqualTo(2);
+		assertThat(successAttempts).hasValue(2);
+		assertThat(scheduler.isRunning()).isTrue();
+
+		scheduler.stop();
+	}
+
+	@Test
+	void testFailureHookExceptionDoesNotStopScheduler() {
+		mockSession1.setShouldFailPing(true);
+		AtomicInteger failureAttempts = new AtomicInteger();
+
+		KeepAliveScheduler scheduler = KeepAliveScheduler.builder(mockSessionsSupplier)
+			.scheduler(virtualTimeScheduler)
+			.initialDelay(Duration.ofSeconds(1))
+			.interval(Duration.ofSeconds(2))
+			.onFailure((session, error) -> {
+				failureAttempts.incrementAndGet();
+				throw new IllegalStateException("failure callback failed");
+			})
+			.build();
+
+		scheduler.start();
+
+		virtualTimeScheduler.advanceTimeBy(Duration.ofSeconds(1));
+		virtualTimeScheduler.advanceTimeBy(Duration.ofSeconds(2));
+
+		assertThat(mockSession1.getPingCount()).isEqualTo(2);
+		assertThat(failureAttempts).hasValue(2);
+		assertThat(scheduler.isRunning()).isTrue();
+
 		scheduler.stop();
 	}
 


### PR DESCRIPTION
## Summary

Fixes #1022.

Evict dead Streamable HTTP sessions after repeated keep-alive ping failures.

When `keep-alive-interval` is enabled, `KeepAliveScheduler` currently detects dead sessions by logging failed pings, but the failed sessions remain in the Streamable HTTP provider's session registry. Over time, the scheduler keeps pinging the same unreachable sessions every interval, causing repeated WARN logs and CPU usage that grows with the number of accumulated dead sessions.

This PR adds keep-alive success/failure hooks and lets the Streamable HTTP servlet provider evict the logical session after consecutive keep-alive failures.

## Dependency / Review Order

Depends on #1027.

#1027 establishes the transport-level lifecycle behavior: servlet async lifecycle events and SSE write failures close only the current HTTP/SSE transport while keeping the logical MCP session registered.

This PR builds on that behavior by evicting the logical MCP session only after repeated keep-alive ping failures. After #1027 lands, this PR should be rebased on top of it so the keep-alive eviction behavior does not conflict with transport-level write-failure cleanup.

## Related Issues and PRs

- Fixes #1022.
- Depends on #1027 for servlet async lifecycle cleanup and write-failure semantics.
- Related to #952 and #972: this PR should not be interpreted as deleting the logical session on a single request-specific write failure. That behavior belongs to #1027 / #972.
- Related to #920: transient write failures should not immediately orphan a session, so this PR uses a consecutive-failure threshold rather than evicting on the first failure.

## Changes

- Add success and failure callbacks to `KeepAliveScheduler`.
- Keep the new scheduler callbacks backward compatible by defaulting them to no-op handlers.
- Track consecutive keep-alive ping failures in `HttpServletStreamableServerTransportProvider`.
- Reset the failure count after a successful keep-alive ping.
- Evict and close a Streamable HTTP session after 3 consecutive keep-alive ping failures.
- Clear failure counts on session deletion and provider shutdown.
- Guard failure-count reset and eviction with session identity checks so stale keep-alive results cannot affect a replaced session.
- Add focused tests for scheduler callbacks and Streamable HTTP keep-alive eviction behavior.

## Rationale

The issue suggested doing the failure counter and session removal directly in `KeepAliveScheduler`. This PR intentionally keeps `KeepAliveScheduler` transport-agnostic.

`KeepAliveScheduler` only receives a `Supplier<Flux<McpSession>>`. It does not own the Streamable HTTP provider's session registry, and it cannot safely remove entries from that registry directly.

The Streamable HTTP servlet provider owns the `sessions` map, so it also owns eviction. The scheduler reports ping success or failure through hooks, and the provider decides whether to reset the failure count, keep the session, or evict it.

This PR also avoids evicting on the first failure. A single failed ping can be transient, especially around load balancer timeouts, reconnects, request-specific streams, or temporary transport unavailability. Requiring 3 consecutive failures provides a conservative boundary between transient transport failure and a logical session that is no longer reachable.

Session TTL is intentionally left out of this PR. TTL may still be useful as a separate defense-in-depth policy, but this PR focuses only on sessions that keep-alive has already identified as repeatedly unreachable.

## Scope

This PR intentionally focuses on:

- `KeepAliveScheduler`
- Streamable HTTP servlet session eviction in `HttpServletStreamableServerTransportProvider`

Out of scope:

- Servlet async lifecycle cleanup and write-failure retention, handled in #1027
- Explicit session TTL
- Configurable keep-alive failure threshold
- Session persistence / distributed session storage
- Last-Event-ID resumability / event store support
- Deprecated `HttpServletSseServerTransportProvider`

## How Has This Been Tested?

```bash
mvn -pl mcp-core -Dtest=KeepAliveSchedulerTests,HttpServletStreamableServerTransportProviderTests test
mvn -pl mcp-core test
```

The added scheduler tests cover:

- null success/failure callback validation
- success callback invocation after successful ping
- failure callback invocation after failed ping
- callback exceptions do not stop the scheduler

The added provider tests cover:

- first keep-alive failure does not evict the session
- repeated keep-alive failures evict and close the session
- successful keep-alive resets the failure count
- stale failures from an old session instance do not evict a replacement session with the same id

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io/)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed