### PR TITLE
feat(server): support sync stateless MCP primitive repositories

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/CompletionsRepository.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/CompletionsRepository.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * Repository contract for handling stateless completion requests from the current MCP
+ * request context.
+ *
+ * @author Taewoong Kim
+ */
+public interface CompletionsRepository {
+
+	/**
+	 * Complete the request for the current request context.
+	 * @param request the completion request
+	 * @param transportContext the transport context for the current request
+	 * @return the completion result
+	 */
+	McpSchema.CompleteResult complete(McpSchema.CompleteRequest request, McpTransportContext transportContext);
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the original author or authors.
+ * Copyright 2024-2026 the original author or authors.
  */
 
 package io.modelcontextprotocol.server;
@@ -139,6 +139,7 @@ import reactor.core.publisher.Mono;
  * @author Christian Tzolov
  * @author Dariusz Jędrzejczyk
  * @author Jihoon Kim
+ * @author Taewoong Kim
  * @see McpAsyncServer
  * @see McpSyncServer
  * @see McpServerTransportProvider
@@ -1605,13 +1606,13 @@ public interface McpServer {
 		/**
 		 * Adds a single tool with its implementation handler to the server. This is a
 		 * convenience method for registering individual tools without creating a
-		 * {@link McpServerFeatures.AsyncToolSpecification} explicitly.
+		 * {@link McpStatelessServerFeatures.AsyncToolSpecification} explicitly.
 		 * @param tool The tool definition including name, description, and schema. Must
 		 * not be null.
 		 * @param callHandler The function that implements the tool's logic. Must not be
-		 * null. The function's first argument is an {@link McpAsyncServerExchange} upon
-		 * which the server can interact with the connected client. The second argument is
-		 * the {@link McpSchema.CallToolRequest} object containing the tool call
+		 * null. The function's first argument is an {@link McpTransportContext} for the
+		 * current request. The second argument is the {@link McpSchema.CallToolRequest}
+		 * object containing the tool call
 		 * @return This builder instance for method chaining
 		 * @throws IllegalArgumentException if tool or handler is null
 		 */
@@ -1658,9 +1659,9 @@ public interface McpServer {
 		 * <p>
 		 * Example usage: <pre>{@code
 		 * .tools(
-		 *     McpServerFeatures.AsyncToolSpecification.builder().tool(calculatorTool).callTool(calculatorHandler).build(),
-		 *     McpServerFeatures.AsyncToolSpecification.builder().tool(weatherTool).callTool(weatherHandler).build(),
-		 *     McpServerFeatures.AsyncToolSpecification.builder().tool(fileManagerTool).callTool(fileManagerHandler).build()
+		 *     McpStatelessServerFeatures.AsyncToolSpecification.builder().tool(calculatorTool).callTool(calculatorHandler).build(),
+		 *     McpStatelessServerFeatures.AsyncToolSpecification.builder().tool(weatherTool).callTool(weatherHandler).build(),
+		 *     McpStatelessServerFeatures.AsyncToolSpecification.builder().tool(fileManagerTool).callTool(fileManagerHandler).build()
 		 * )
 		 * }</pre>
 		 * @param toolSpecifications The tool specifications to add. Must not be null.
@@ -1731,9 +1732,9 @@ public interface McpServer {
 		 * <p>
 		 * Example usage: <pre>{@code
 		 * .resources(
-		 *     new McpServerFeatures.AsyncResourceSpecification(fileResource, fileHandler),
-		 *     new McpServerFeatures.AsyncResourceSpecification(dbResource, dbHandler),
-		 *     new McpServerFeatures.AsyncResourceSpecification(apiResource, apiHandler)
+		 *     new McpStatelessServerFeatures.AsyncResourceSpecification(fileResource, fileHandler),
+		 *     new McpStatelessServerFeatures.AsyncResourceSpecification(dbResource, dbHandler),
+		 *     new McpStatelessServerFeatures.AsyncResourceSpecification(apiResource, apiHandler)
 		 * )
 		 * }</pre>
 		 * @param resourceSpecifications The resource specifications to add. Must not be
@@ -1791,9 +1792,9 @@ public interface McpServer {
 		 *
 		 * <p>
 		 * Example usage: <pre>{@code
-		 * .prompts(Map.of("analysis", new McpServerFeatures.AsyncPromptSpecification(
+		 * .prompts(Map.of("analysis", new McpStatelessServerFeatures.AsyncPromptSpecification(
 		 *     new Prompt("analysis", "Code analysis template"),
-		 *     request -> Mono.fromSupplier(() -> generateAnalysisPrompt(request))
+		 *     (context, request) -> Mono.fromSupplier(() -> generateAnalysisPrompt(request))
 		 *         .map(GetPromptResult::new)
 		 * )));
 		 * }</pre>
@@ -1831,9 +1832,9 @@ public interface McpServer {
 		 * <p>
 		 * Example usage: <pre>{@code
 		 * .prompts(
-		 *     new McpServerFeatures.AsyncPromptSpecification(analysisPrompt, analysisHandler),
-		 *     new McpServerFeatures.AsyncPromptSpecification(summaryPrompt, summaryHandler),
-		 *     new McpServerFeatures.AsyncPromptSpecification(reviewPrompt, reviewHandler)
+		 *     new McpStatelessServerFeatures.AsyncPromptSpecification(analysisPrompt, analysisHandler),
+		 *     new McpStatelessServerFeatures.AsyncPromptSpecification(summaryPrompt, summaryHandler),
+		 *     new McpStatelessServerFeatures.AsyncPromptSpecification(reviewPrompt, reviewHandler)
 		 * )
 		 * }</pre>
 		 * @param prompts The prompt specifications to add. Must not be null.
@@ -1908,7 +1909,8 @@ public interface McpServer {
 
 		public McpStatelessAsyncServer build() {
 			var features = new McpStatelessServerFeatures.Async(this.serverInfo, this.serverCapabilities, this.tools,
-					this.resources, this.resourceTemplates, this.prompts, this.completions, this.instructions);
+					this.resources, this.resourceTemplates, this.prompts, this.completions, null, null, null, null,
+					false, this.instructions);
 			var jsonSchemaValidator = this.jsonSchemaValidator != null ? this.jsonSchemaValidator
 					: McpJsonDefaults.getSchemaValidator();
 
@@ -1979,6 +1981,14 @@ public interface McpServer {
 		final Map<String, McpStatelessServerFeatures.SyncPromptSpecification> prompts = new HashMap<>();
 
 		final Map<McpSchema.CompleteReference, McpStatelessServerFeatures.SyncCompletionSpecification> completions = new HashMap<>();
+
+		ToolsRepository toolsRepository;
+
+		ResourcesRepository resourcesRepository;
+
+		PromptsRepository promptsRepository;
+
+		CompletionsRepository completionsRepository;
 
 		Duration requestTimeout = Duration.ofSeconds(10); // Default timeout
 
@@ -2105,13 +2115,13 @@ public interface McpServer {
 		/**
 		 * Adds a single tool with its implementation handler to the server. This is a
 		 * convenience method for registering individual tools without creating a
-		 * {@link McpServerFeatures.SyncToolSpecification} explicitly.
+		 * {@link McpStatelessServerFeatures.SyncToolSpecification} explicitly.
 		 * @param tool The tool definition including name, description, and schema. Must
 		 * not be null.
 		 * @param callHandler The function that implements the tool's logic. Must not be
-		 * null. The function's first argument is an {@link McpSyncServerExchange} upon
-		 * which the server can interact with the connected client. The second argument is
-		 * the {@link McpSchema.CallToolRequest} object containing the tool call
+		 * null. The function's first argument is an {@link McpTransportContext} for the
+		 * current request. The second argument is the {@link McpSchema.CallToolRequest}
+		 * object containing the tool call
 		 * @return This builder instance for method chaining
 		 * @throws IllegalArgumentException if tool or handler is null
 		 */
@@ -2120,6 +2130,7 @@ public interface McpServer {
 
 			Assert.notNull(tool, "Tool must not be null");
 			Assert.notNull(callHandler, "Handler must not be null");
+			assertNoRepository(this.toolsRepository, "toolsRepository", "Static tool registrations");
 			validateToolName(tool.name());
 			assertNoDuplicateTool(tool.name());
 
@@ -2141,6 +2152,7 @@ public interface McpServer {
 		public StatelessSyncSpecification tools(
 				List<McpStatelessServerFeatures.SyncToolSpecification> toolSpecifications) {
 			Assert.notNull(toolSpecifications, "Tool handlers list must not be null");
+			assertNoRepository(this.toolsRepository, "toolsRepository", "Static tool registrations");
 
 			for (var tool : toolSpecifications) {
 				validateToolName(tool.tool().name());
@@ -2158,9 +2170,9 @@ public interface McpServer {
 		 * <p>
 		 * Example usage: <pre>{@code
 		 * .tools(
-		 *     McpServerFeatures.SyncToolSpecification.builder().tool(calculatorTool).callTool(calculatorHandler).build(),
-		 *     McpServerFeatures.SyncToolSpecification.builder().tool(weatherTool).callTool(weatherHandler).build(),
-		 *     McpServerFeatures.SyncToolSpecification.builder().tool(fileManagerTool).callTool(fileManagerHandler).build()
+		 *     McpStatelessServerFeatures.SyncToolSpecification.builder().tool(calculatorTool).callTool(calculatorHandler).build(),
+		 *     McpStatelessServerFeatures.SyncToolSpecification.builder().tool(weatherTool).callTool(weatherHandler).build(),
+		 *     McpStatelessServerFeatures.SyncToolSpecification.builder().tool(fileManagerTool).callTool(fileManagerHandler).build()
 		 * )
 		 * }</pre>
 		 * @param toolSpecifications The tool specifications to add. Must not be null.
@@ -2170,6 +2182,7 @@ public interface McpServer {
 		public StatelessSyncSpecification tools(
 				McpStatelessServerFeatures.SyncToolSpecification... toolSpecifications) {
 			Assert.notNull(toolSpecifications, "Tool handlers list must not be null");
+			assertNoRepository(this.toolsRepository, "toolsRepository", "Static tool registrations");
 
 			for (var tool : toolSpecifications) {
 				validateToolName(tool.tool().name());
@@ -2190,6 +2203,19 @@ public interface McpServer {
 		}
 
 		/**
+		 * Sets the repository used to list, resolve, and call tools for each stateless
+		 * request. Static tool registrations cannot be mixed with a tools repository.
+		 * @param toolsRepository The tools repository. Must not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public StatelessSyncSpecification toolsRepository(ToolsRepository toolsRepository) {
+			Assert.notNull(toolsRepository, "Tools repository must not be null");
+			assertNoStaticRegistrations(!this.tools.isEmpty(), "toolsRepository", "static tool registrations");
+			this.toolsRepository = toolsRepository;
+			return this;
+		}
+
+		/**
 		 * Registers multiple resources with their handlers using a Map. This method is
 		 * useful when resources are dynamically generated or loaded from a configuration
 		 * source.
@@ -2202,6 +2228,7 @@ public interface McpServer {
 		public StatelessSyncSpecification resources(
 				Map<String, McpStatelessServerFeatures.SyncResourceSpecification> resourceSpecifications) {
 			Assert.notNull(resourceSpecifications, "Resource handlers map must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository", "Static resource registrations");
 			this.resources.putAll(resourceSpecifications);
 			return this;
 		}
@@ -2218,6 +2245,7 @@ public interface McpServer {
 		public StatelessSyncSpecification resources(
 				List<McpStatelessServerFeatures.SyncResourceSpecification> resourceSpecifications) {
 			Assert.notNull(resourceSpecifications, "Resource handlers list must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository", "Static resource registrations");
 			for (var resource : resourceSpecifications) {
 				this.resources.put(resource.resource().uri(), resource);
 			}
@@ -2231,9 +2259,9 @@ public interface McpServer {
 		 * <p>
 		 * Example usage: <pre>{@code
 		 * .resources(
-		 *     new McpServerFeatures.SyncResourceSpecification(fileResource, fileHandler),
-		 *     new McpServerFeatures.SyncResourceSpecification(dbResource, dbHandler),
-		 *     new McpServerFeatures.SyncResourceSpecification(apiResource, apiHandler)
+		 *     new McpStatelessServerFeatures.SyncResourceSpecification(fileResource, fileHandler),
+		 *     new McpStatelessServerFeatures.SyncResourceSpecification(dbResource, dbHandler),
+		 *     new McpStatelessServerFeatures.SyncResourceSpecification(apiResource, apiHandler)
 		 * )
 		 * }</pre>
 		 * @param resourceSpecifications The resource specifications to add. Must not be
@@ -2244,6 +2272,7 @@ public interface McpServer {
 		public StatelessSyncSpecification resources(
 				McpStatelessServerFeatures.SyncResourceSpecification... resourceSpecifications) {
 			Assert.notNull(resourceSpecifications, "Resource handlers list must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository", "Static resource registrations");
 			for (var resource : resourceSpecifications) {
 				this.resources.put(resource.resource().uri(), resource);
 			}
@@ -2261,6 +2290,8 @@ public interface McpServer {
 		public StatelessSyncSpecification resourceTemplates(
 				List<McpStatelessServerFeatures.SyncResourceTemplateSpecification> resourceTemplatesSpec) {
 			Assert.notNull(resourceTemplatesSpec, "Resource templates must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository",
+					"Static resource template registrations");
 			for (var resourceTemplate : resourceTemplatesSpec) {
 				this.resourceTemplates.put(resourceTemplate.resourceTemplate().uriTemplate(), resourceTemplate);
 			}
@@ -2278,9 +2309,26 @@ public interface McpServer {
 		public StatelessSyncSpecification resourceTemplates(
 				McpStatelessServerFeatures.SyncResourceTemplateSpecification... resourceTemplates) {
 			Assert.notNull(resourceTemplates, "Resource templates must not be null");
+			assertNoRepository(this.resourcesRepository, "resourcesRepository",
+					"Static resource template registrations");
 			for (McpStatelessServerFeatures.SyncResourceTemplateSpecification resourceTemplate : resourceTemplates) {
 				this.resourceTemplates.put(resourceTemplate.resourceTemplate().uriTemplate(), resourceTemplate);
 			}
+			return this;
+		}
+
+		/**
+		 * Sets the repository used to list, resolve, and read resources and resource
+		 * templates for each stateless request. Static resource and resource-template
+		 * registrations cannot be mixed with a resources repository.
+		 * @param resourcesRepository The resources repository. Must not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public StatelessSyncSpecification resourcesRepository(ResourcesRepository resourcesRepository) {
+			Assert.notNull(resourcesRepository, "Resources repository must not be null");
+			assertNoStaticRegistrations(!this.resources.isEmpty() || !this.resourceTemplates.isEmpty(),
+					"resourcesRepository", "static resource or resource template registrations");
+			this.resourcesRepository = resourcesRepository;
 			return this;
 		}
 
@@ -2291,10 +2339,9 @@ public interface McpServer {
 		 *
 		 * <p>
 		 * Example usage: <pre>{@code
-		 * .prompts(Map.of("analysis", new McpServerFeatures.SyncPromptSpecification(
+		 * .prompts(Map.of("analysis", new McpStatelessServerFeatures.SyncPromptSpecification(
 		 *     new Prompt("analysis", "Code analysis template"),
-		 *     request -> Mono.fromSupplier(() -> generateAnalysisPrompt(request))
-		 *         .map(GetPromptResult::new)
+		 *     (context, request) -> generateAnalysisPrompt(request)
 		 * )));
 		 * }</pre>
 		 * @param prompts Map of prompt name to specification. Must not be null.
@@ -2304,6 +2351,7 @@ public interface McpServer {
 		public StatelessSyncSpecification prompts(
 				Map<String, McpStatelessServerFeatures.SyncPromptSpecification> prompts) {
 			Assert.notNull(prompts, "Prompts map must not be null");
+			assertNoRepository(this.promptsRepository, "promptsRepository", "Static prompt registrations");
 			this.prompts.putAll(prompts);
 			return this;
 		}
@@ -2318,6 +2366,7 @@ public interface McpServer {
 		 */
 		public StatelessSyncSpecification prompts(List<McpStatelessServerFeatures.SyncPromptSpecification> prompts) {
 			Assert.notNull(prompts, "Prompts list must not be null");
+			assertNoRepository(this.promptsRepository, "promptsRepository", "Static prompt registrations");
 			for (var prompt : prompts) {
 				this.prompts.put(prompt.prompt().name(), prompt);
 			}
@@ -2331,9 +2380,9 @@ public interface McpServer {
 		 * <p>
 		 * Example usage: <pre>{@code
 		 * .prompts(
-		 *     new McpServerFeatures.SyncPromptSpecification(analysisPrompt, analysisHandler),
-		 *     new McpServerFeatures.SyncPromptSpecification(summaryPrompt, summaryHandler),
-		 *     new McpServerFeatures.SyncPromptSpecification(reviewPrompt, reviewHandler)
+		 *     new McpStatelessServerFeatures.SyncPromptSpecification(analysisPrompt, analysisHandler),
+		 *     new McpStatelessServerFeatures.SyncPromptSpecification(summaryPrompt, summaryHandler),
+		 *     new McpStatelessServerFeatures.SyncPromptSpecification(reviewPrompt, reviewHandler)
 		 * )
 		 * }</pre>
 		 * @param prompts The prompt specifications to add. Must not be null.
@@ -2342,9 +2391,23 @@ public interface McpServer {
 		 */
 		public StatelessSyncSpecification prompts(McpStatelessServerFeatures.SyncPromptSpecification... prompts) {
 			Assert.notNull(prompts, "Prompts list must not be null");
+			assertNoRepository(this.promptsRepository, "promptsRepository", "Static prompt registrations");
 			for (var prompt : prompts) {
 				this.prompts.put(prompt.prompt().name(), prompt);
 			}
+			return this;
+		}
+
+		/**
+		 * Sets the repository used to list, resolve, and get prompts for each stateless
+		 * request. Static prompt registrations cannot be mixed with a prompts repository.
+		 * @param promptsRepository The prompts repository. Must not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public StatelessSyncSpecification promptsRepository(PromptsRepository promptsRepository) {
+			Assert.notNull(promptsRepository, "Prompts repository must not be null");
+			assertNoStaticRegistrations(!this.prompts.isEmpty(), "promptsRepository", "static prompt registrations");
+			this.promptsRepository = promptsRepository;
 			return this;
 		}
 
@@ -2358,6 +2421,7 @@ public interface McpServer {
 		public StatelessSyncSpecification completions(
 				List<McpStatelessServerFeatures.SyncCompletionSpecification> completions) {
 			Assert.notNull(completions, "Completions list must not be null");
+			assertNoRepository(this.completionsRepository, "completionsRepository", "Static completion registrations");
 			for (var completion : completions) {
 				this.completions.put(completion.referenceKey(), completion);
 			}
@@ -2374,9 +2438,24 @@ public interface McpServer {
 		public StatelessSyncSpecification completions(
 				McpStatelessServerFeatures.SyncCompletionSpecification... completions) {
 			Assert.notNull(completions, "Completions list must not be null");
+			assertNoRepository(this.completionsRepository, "completionsRepository", "Static completion registrations");
 			for (var completion : completions) {
 				this.completions.put(completion.referenceKey(), completion);
 			}
+			return this;
+		}
+
+		/**
+		 * Sets the repository used to complete stateless completion requests. Static
+		 * completion registrations cannot be mixed with a completions repository.
+		 * @param completionsRepository The completions repository. Must not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public StatelessSyncSpecification completionsRepository(CompletionsRepository completionsRepository) {
+			Assert.notNull(completionsRepository, "Completions repository must not be null");
+			assertNoStaticRegistrations(!this.completions.isEmpty(), "completionsRepository",
+					"static completion registrations");
+			this.completionsRepository = completionsRepository;
 			return this;
 		}
 
@@ -2407,7 +2486,7 @@ public interface McpServer {
 		}
 
 		/**
-		 * Enable on "immediate execution" of the operations on the underlying
+		 * Enables immediate execution of operations on the underlying
 		 * {@link McpStatelessAsyncServer}. Defaults to false, which does blocking code
 		 * offloading to prevent accidental blocking of the non-blocking transport.
 		 * <p>
@@ -2424,7 +2503,8 @@ public interface McpServer {
 
 		public McpStatelessSyncServer build() {
 			var syncFeatures = new McpStatelessServerFeatures.Sync(this.serverInfo, this.serverCapabilities, this.tools,
-					this.resources, this.resourceTemplates, this.prompts, this.completions, this.instructions);
+					this.resources, this.resourceTemplates, this.prompts, this.completions, this.toolsRepository,
+					this.resourcesRepository, this.promptsRepository, this.completionsRepository, this.instructions);
 			var asyncFeatures = McpStatelessServerFeatures.Async.fromSync(syncFeatures, this.immediateExecution);
 			var jsonSchemaValidator = this.jsonSchemaValidator != null ? this.jsonSchemaValidator
 					: McpJsonDefaults.getSchemaValidator();
@@ -2434,9 +2514,24 @@ public interface McpServer {
 			var asyncServer = new McpStatelessAsyncServer(transport,
 					jsonMapper == null ? McpJsonDefaults.getMapper() : jsonMapper, asyncFeatures, requestTimeout,
 					uriTemplateManagerFactory, jsonSchemaValidator, validateToolInputs);
-			return new McpStatelessSyncServer(asyncServer, this.immediateExecution);
+			return new McpStatelessSyncServer(asyncServer);
 		}
 
+	}
+
+	private static void assertNoStaticRegistrations(boolean hasStaticRegistrations, String repositoryName,
+			String registrationsName) {
+		if (hasStaticRegistrations) {
+			throw new IllegalStateException(
+					repositoryName + " cannot be configured together with " + registrationsName);
+		}
+	}
+
+	private static void assertNoRepository(Object repository, String repositoryName, String registrationsName) {
+		if (repository != null) {
+			throw new IllegalStateException(
+					registrationsName + " cannot be configured together with " + repositoryName);
+		}
 	}
 
 	private static void validateAsyncToolSchemas(JsonSchemaValidator validator,

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
@@ -47,6 +47,7 @@ import static io.modelcontextprotocol.spec.McpError.RESOURCE_NOT_FOUND;
  * knowledge and can serve the clients with the capabilities it supports.
  *
  * @author Dariusz Jędrzejczyk
+ * @author Taewoong Kim
  */
 public class McpStatelessAsyncServer {
 
@@ -72,6 +73,18 @@ public class McpStatelessAsyncServer {
 
 	private final ConcurrentHashMap<McpSchema.CompleteReference, McpStatelessServerFeatures.AsyncCompletionSpecification> completions = new ConcurrentHashMap<>();
 
+	private final ToolsRepository toolsRepository;
+
+	private final ResourcesRepository resourcesRepository;
+
+	private final PromptsRepository promptsRepository;
+
+	private final CompletionsRepository completionsRepository;
+
+	private final boolean immediateExecution;
+
+	private final SyncRepositoryCallAdapter repositoryCallAdapter;
+
 	private List<String> protocolVersions;
 
 	private McpUriTemplateManagerFactory uriTemplateManagerFactory = new DefaultMcpUriTemplateManagerFactory();
@@ -94,6 +107,12 @@ public class McpStatelessAsyncServer {
 		this.resourceTemplates.putAll(features.resourceTemplates());
 		this.prompts.putAll(features.prompts());
 		this.completions.putAll(features.completions());
+		this.toolsRepository = features.toolsRepository();
+		this.resourcesRepository = features.resourcesRepository();
+		this.promptsRepository = features.promptsRepository();
+		this.completionsRepository = features.completionsRepository();
+		this.immediateExecution = features.immediateExecution();
+		this.repositoryCallAdapter = new SyncRepositoryCallAdapter(this.immediateExecution);
 		this.uriTemplateManagerFactory = uriTemplateManagerFactory;
 		this.jsonSchemaValidator = jsonSchemaValidator;
 		this.validateToolInputs = validateToolInputs;
@@ -187,6 +206,14 @@ public class McpStatelessAsyncServer {
 		return this.serverInfo;
 	}
 
+	private McpSchema.PaginatedRequest paginatedRequest(Object params) {
+		if (params == null) {
+			return new McpSchema.PaginatedRequest();
+		}
+		return this.jsonMapper.convertValue(params, new TypeRef<>() {
+		});
+	}
+
 	/**
 	 * Gracefully closes the server, allowing any in-progress operations to complete.
 	 * @return A Mono that completes when the server has been closed
@@ -235,6 +262,94 @@ public class McpStatelessAsyncServer {
 						toolSpecification.callHandler()));
 	}
 
+	private void assertToolSpecification(McpStatelessServerFeatures.AsyncToolSpecification toolSpecification) {
+		if (toolSpecification == null) {
+			throw new IllegalArgumentException("Tool specification must not be null");
+		}
+		assertToolSpecification(toolSpecification.tool(), toolSpecification.callHandler());
+	}
+
+	private void assertToolSpecification(McpStatelessServerFeatures.SyncToolSpecification toolSpecification) {
+		if (toolSpecification == null) {
+			throw new IllegalArgumentException("Tool specification must not be null");
+		}
+		assertToolSpecification(toolSpecification.tool(), toolSpecification.callHandler());
+	}
+
+	private void assertToolSpecification(McpSchema.Tool tool, Object callHandler) {
+		if (tool == null) {
+			throw new IllegalArgumentException("Tool must not be null");
+		}
+		if (callHandler == null) {
+			throw new IllegalArgumentException("Tool call handler must not be null");
+		}
+		if (this.serverCapabilities.tools() == null) {
+			throw new IllegalStateException("Server must be configured with tool capabilities");
+		}
+		this.jsonSchemaValidator.assertConforms("Tool '" + tool.name() + "' inputSchema", tool.inputSchema());
+		this.jsonSchemaValidator.assertConforms("Tool '" + tool.name() + "' outputSchema", tool.outputSchema());
+	}
+
+	private static CallToolResult validateToolOutput(JsonSchemaValidator jsonSchemaValidator,
+			Map<String, Object> outputSchema, McpSchema.CallToolRequest request, CallToolResult result) {
+
+		if (Boolean.TRUE.equals(result.isError())) {
+			// If the tool call resulted in an error, skip further validation
+			return result;
+		}
+
+		if (outputSchema == null) {
+			if (result.structuredContent() != null) {
+				logger.warn(
+						"Tool call with no outputSchema is not expected to have a result with structured content, but got: {}",
+						result.structuredContent());
+			}
+			// Pass through. No validation is required if no output schema is
+			// provided.
+			return result;
+		}
+
+		// If an output schema is provided, servers MUST provide structured
+		// results that conform to this schema.
+		// https://modelcontextprotocol.io/specification/2025-06-18/server/tools#output-schema
+		if (result.structuredContent() == null) {
+			String content = "Response missing structured content which is expected when calling tool with non-empty outputSchema";
+			logger.warn(content);
+			return CallToolResult.builder()
+				.content(List.of(McpSchema.TextContent.builder(content).build()))
+				.isError(true)
+				.build();
+		}
+
+		// Validate the result against the output schema
+		var validation = jsonSchemaValidator.validate(outputSchema, result.structuredContent());
+
+		if (!validation.valid()) {
+			String message = "Tool (" + request.name() + ") output validation failed: " + validation.errorMessage();
+			logger.warn(message);
+			return CallToolResult.builder()
+				.content(List.of(McpSchema.TextContent.builder(message).build()))
+				.isError(true)
+				.build();
+		}
+
+		if (Utils.isEmpty(result.content())) {
+			// For backwards compatibility, a tool that returns structured
+			// content SHOULD also return functionally equivalent unstructured
+			// content. (For example, serialized JSON can be returned in a
+			// TextContent block.)
+			// https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content
+
+			return CallToolResult.builder()
+				.content(List.of(McpSchema.TextContent.builder(validation.jsonStructuredOutput()).build()))
+				.isError(result.isError())
+				.structuredContent(result.structuredContent())
+				.build();
+		}
+
+		return result;
+	}
+
 	private static class StructuredOutputCallToolHandler
 			implements BiFunction<McpTransportContext, McpSchema.CallToolRequest, Mono<McpSchema.CallToolResult>> {
 
@@ -259,65 +374,8 @@ public class McpStatelessAsyncServer {
 		@Override
 		public Mono<CallToolResult> apply(McpTransportContext transportContext, McpSchema.CallToolRequest request) {
 
-			return this.delegateHandler.apply(transportContext, request).map(result -> {
-
-				if (Boolean.TRUE.equals(result.isError())) {
-					// If the tool call resulted in an error, skip further validation
-					return result;
-				}
-
-				if (outputSchema == null) {
-					if (result.structuredContent() != null) {
-						logger.warn(
-								"Tool call with no outputSchema is not expected to have a result with structured content, but got: {}",
-								result.structuredContent());
-					}
-					// Pass through. No validation is required if no output schema is
-					// provided.
-					return result;
-				}
-
-				// If an output schema is provided, servers MUST provide structured
-				// results that conform to this schema.
-				// https://modelcontextprotocol.io/specification/2025-06-18/server/tools#output-schema
-				if (result.structuredContent() == null) {
-					String content = "Response missing structured content which is expected when calling tool with non-empty outputSchema";
-					logger.warn(content);
-					return CallToolResult.builder()
-						.content(List.of(McpSchema.TextContent.builder(content).build()))
-						.isError(true)
-						.build();
-				}
-
-				// Validate the result against the output schema
-				var validation = this.jsonSchemaValidator.validate(outputSchema, result.structuredContent());
-
-				if (!validation.valid()) {
-					String message = "Tool (" + request.name() + ") output validation failed: "
-							+ validation.errorMessage();
-					logger.warn(message);
-					return CallToolResult.builder()
-						.content(List.of(McpSchema.TextContent.builder(message).build()))
-						.isError(true)
-						.build();
-				}
-
-				if (Utils.isEmpty(result.content())) {
-					// For backwards compatibility, a tool that returns structured
-					// content SHOULD also return functionally equivalent unstructured
-					// content. (For example, serialized JSON can be returned in a
-					// TextContent block.)
-					// https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content
-
-					return CallToolResult.builder()
-						.content(List.of(McpSchema.TextContent.builder(validation.jsonStructuredOutput()).build()))
-						.isError(result.isError())
-						.structuredContent(result.structuredContent())
-						.build();
-				}
-
-				return result;
-			});
+			return this.delegateHandler.apply(transportContext, request)
+				.map(result -> validateToolOutput(this.jsonSchemaValidator, this.outputSchema, request, result));
 		}
 
 	}
@@ -325,28 +383,17 @@ public class McpStatelessAsyncServer {
 	/**
 	 * Add a new tool specification at runtime.
 	 * @param toolSpecification The tool specification to add
-	 * @return Mono that completes when clients have been notified of the change
+	 * @return Mono that completes when the server has been updated
 	 */
 	public Mono<Void> addTool(McpStatelessServerFeatures.AsyncToolSpecification toolSpecification) {
-		if (toolSpecification == null) {
-			return Mono.error(new IllegalArgumentException("Tool specification must not be null"));
+		if (this.toolsRepository != null) {
+			return Mono.error(new IllegalStateException(
+					"Server is configured with a tools repository and cannot accept async tool registrations"));
 		}
-		if (toolSpecification.tool() == null) {
-			return Mono.error(new IllegalArgumentException("Tool must not be null"));
-		}
-		if (toolSpecification.callHandler() == null) {
-			return Mono.error(new IllegalArgumentException("Tool call handler must not be null"));
-		}
-		if (this.serverCapabilities.tools() == null) {
-			return Mono.error(new IllegalStateException("Server must be configured with tool capabilities"));
-		}
-
 		try {
-			var t = toolSpecification.tool();
-			this.jsonSchemaValidator.assertConforms("Tool '" + t.name() + "' inputSchema", t.inputSchema());
-			this.jsonSchemaValidator.assertConforms("Tool '" + t.name() + "' outputSchema", t.outputSchema());
+			assertToolSpecification(toolSpecification);
 		}
-		catch (IllegalArgumentException e) {
+		catch (RuntimeException e) {
 			return Mono.error(e);
 		}
 
@@ -365,18 +412,39 @@ public class McpStatelessAsyncServer {
 		});
 	}
 
+	Mono<Void> addTool(McpStatelessServerFeatures.SyncToolSpecification toolSpecification) {
+		if (this.toolsRepository != null) {
+			try {
+				assertToolSpecification(toolSpecification);
+			}
+			catch (RuntimeException e) {
+				return Mono.error(e);
+			}
+			return this.repositoryCallAdapter.run(() -> this.toolsRepository.addTool(toolSpecification));
+		}
+		return addTool(
+				McpStatelessServerFeatures.AsyncToolSpecification.fromSync(toolSpecification, this.immediateExecution));
+	}
+
 	/**
-	 * List all registered tools.
-	 * @return A Flux stream of all registered tools
+	 * List tools without a client request context.
+	 * @return A Flux stream of context-free visible tools
 	 */
 	public Flux<Tool> listTools() {
+		if (this.toolsRepository != null) {
+			return this.repositoryCallAdapter
+				.invoke(() -> this.toolsRepository
+					.listTools(new McpSchema.PaginatedRequest(), McpTransportContext.EMPTY)
+					.tools())
+				.flatMapIterable(tools -> tools);
+		}
 		return Flux.fromIterable(this.tools).map(McpStatelessServerFeatures.AsyncToolSpecification::tool);
 	}
 
 	/**
 	 * Remove a tool handler at runtime.
 	 * @param toolName The name of the tool handler to remove
-	 * @return Mono that completes when clients have been notified of the change
+	 * @return Mono that completes when the server has been updated
 	 */
 	public Mono<Void> removeTool(String toolName) {
 		if (toolName == null) {
@@ -385,10 +453,12 @@ public class McpStatelessAsyncServer {
 		if (this.serverCapabilities.tools() == null) {
 			return Mono.error(new IllegalStateException("Server must be configured with tool capabilities"));
 		}
+		if (this.toolsRepository != null) {
+			return this.repositoryCallAdapter.invoke(() -> this.toolsRepository.removeTool(toolName)).then();
+		}
 
 		return Mono.defer(() -> {
 			if (this.tools.removeIf(toolSpecification -> toolSpecification.tool().name().equals(toolName))) {
-
 				logger.debug("Removed tool handler: {}", toolName);
 			}
 			else {
@@ -401,6 +471,10 @@ public class McpStatelessAsyncServer {
 
 	private McpStatelessRequestHandler<McpSchema.ListToolsResult> toolsListRequestHandler() {
 		return (ctx, params) -> {
+			if (this.toolsRepository != null) {
+				McpSchema.PaginatedRequest request = paginatedRequest(params);
+				return this.repositoryCallAdapter.invoke(() -> this.toolsRepository.listTools(request, ctx));
+			}
 			List<Tool> tools = this.tools.stream()
 				.map(McpStatelessServerFeatures.AsyncToolSpecification::tool)
 				.toList();
@@ -413,6 +487,16 @@ public class McpStatelessAsyncServer {
 			McpSchema.CallToolRequest callToolRequest = jsonMapper.convertValue(params,
 					new TypeRef<McpSchema.CallToolRequest>() {
 					});
+
+			if (this.toolsRepository != null) {
+				return this.repositoryCallAdapter
+					.invoke(() -> this.toolsRepository.resolveTool(callToolRequest.name(), ctx))
+					.flatMap(tool -> tool.map(resolvedTool -> callRepositoryTool(ctx, callToolRequest, resolvedTool))
+						.orElseGet(() -> Mono.error(McpError.builder(McpSchema.ErrorCodes.INVALID_PARAMS)
+							.message("Unknown tool: invalid_tool_name")
+							.data("Tool not found: " + callToolRequest.name())
+							.build())));
+			}
 
 			Optional<McpStatelessServerFeatures.AsyncToolSpecification> toolSpecification = this.tools.stream()
 				.filter(tr -> callToolRequest.name().equals(tr.tool().name()))
@@ -436,6 +520,19 @@ public class McpStatelessAsyncServer {
 		};
 	}
 
+	private Mono<CallToolResult> callRepositoryTool(McpTransportContext transportContext,
+			McpSchema.CallToolRequest callToolRequest, McpSchema.Tool tool) {
+
+		CallToolResult validationError = ToolInputValidator.validate(tool, callToolRequest.arguments(),
+				this.validateToolInputs, this.jsonSchemaValidator);
+		if (validationError != null) {
+			return Mono.just(validationError);
+		}
+
+		return this.repositoryCallAdapter.invoke(() -> this.toolsRepository.callTool(callToolRequest, transportContext))
+			.map(result -> validateToolOutput(this.jsonSchemaValidator, tool.outputSchema(), callToolRequest, result));
+	}
+
 	// ---------------------------------------
 	// Resource Management
 	// ---------------------------------------
@@ -443,9 +540,13 @@ public class McpStatelessAsyncServer {
 	/**
 	 * Add a new resource handler at runtime.
 	 * @param resourceSpecification The resource handler to add
-	 * @return Mono that completes when clients have been notified of the change
+	 * @return Mono that completes when the server has been updated
 	 */
 	public Mono<Void> addResource(McpStatelessServerFeatures.AsyncResourceSpecification resourceSpecification) {
+		if (this.resourcesRepository != null) {
+			return Mono.error(new IllegalStateException(
+					"Server is configured with a resources repository and cannot accept async resource registrations"));
+		}
 		if (resourceSpecification == null || resourceSpecification.resource() == null) {
 			return Mono.error(new IllegalArgumentException("Resource must not be null"));
 		}
@@ -466,11 +567,32 @@ public class McpStatelessAsyncServer {
 		});
 	}
 
+	Mono<Void> addResource(McpStatelessServerFeatures.SyncResourceSpecification resourceSpecification) {
+		if (this.resourcesRepository != null) {
+			if (resourceSpecification == null || resourceSpecification.resource() == null) {
+				return Mono.error(new IllegalArgumentException("Resource must not be null"));
+			}
+			if (this.serverCapabilities.resources() == null) {
+				return Mono.error(new IllegalStateException("Server must be configured with resource capabilities"));
+			}
+			return this.repositoryCallAdapter.run(() -> this.resourcesRepository.addResource(resourceSpecification));
+		}
+		return addResource(McpStatelessServerFeatures.AsyncResourceSpecification.fromSync(resourceSpecification,
+				this.immediateExecution));
+	}
+
 	/**
-	 * List all registered resources.
-	 * @return A Flux stream of all registered resources
+	 * List resources without a client request context.
+	 * @return A Flux stream of context-free visible resources
 	 */
 	public Flux<McpSchema.Resource> listResources() {
+		if (this.resourcesRepository != null) {
+			return this.repositoryCallAdapter
+				.invoke(() -> this.resourcesRepository
+					.listResources(new McpSchema.PaginatedRequest(), McpTransportContext.EMPTY)
+					.resources())
+				.flatMapIterable(resources -> resources);
+		}
 		return Flux.fromIterable(this.resources.values())
 			.map(McpStatelessServerFeatures.AsyncResourceSpecification::resource);
 	}
@@ -478,7 +600,7 @@ public class McpStatelessAsyncServer {
 	/**
 	 * Remove a resource handler at runtime.
 	 * @param resourceUri The URI of the resource handler to remove
-	 * @return Mono that completes when clients have been notified of the change
+	 * @return Mono that completes when the server has been updated
 	 */
 	public Mono<Void> removeResource(String resourceUri) {
 		if (resourceUri == null) {
@@ -486,6 +608,9 @@ public class McpStatelessAsyncServer {
 		}
 		if (this.serverCapabilities.resources() == null) {
 			return Mono.error(new IllegalStateException("Server must be configured with resource capabilities"));
+		}
+		if (this.resourcesRepository != null) {
+			return this.repositoryCallAdapter.invoke(() -> this.resourcesRepository.removeResource(resourceUri)).then();
 		}
 
 		return Mono.defer(() -> {
@@ -503,10 +628,14 @@ public class McpStatelessAsyncServer {
 	/**
 	 * Add a new resource template at runtime.
 	 * @param resourceTemplateSpecification The resource template to add
-	 * @return Mono that completes when clients have been notified of the change
+	 * @return Mono that completes when the server has been updated
 	 */
 	public Mono<Void> addResourceTemplate(
 			McpStatelessServerFeatures.AsyncResourceTemplateSpecification resourceTemplateSpecification) {
+		if (this.resourcesRepository != null) {
+			return Mono.error(new IllegalStateException(
+					"Server is configured with a resources repository and cannot accept async resource template registrations"));
+		}
 
 		if (this.serverCapabilities.resources() == null) {
 			return Mono.error(new IllegalStateException(
@@ -528,11 +657,32 @@ public class McpStatelessAsyncServer {
 		});
 	}
 
+	Mono<Void> addResourceTemplate(
+			McpStatelessServerFeatures.SyncResourceTemplateSpecification resourceTemplateSpecification) {
+		if (this.resourcesRepository != null) {
+			if (this.serverCapabilities.resources() == null) {
+				return Mono.error(new IllegalStateException(
+						"Server must be configured with resource capabilities to allow adding resource templates"));
+			}
+			return this.repositoryCallAdapter
+				.run(() -> this.resourcesRepository.addResourceTemplate(resourceTemplateSpecification));
+		}
+		return addResourceTemplate(McpStatelessServerFeatures.AsyncResourceTemplateSpecification
+			.fromSync(resourceTemplateSpecification, this.immediateExecution));
+	}
+
 	/**
-	 * List all registered resource templates.
-	 * @return A Flux stream of all registered resource templates
+	 * List resource templates without a client request context.
+	 * @return A Flux stream of context-free visible resource templates
 	 */
 	public Flux<McpSchema.ResourceTemplate> listResourceTemplates() {
+		if (this.resourcesRepository != null) {
+			return this.repositoryCallAdapter
+				.invoke(() -> this.resourcesRepository
+					.listResourceTemplates(new McpSchema.PaginatedRequest(), McpTransportContext.EMPTY)
+					.resourceTemplates())
+				.flatMapIterable(resourceTemplates -> resourceTemplates);
+		}
 		return Flux.fromIterable(this.resourceTemplates.values())
 			.map(McpStatelessServerFeatures.AsyncResourceTemplateSpecification::resourceTemplate);
 	}
@@ -540,13 +690,17 @@ public class McpStatelessAsyncServer {
 	/**
 	 * Remove a resource template at runtime.
 	 * @param uriTemplate The URI template of the resource template to remove
-	 * @return Mono that completes when clients have been notified of the change
+	 * @return Mono that completes when the server has been updated
 	 */
 	public Mono<Void> removeResourceTemplate(String uriTemplate) {
 
 		if (this.serverCapabilities.resources() == null) {
 			return Mono.error(new IllegalStateException(
 					"Server must be configured with resource capabilities to allow removing resource templates"));
+		}
+		if (this.resourcesRepository != null) {
+			return this.repositoryCallAdapter.invoke(() -> this.resourcesRepository.removeResourceTemplate(uriTemplate))
+				.then();
 		}
 
 		return Mono.defer(() -> {
@@ -564,6 +718,10 @@ public class McpStatelessAsyncServer {
 
 	private McpStatelessRequestHandler<McpSchema.ListResourcesResult> resourcesListRequestHandler() {
 		return (ctx, params) -> {
+			if (this.resourcesRepository != null) {
+				McpSchema.PaginatedRequest request = paginatedRequest(params);
+				return this.repositoryCallAdapter.invoke(() -> this.resourcesRepository.listResources(request, ctx));
+			}
 			var resourceList = this.resources.values()
 				.stream()
 				.map(McpStatelessServerFeatures.AsyncResourceSpecification::resource)
@@ -573,7 +731,12 @@ public class McpStatelessAsyncServer {
 	}
 
 	private McpStatelessRequestHandler<McpSchema.ListResourceTemplatesResult> resourceTemplateListRequestHandler() {
-		return (exchange, params) -> {
+		return (ctx, params) -> {
+			if (this.resourcesRepository != null) {
+				McpSchema.PaginatedRequest request = paginatedRequest(params);
+				return this.repositoryCallAdapter
+					.invoke(() -> this.resourcesRepository.listResourceTemplates(request, ctx));
+			}
 			var resourceList = this.resourceTemplates.values()
 				.stream()
 				.map(AsyncResourceTemplateSpecification::resourceTemplate)
@@ -588,6 +751,21 @@ public class McpStatelessAsyncServer {
 			});
 			var resourceUri = resourceRequest.uri();
 
+			if (this.resourcesRepository != null) {
+				return this.repositoryCallAdapter
+					.invoke(() -> this.resourcesRepository.resolveResource(resourceUri, ctx))
+					.flatMap(resource -> {
+						if (resource.isPresent()) {
+							return readRepositoryResource(resourceRequest, ctx);
+						}
+						return this.repositoryCallAdapter
+							.invoke(() -> this.resourcesRepository.resolveResourceTemplate(resourceUri, ctx))
+							.flatMap(resourceTemplate -> resourceTemplate.isPresent()
+									? readRepositoryResource(resourceRequest, ctx)
+									: Mono.error(RESOURCE_NOT_FOUND.apply(resourceUri)));
+					});
+			}
+
 			// First try to find a static resource specification
 			// Static resources have exact URIs
 			return this.findResourceSpecification(resourceUri)
@@ -601,6 +779,12 @@ public class McpStatelessAsyncServer {
 				});
 
 		};
+	}
+
+	private Mono<McpSchema.ReadResourceResult> readRepositoryResource(McpSchema.ReadResourceRequest resourceRequest,
+			McpTransportContext transportContext) {
+		return this.repositoryCallAdapter
+			.invoke(() -> this.resourcesRepository.readResource(resourceRequest, transportContext));
 	}
 
 	private Optional<McpStatelessServerFeatures.AsyncResourceSpecification> findResourceSpecification(String uri) {
@@ -626,9 +810,13 @@ public class McpStatelessAsyncServer {
 	/**
 	 * Add a new prompt handler at runtime.
 	 * @param promptSpecification The prompt handler to add
-	 * @return Mono that completes when clients have been notified of the change
+	 * @return Mono that completes when the server has been updated
 	 */
 	public Mono<Void> addPrompt(McpStatelessServerFeatures.AsyncPromptSpecification promptSpecification) {
+		if (this.promptsRepository != null) {
+			return Mono.error(new IllegalStateException(
+					"Server is configured with a prompts repository and cannot accept async prompt registrations"));
+		}
 		if (promptSpecification == null) {
 			return Mono.error(new IllegalArgumentException("Prompt specification must not be null"));
 		}
@@ -649,11 +837,32 @@ public class McpStatelessAsyncServer {
 		});
 	}
 
+	Mono<Void> addPrompt(McpStatelessServerFeatures.SyncPromptSpecification promptSpecification) {
+		if (this.promptsRepository != null) {
+			if (promptSpecification == null) {
+				return Mono.error(new IllegalArgumentException("Prompt specification must not be null"));
+			}
+			if (this.serverCapabilities.prompts() == null) {
+				return Mono.error(new IllegalStateException("Server must be configured with prompt capabilities"));
+			}
+			return this.repositoryCallAdapter.run(() -> this.promptsRepository.addPrompt(promptSpecification));
+		}
+		return addPrompt(McpStatelessServerFeatures.AsyncPromptSpecification.fromSync(promptSpecification,
+				this.immediateExecution));
+	}
+
 	/**
-	 * List all registered prompts.
-	 * @return A Flux stream of all registered prompts
+	 * List prompts without a client request context.
+	 * @return A Flux stream of context-free visible prompts
 	 */
 	public Flux<McpSchema.Prompt> listPrompts() {
+		if (this.promptsRepository != null) {
+			return this.repositoryCallAdapter
+				.invoke(() -> this.promptsRepository
+					.listPrompts(new McpSchema.PaginatedRequest(), McpTransportContext.EMPTY)
+					.prompts())
+				.flatMapIterable(prompts -> prompts);
+		}
 		return Flux.fromIterable(this.prompts.values())
 			.map(McpStatelessServerFeatures.AsyncPromptSpecification::prompt);
 	}
@@ -661,7 +870,7 @@ public class McpStatelessAsyncServer {
 	/**
 	 * Remove a prompt handler at runtime.
 	 * @param promptName The name of the prompt handler to remove
-	 * @return Mono that completes when clients have been notified of the change
+	 * @return Mono that completes when the server has been updated
 	 */
 	public Mono<Void> removePrompt(String promptName) {
 		if (promptName == null) {
@@ -669,6 +878,9 @@ public class McpStatelessAsyncServer {
 		}
 		if (this.serverCapabilities.prompts() == null) {
 			return Mono.error(new IllegalStateException("Server must be configured with prompt capabilities"));
+		}
+		if (this.promptsRepository != null) {
+			return this.repositoryCallAdapter.invoke(() -> this.promptsRepository.removePrompt(promptName)).then();
 		}
 
 		return Mono.defer(() -> {
@@ -688,6 +900,10 @@ public class McpStatelessAsyncServer {
 
 	private McpStatelessRequestHandler<McpSchema.ListPromptsResult> promptsListRequestHandler() {
 		return (ctx, params) -> {
+			if (this.promptsRepository != null) {
+				McpSchema.PaginatedRequest request = paginatedRequest(params);
+				return this.repositoryCallAdapter.invoke(() -> this.promptsRepository.listPrompts(request, ctx));
+			}
 			// TODO: Implement pagination
 			// McpSchema.PaginatedRequest request = objectMapper.convertValue(params,
 			// new TypeReference<McpSchema.PaginatedRequest>() {
@@ -708,6 +924,18 @@ public class McpStatelessAsyncServer {
 					new TypeRef<McpSchema.GetPromptRequest>() {
 					});
 
+			if (this.promptsRepository != null) {
+				return this.repositoryCallAdapter
+					.invoke(() -> this.promptsRepository.resolvePrompt(promptRequest.name(), ctx))
+					.flatMap(prompt -> prompt
+						.map(resolvedPrompt -> this.repositoryCallAdapter
+							.invoke(() -> this.promptsRepository.getPrompt(promptRequest, ctx)))
+						.orElseGet(() -> Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
+							.message("Invalid prompt name")
+							.data("Prompt not found: " + promptRequest.name())
+							.build())));
+			}
+
 			// Implement prompt retrieval logic here
 			McpStatelessServerFeatures.AsyncPromptSpecification specification = this.prompts.get(promptRequest.name());
 			if (specification == null) {
@@ -721,8 +949,10 @@ public class McpStatelessAsyncServer {
 		};
 	}
 
-	private static final Mono<McpSchema.CompleteResult> EMPTY_COMPLETION_RESULT = Mono
-		.just(new McpSchema.CompleteResult(new CompleteCompletion(List.of(), 0, false)));
+	private static final McpSchema.CompleteResult EMPTY_COMPLETION = new McpSchema.CompleteResult(
+			new CompleteCompletion(List.of(), 0, false));
+
+	private static final Mono<McpSchema.CompleteResult> EMPTY_COMPLETION_RESULT = Mono.just(EMPTY_COMPLETION);
 
 	private McpStatelessRequestHandler<McpSchema.CompleteResult> completionCompleteRequestHandler() {
 		return (ctx, params) -> {
@@ -744,84 +974,130 @@ public class McpStatelessAsyncServer {
 
 			String argumentName = request.argument().name();
 
-			// Check if valid a Prompt exists for this completion request
-			if (type.equals(PromptReference.TYPE)
-					&& request.ref() instanceof McpSchema.PromptReference promptReference) {
+			return validateCompletionReference(ctx, request, type, argumentName)
+				.flatMap(result -> result.map(Mono::just).orElseGet(() -> {
+					if (this.completionsRepository != null) {
+						return this.repositoryCallAdapter
+							.invoke(() -> this.completionsRepository.complete(request, ctx));
+					}
+					return resolveCompletionSpecification(request.ref())
+						.flatMap(specification -> specification.completionHandler().apply(ctx, request));
+				}));
+		};
+	}
 
-				McpStatelessServerFeatures.AsyncPromptSpecification promptSpec = this.prompts
-					.get(promptReference.name());
-				if (promptSpec == null) {
+	private Mono<Optional<McpSchema.CompleteResult>> validateCompletionReference(McpTransportContext transportContext,
+			McpSchema.CompleteRequest request, String type, String argumentName) {
+
+		if (type.equals(PromptReference.TYPE) && request.ref() instanceof McpSchema.PromptReference promptReference) {
+			return resolvePrompt(promptReference.name(), transportContext).flatMap(prompt -> {
+				if (prompt.isEmpty()) {
 					return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
 						.message("Prompt not found: " + promptReference.name())
 						.build());
 				}
-				List<McpSchema.PromptArgument> arguments = promptSpec.prompt().arguments();
-				if (arguments == null
-						|| !arguments.stream().filter(arg -> arg.name().equals(argumentName)).findFirst().isPresent()) {
 
+				List<McpSchema.PromptArgument> arguments = prompt.get().arguments();
+				if (arguments == null || arguments.stream().noneMatch(arg -> arg.name().equals(argumentName))) {
 					logger.warn("Argument not found: {} in prompt: {}", argumentName, promptReference.name());
-
-					return EMPTY_COMPLETION_RESULT;
+					return Mono.just(Optional.of(EMPTY_COMPLETION));
 				}
+
+				return Mono.just(Optional.empty());
+			});
+		}
+
+		if (type.equals(ResourceReference.TYPE)
+				&& request.ref() instanceof McpSchema.ResourceReference resourceReference) {
+
+			var uriTemplateManager = uriTemplateManagerFactory.create(resourceReference.uri());
+
+			if (!uriTemplateManager.isUriTemplate(resourceReference.uri())) {
+				// Attempting to autocomplete a fixed resource URI is not an error in
+				// the spec (but probably should be).
+				return Mono.just(Optional.of(EMPTY_COMPLETION));
 			}
 
-			// Check if valid Resource or ResourceTemplate exists for this completion
-			// request
-			if (type.equals(ResourceReference.TYPE)
-					&& request.ref() instanceof McpSchema.ResourceReference resourceReference) {
+			return validateResourceCompletionReference(resourceReference, argumentName, transportContext);
+		}
 
-				var uriTemplateManager = uriTemplateManagerFactory.create(resourceReference.uri());
+		return Mono.just(Optional.empty());
+	}
 
-				if (!uriTemplateManager.isUriTemplate(resourceReference.uri())) {
-					// Attempting to autocomplete a fixed resource URI is not an error in
-					// the spec (but probably should be).
-					return EMPTY_COMPLETION_RESULT;
+	private Mono<Optional<McpSchema.CompleteResult>> validateResourceCompletionReference(
+			McpSchema.ResourceReference resourceReference, String argumentName, McpTransportContext transportContext) {
+
+		return resolveResource(resourceReference.uri(), transportContext).flatMap(resource -> {
+			if (resource.isPresent()) {
+				if (!uriTemplateManagerFactory.create(resource.get().uri()).getVariableNames().contains(argumentName)) {
+					return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
+						.message("Argument not found: " + argumentName + " in resource: " + resourceReference.uri())
+						.build());
 				}
-
-				McpStatelessServerFeatures.AsyncResourceSpecification resourceSpec = this
-					.findResourceSpecification(resourceReference.uri())
-					.orElse(null);
-
-				if (resourceSpec != null) {
-					if (!uriTemplateManagerFactory.create(resourceSpec.resource().uri())
-						.getVariableNames()
-						.contains(argumentName)) {
-
-						return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
-							.message("Argument not found: " + argumentName + " in resource: " + resourceReference.uri())
-							.build());
-					}
-				}
-				else {
-					var templateSpec = this.findResourceTemplateSpecification(resourceReference.uri()).orElse(null);
-					if (templateSpec != null) {
-
-						if (!uriTemplateManagerFactory.create(templateSpec.resourceTemplate().uriTemplate())
-							.getVariableNames()
-							.contains(argumentName)) {
-
-							return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
-								.message("Argument not found: " + argumentName + " in resource template: "
-										+ resourceReference.uri())
-								.build());
-						}
-					}
-					else {
-						return Mono.error(RESOURCE_NOT_FOUND.apply(resourceReference.uri()));
-					}
-				}
+				return Mono.just(Optional.empty());
 			}
 
-			McpStatelessServerFeatures.AsyncCompletionSpecification specification = this.completions.get(request.ref());
+			return resolveResourceTemplate(resourceReference.uri(), transportContext).flatMap(resourceTemplate -> {
+				if (resourceTemplate.isEmpty()) {
+					return Mono.error(RESOURCE_NOT_FOUND.apply(resourceReference.uri()));
+				}
+				if (!uriTemplateManagerFactory.create(resourceTemplate.get().uriTemplate())
+					.getVariableNames()
+					.contains(argumentName)) {
+					return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
+						.message("Argument not found: " + argumentName + " in resource template: "
+								+ resourceReference.uri())
+						.build());
+				}
+				return Mono.just(Optional.empty());
+			});
+		});
+	}
 
-			if (specification == null) {
-				return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
-					.message("AsyncCompletionSpecification not found: " + request.ref())
-					.build());
-			}
+	private Mono<Optional<McpSchema.Prompt>> resolvePrompt(String name, McpTransportContext transportContext) {
 
-			return specification.completionHandler().apply(ctx, request);
-		};
+		if (this.promptsRepository != null) {
+			return this.repositoryCallAdapter
+				.invoke(() -> this.promptsRepository.resolvePrompt(name, transportContext));
+		}
+
+		return Mono.just(Optional.ofNullable(this.prompts.get(name))
+			.map(McpStatelessServerFeatures.AsyncPromptSpecification::prompt));
+	}
+
+	private Mono<Optional<McpSchema.Resource>> resolveResource(String uri, McpTransportContext transportContext) {
+
+		if (this.resourcesRepository != null) {
+			return this.repositoryCallAdapter
+				.invoke(() -> this.resourcesRepository.resolveResource(uri, transportContext));
+		}
+
+		return Mono
+			.just(findResourceSpecification(uri).map(McpStatelessServerFeatures.AsyncResourceSpecification::resource));
+	}
+
+	private Mono<Optional<McpSchema.ResourceTemplate>> resolveResourceTemplate(String uri,
+			McpTransportContext transportContext) {
+
+		if (this.resourcesRepository != null) {
+			return this.repositoryCallAdapter
+				.invoke(() -> this.resourcesRepository.resolveResourceTemplate(uri, transportContext));
+		}
+
+		return Mono.just(findResourceTemplateSpecification(uri)
+			.map(McpStatelessServerFeatures.AsyncResourceTemplateSpecification::resourceTemplate));
+	}
+
+	private Mono<McpStatelessServerFeatures.AsyncCompletionSpecification> resolveCompletionSpecification(
+			McpSchema.CompleteReference reference) {
+
+		McpStatelessServerFeatures.AsyncCompletionSpecification specification = this.completions.get(reference);
+		if (specification == null) {
+			return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
+				.message("AsyncCompletionSpecification not found: " + reference)
+				.build());
+		}
+		return Mono.just(specification);
 	}
 
 	/**

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessServerFeatures.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessServerFeatures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the original author or authors.
+ * Copyright 2024-2026 the original author or authors.
  */
 
 package io.modelcontextprotocol.server;
@@ -24,6 +24,7 @@ import reactor.core.scheduler.Schedulers;
  *
  * @author Dariusz Jędrzejczyk
  * @author Christian Tzolov
+ * @author Taewoong Kim
  */
 public class McpStatelessServerFeatures {
 
@@ -36,6 +37,17 @@ public class McpStatelessServerFeatures {
 	 * @param resources The map of resource specifications
 	 * @param resourceTemplates The map of resource templates
 	 * @param prompts The map of prompt specifications
+	 * @param completions The map of completion specifications
+	 * @param toolsRepository The repository used to resolve tools from the request
+	 * context
+	 * @param resourcesRepository The repository used to resolve resources from the
+	 * request context
+	 * @param promptsRepository The repository used to resolve prompts from the request
+	 * context
+	 * @param completionsRepository The repository used to handle completion requests from
+	 * the request context
+	 * @param immediateExecution Whether repository and synchronous specification calls
+	 * should execute immediately instead of being offloaded
 	 * @param instructions The server instructions text
 	 */
 	record Async(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
@@ -44,7 +56,9 @@ public class McpStatelessServerFeatures {
 			Map<String, McpStatelessServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates,
 			Map<String, McpStatelessServerFeatures.AsyncPromptSpecification> prompts,
 			Map<McpSchema.CompleteReference, McpStatelessServerFeatures.AsyncCompletionSpecification> completions,
-			String instructions) {
+			ToolsRepository toolsRepository, ResourcesRepository resourcesRepository,
+			PromptsRepository promptsRepository, CompletionsRepository completionsRepository,
+			boolean immediateExecution, String instructions) {
 
 		/**
 		 * Create an instance and validate the arguments.
@@ -54,6 +68,17 @@ public class McpStatelessServerFeatures {
 		 * @param resources The map of resource specifications
 		 * @param resourceTemplates The map of resource templates
 		 * @param prompts The map of prompt specifications
+		 * @param completions The map of completion specifications
+		 * @param toolsRepository The repository used to resolve tools from the request
+		 * context
+		 * @param resourcesRepository The repository used to resolve resources from the
+		 * request context
+		 * @param promptsRepository The repository used to resolve prompts from the
+		 * request context
+		 * @param completionsRepository The repository used to handle completion requests
+		 * from the request context
+		 * @param immediateExecution Whether repository and synchronous specification
+		 * calls should execute immediately instead of being offloaded
 		 * @param instructions The server instructions text
 		 */
 		Async(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
@@ -62,33 +87,42 @@ public class McpStatelessServerFeatures {
 				Map<String, McpStatelessServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates,
 				Map<String, McpStatelessServerFeatures.AsyncPromptSpecification> prompts,
 				Map<McpSchema.CompleteReference, McpStatelessServerFeatures.AsyncCompletionSpecification> completions,
-				String instructions) {
+				ToolsRepository toolsRepository, ResourcesRepository resourcesRepository,
+				PromptsRepository promptsRepository, CompletionsRepository completionsRepository,
+				boolean immediateExecution, String instructions) {
 
 			Assert.notNull(serverInfo, "Server info must not be null");
 
 			this.serverInfo = serverInfo;
 			this.serverCapabilities = (serverCapabilities != null) ? serverCapabilities
-					: new McpSchema.ServerCapabilities(null, // completions
-							null, // experimental
-							null, // currently statless server doesn't support set logging
-							!Utils.isEmpty(prompts) ? McpSchema.ServerCapabilities.PromptCapabilities.builder().build()
+					: new McpSchema.ServerCapabilities(
+							(completionsRepository != null) ? new McpSchema.ServerCapabilities.CompletionCapabilities()
 									: null,
-							!Utils.isEmpty(resources)
+							null, // experimental
+							null, // currently stateless server does not support logging
+							(!Utils.isEmpty(prompts) || promptsRepository != null)
+									? McpSchema.ServerCapabilities.PromptCapabilities.builder().build() : null,
+							(!Utils.isEmpty(resources) || resourcesRepository != null)
 									? McpSchema.ServerCapabilities.ResourceCapabilities.builder().build() : null,
-							!Utils.isEmpty(tools) ? McpSchema.ServerCapabilities.ToolCapabilities.builder().build()
-									: null);
+							(!Utils.isEmpty(tools) || toolsRepository != null)
+									? McpSchema.ServerCapabilities.ToolCapabilities.builder().build() : null);
 
 			this.tools = (tools != null) ? tools : List.of();
 			this.resources = (resources != null) ? resources : Map.of();
 			this.resourceTemplates = (resourceTemplates != null) ? resourceTemplates : Map.of();
 			this.prompts = (prompts != null) ? prompts : Map.of();
 			this.completions = (completions != null) ? completions : Map.of();
+			this.toolsRepository = toolsRepository;
+			this.resourcesRepository = resourcesRepository;
+			this.promptsRepository = promptsRepository;
+			this.completionsRepository = completionsRepository;
+			this.immediateExecution = immediateExecution;
 			this.instructions = instructions;
 		}
 
 		/**
-		 * Convert a synchronous specification into an asynchronous one and provide
-		 * blocking code offloading to prevent accidental blocking of the non-blocking
+		 * Convert a synchronous specification into an asynchronous one, optionally
+		 * offloading blocking code to prevent accidental blocking of the non-blocking
 		 * transport.
 		 * @param syncSpec a potentially blocking, synchronous specification.
 		 * @param immediateExecution when true, do not offload. Do NOT set to true when
@@ -123,7 +157,9 @@ public class McpStatelessServerFeatures {
 			});
 
 			return new Async(syncSpec.serverInfo(), syncSpec.serverCapabilities(), tools, resources, resourceTemplates,
-					prompts, completions, syncSpec.instructions());
+					prompts, completions, syncSpec.toolsRepository(), syncSpec.resourcesRepository(),
+					syncSpec.promptsRepository(), syncSpec.completionsRepository(), immediateExecution,
+					syncSpec.instructions());
 		}
 	}
 
@@ -136,6 +172,15 @@ public class McpStatelessServerFeatures {
 	 * @param resources The map of resource specifications
 	 * @param resourceTemplates The map of resource templates
 	 * @param prompts The map of prompt specifications
+	 * @param completions The map of completion specifications
+	 * @param toolsRepository The repository used to resolve tools from the request
+	 * context
+	 * @param resourcesRepository The repository used to resolve resources from the
+	 * request context
+	 * @param promptsRepository The repository used to resolve prompts from the request
+	 * context
+	 * @param completionsRepository The repository used to handle completion requests from
+	 * the request context
 	 * @param instructions The server instructions text
 	 */
 	record Sync(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
@@ -144,7 +189,8 @@ public class McpStatelessServerFeatures {
 			Map<String, McpStatelessServerFeatures.SyncResourceTemplateSpecification> resourceTemplates,
 			Map<String, McpStatelessServerFeatures.SyncPromptSpecification> prompts,
 			Map<McpSchema.CompleteReference, McpStatelessServerFeatures.SyncCompletionSpecification> completions,
-			String instructions) {
+			ToolsRepository toolsRepository, ResourcesRepository resourcesRepository,
+			PromptsRepository promptsRepository, CompletionsRepository completionsRepository, String instructions) {
 
 		/**
 		 * Create an instance and validate the arguments.
@@ -154,6 +200,15 @@ public class McpStatelessServerFeatures {
 		 * @param resources The map of resource specifications
 		 * @param resourceTemplates The map of resource templates
 		 * @param prompts The map of prompt specifications
+		 * @param completions The map of completion specifications
+		 * @param toolsRepository The repository used to resolve tools from the request
+		 * context
+		 * @param resourcesRepository The repository used to resolve resources from the
+		 * request context
+		 * @param promptsRepository The repository used to resolve prompts from the
+		 * request context
+		 * @param completionsRepository The repository used to handle completion requests
+		 * from the request context
 		 * @param instructions The server instructions text
 		 */
 		Sync(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
@@ -162,30 +217,37 @@ public class McpStatelessServerFeatures {
 				Map<String, McpStatelessServerFeatures.SyncResourceTemplateSpecification> resourceTemplates,
 				Map<String, McpStatelessServerFeatures.SyncPromptSpecification> prompts,
 				Map<McpSchema.CompleteReference, McpStatelessServerFeatures.SyncCompletionSpecification> completions,
-				String instructions) {
+				ToolsRepository toolsRepository, ResourcesRepository resourcesRepository,
+				PromptsRepository promptsRepository, CompletionsRepository completionsRepository, String instructions) {
 
 			Assert.notNull(serverInfo, "Server info must not be null");
 
 			this.serverInfo = serverInfo;
 			this.serverCapabilities = (serverCapabilities != null) ? serverCapabilities
-					: new McpSchema.ServerCapabilities(null, // completions
+					: new McpSchema.ServerCapabilities(
+							(completionsRepository != null) ? new McpSchema.ServerCapabilities.CompletionCapabilities()
+									: null,
 							null, // experimental
 							new McpSchema.ServerCapabilities.LoggingCapabilities(), // Enable
 																					// logging
 																					// by
 																					// default
-							!Utils.isEmpty(prompts) ? McpSchema.ServerCapabilities.PromptCapabilities.builder().build()
-									: null,
-							!Utils.isEmpty(resources)
+							(!Utils.isEmpty(prompts) || promptsRepository != null)
+									? McpSchema.ServerCapabilities.PromptCapabilities.builder().build() : null,
+							(!Utils.isEmpty(resources) || resourcesRepository != null)
 									? McpSchema.ServerCapabilities.ResourceCapabilities.builder().build() : null,
-							!Utils.isEmpty(tools) ? McpSchema.ServerCapabilities.ToolCapabilities.builder().build()
-									: null);
+							(!Utils.isEmpty(tools) || toolsRepository != null)
+									? McpSchema.ServerCapabilities.ToolCapabilities.builder().build() : null);
 
 			this.tools = (tools != null) ? tools : new ArrayList<>();
 			this.resources = (resources != null) ? resources : new HashMap<>();
 			this.resourceTemplates = (resourceTemplates != null) ? resourceTemplates : Map.of();
 			this.prompts = (prompts != null) ? prompts : new HashMap<>();
 			this.completions = (completions != null) ? completions : new HashMap<>();
+			this.toolsRepository = toolsRepository;
+			this.resourcesRepository = resourcesRepository;
+			this.promptsRepository = promptsRepository;
+			this.completionsRepository = completionsRepository;
 			this.instructions = instructions;
 		}
 
@@ -197,8 +259,9 @@ public class McpStatelessServerFeatures {
 	 * represents a specific capability.
 	 *
 	 * @param tool The tool definition including name, description, and parameter schema
-	 * @param callHandler The function that implements the tool's logic, receiving a
-	 * {@link CallToolRequest} and returning the result.
+	 * @param callHandler The function that implements the tool's logic. The first
+	 * argument is the {@link McpTransportContext}; the second argument is the
+	 * {@link CallToolRequest}.
 	 */
 	public record AsyncToolSpecification(McpSchema.Tool tool,
 			BiFunction<McpTransportContext, CallToolRequest, Mono<McpSchema.CallToolResult>> callHandler) {
@@ -290,7 +353,8 @@ public class McpStatelessServerFeatures {
 	 *
 	 * @param resource The resource definition including name, description, and MIME type
 	 * @param readHandler The function that handles resource read requests. The function's
-	 * argument is a {@link McpSchema.ReadResourceRequest}.
+	 * first argument is the {@link McpTransportContext}; the second argument is the
+	 * {@link McpSchema.ReadResourceRequest}.
 	 */
 	public record AsyncResourceSpecification(McpSchema.Resource resource,
 			BiFunction<McpTransportContext, McpSchema.ReadResourceRequest, Mono<McpSchema.ReadResourceResult>> readHandler) {
@@ -308,7 +372,7 @@ public class McpStatelessServerFeatures {
 	}
 
 	/**
-	 * Specification of a resource template with its synchronous handler function.
+	 * Specification of a resource template with its asynchronous handler function.
 	 * Resource templates allow servers to expose parameterized resources using URI
 	 * templates: <a href=https://datatracker.ietf.org/doc/html/rfc6570> URI
 	 * templates.</a>. Arguments may be auto-completed through <a href=
@@ -326,10 +390,8 @@ public class McpStatelessServerFeatures {
 	 * @param resourceTemplate The resource template definition including name,
 	 * description, and parameter schema
 	 * @param readHandler The function that handles resource read requests. The function's
-	 * first argument is an {@link McpTransportContext} upon which the server can interact
-	 * with the connected client. The second arguments is a
-	 * {@link McpSchema.ReadResourceRequest}. {@link McpSchema.ResourceTemplate}
-	 * {@link McpSchema.ReadResourceResult}
+	 * first argument is the {@link McpTransportContext}; the second argument is the
+	 * {@link McpSchema.ReadResourceRequest}.
 	 */
 	public record AsyncResourceTemplateSpecification(McpSchema.ResourceTemplate resourceTemplate,
 			BiFunction<McpTransportContext, McpSchema.ReadResourceRequest, Mono<McpSchema.ReadResourceResult>> readHandler) {
@@ -360,8 +422,8 @@ public class McpStatelessServerFeatures {
 	 *
 	 * @param prompt The prompt definition including name and description
 	 * @param promptHandler The function that processes prompt requests and returns
-	 * formatted templates. The function's argument is a
-	 * {@link McpSchema.GetPromptRequest}.
+	 * formatted templates. The first argument is the {@link McpTransportContext}; the
+	 * second argument is the {@link McpSchema.GetPromptRequest}.
 	 */
 	public record AsyncPromptSpecification(McpSchema.Prompt prompt,
 			BiFunction<McpTransportContext, McpSchema.GetPromptRequest, Mono<McpSchema.GetPromptResult>> promptHandler) {
@@ -385,12 +447,13 @@ public class McpStatelessServerFeatures {
 	 * <ul>
 	 * <li>Customizable response generation logic
 	 * <li>Parameter-driven template expansion
-	 * <li>Dynamic interaction with connected clients
+	 * <li>Context-aware completion logic
 	 * </ul>
 	 *
 	 * @param referenceKey The unique key representing the completion reference.
 	 * @param completionHandler The asynchronous function that processes completion
-	 * requests and returns results. The function's argument is a
+	 * requests and returns results. The first argument is the
+	 * {@link McpTransportContext}; the second argument is the
 	 * {@link McpSchema.CompleteRequest}.
 	 */
 	public record AsyncCompletionSpecification(McpSchema.CompleteReference referenceKey,
@@ -398,9 +461,10 @@ public class McpStatelessServerFeatures {
 
 		/**
 		 * Converts a synchronous {@link SyncCompletionSpecification} into an
-		 * {@link AsyncCompletionSpecification} by wrapping the handler in a bounded
-		 * elastic scheduler for safe non-blocking execution.
+		 * {@link AsyncCompletionSpecification}, optionally offloading the handler to a
+		 * bounded elastic scheduler for safe non-blocking execution.
 		 * @param completion the synchronous completion specification
+		 * @param immediateExecution whether the handler should execute immediately
 		 * @return an asynchronous wrapper of the provided sync specification, or
 		 * {@code null} if input is null
 		 */
@@ -422,8 +486,9 @@ public class McpStatelessServerFeatures {
 	 * primary way for MCP servers to expose functionality to AI models.
 	 *
 	 * @param tool The tool definition including name, description, and parameter schema
-	 * @param callHandler The function that implements the tool's logic, receiving a
-	 * {@link CallToolRequest} and returning results.
+	 * @param callHandler The function that implements the tool's logic. The first
+	 * argument is the {@link McpTransportContext}; the second argument is the
+	 * {@link CallToolRequest}.
 	 */
 	public record SyncToolSpecification(McpSchema.Tool tool,
 			BiFunction<McpTransportContext, CallToolRequest, McpSchema.CallToolResult> callHandler) {
@@ -491,7 +556,8 @@ public class McpStatelessServerFeatures {
 	 *
 	 * @param resource The resource definition including name, description, and MIME type
 	 * @param readHandler The function that handles resource read requests. The function's
-	 * argument is a {@link McpSchema.ReadResourceRequest}.
+	 * first argument is the {@link McpTransportContext}; the second argument is the
+	 * {@link McpSchema.ReadResourceRequest}.
 	 */
 	public record SyncResourceSpecification(McpSchema.Resource resource,
 			BiFunction<McpTransportContext, McpSchema.ReadResourceRequest, McpSchema.ReadResourceResult> readHandler) {
@@ -516,10 +582,8 @@ public class McpStatelessServerFeatures {
 	 * @param resourceTemplate The resource template definition including name,
 	 * description, and parameter schema
 	 * @param readHandler The function that handles resource read requests. The function's
-	 * first argument is an {@link McpTransportContext} upon which the server can interact
-	 * with the connected client. The second arguments is a
-	 * {@link McpSchema.ReadResourceRequest}. {@link McpSchema.ResourceTemplate}
-	 * {@link McpSchema.ReadResourceResult}
+	 * first argument is the {@link McpTransportContext}; the second argument is the
+	 * {@link McpSchema.ReadResourceRequest}.
 	 */
 	public record SyncResourceTemplateSpecification(McpSchema.ResourceTemplate resourceTemplate,
 			BiFunction<McpTransportContext, McpSchema.ReadResourceRequest, McpSchema.ReadResourceResult> readHandler) {
@@ -538,8 +602,8 @@ public class McpStatelessServerFeatures {
 	 *
 	 * @param prompt The prompt definition including name and description
 	 * @param promptHandler The function that processes prompt requests and returns
-	 * formatted templates. The function's argument is a
-	 * {@link McpSchema.GetPromptRequest}.
+	 * formatted templates. The first argument is the {@link McpTransportContext}; the
+	 * second argument is the {@link McpSchema.GetPromptRequest}.
 	 */
 	public record SyncPromptSpecification(McpSchema.Prompt prompt,
 			BiFunction<McpTransportContext, McpSchema.GetPromptRequest, McpSchema.GetPromptResult> promptHandler) {
@@ -550,7 +614,9 @@ public class McpStatelessServerFeatures {
 	 *
 	 * @param referenceKey The unique key representing the completion reference.
 	 * @param completionHandler The synchronous function that processes completion
-	 * requests and returns results. The argument is a {@link McpSchema.CompleteRequest}.
+	 * requests and returns results. The first argument is the
+	 * {@link McpTransportContext}; the second argument is the
+	 * {@link McpSchema.CompleteRequest}.
 	 */
 	public record SyncCompletionSpecification(McpSchema.CompleteReference referenceKey,
 			BiFunction<McpTransportContext, McpSchema.CompleteRequest, McpSchema.CompleteResult> completionHandler) {

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessSyncServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessSyncServer.java
@@ -1,15 +1,14 @@
 /*
- * Copyright 2024-2024 the original author or authors.
+ * Copyright 2024-2026 the original author or authors.
  */
 
 package io.modelcontextprotocol.server;
 
+import java.util.List;
+
 import io.modelcontextprotocol.spec.McpSchema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import reactor.core.publisher.Mono;
-
-import java.util.List;
 
 /**
  * A stateless MCP server implementation for use with Streamable HTTP transport types. It
@@ -18,6 +17,7 @@ import java.util.List;
  * knowledge and can serve the clients with the capabilities it supports.
  *
  * @author Dariusz Jędrzejczyk
+ * @author Taewoong Kim
  */
 public class McpStatelessSyncServer {
 
@@ -25,11 +25,8 @@ public class McpStatelessSyncServer {
 
 	private final McpStatelessAsyncServer asyncServer;
 
-	private final boolean immediateExecution;
-
-	McpStatelessSyncServer(McpStatelessAsyncServer asyncServer, boolean immediateExecution) {
+	McpStatelessSyncServer(McpStatelessAsyncServer asyncServer) {
 		this.asyncServer = asyncServer;
-		this.immediateExecution = immediateExecution;
 	}
 
 	/**
@@ -68,15 +65,12 @@ public class McpStatelessSyncServer {
 	 * @param toolSpecification The tool specification to add
 	 */
 	public void addTool(McpStatelessServerFeatures.SyncToolSpecification toolSpecification) {
-		this.asyncServer
-			.addTool(McpStatelessServerFeatures.AsyncToolSpecification.fromSync(toolSpecification,
-					this.immediateExecution))
-			.block();
+		this.asyncServer.addTool(toolSpecification).block();
 	}
 
 	/**
-	 * List all registered tools.
-	 * @return A list of all registered tools
+	 * List tools without a client request context.
+	 * @return A list of context-free visible tools
 	 */
 	public List<McpSchema.Tool> listTools() {
 		return this.asyncServer.listTools().collectList().block();
@@ -95,15 +89,12 @@ public class McpStatelessSyncServer {
 	 * @param resourceSpecification The resource handler to add
 	 */
 	public void addResource(McpStatelessServerFeatures.SyncResourceSpecification resourceSpecification) {
-		this.asyncServer
-			.addResource(McpStatelessServerFeatures.AsyncResourceSpecification.fromSync(resourceSpecification,
-					this.immediateExecution))
-			.block();
+		this.asyncServer.addResource(resourceSpecification).block();
 	}
 
 	/**
-	 * List all registered resources.
-	 * @return A list of all registered resources
+	 * List resources without a client request context.
+	 * @return A list of context-free visible resources
 	 */
 	public List<McpSchema.Resource> listResources() {
 		return this.asyncServer.listResources().collectList().block();
@@ -123,15 +114,12 @@ public class McpStatelessSyncServer {
 	 */
 	public void addResourceTemplate(
 			McpStatelessServerFeatures.SyncResourceTemplateSpecification resourceTemplateSpecification) {
-		this.asyncServer
-			.addResourceTemplate(McpStatelessServerFeatures.AsyncResourceTemplateSpecification
-				.fromSync(resourceTemplateSpecification, this.immediateExecution))
-			.block();
+		this.asyncServer.addResourceTemplate(resourceTemplateSpecification).block();
 	}
 
 	/**
-	 * List all registered resource templates.
-	 * @return A list of all registered resource templates
+	 * List resource templates without a client request context.
+	 * @return A list of context-free visible resource templates
 	 */
 	public List<McpSchema.ResourceTemplate> listResourceTemplates() {
 		return this.asyncServer.listResourceTemplates().collectList().block();
@@ -150,15 +138,12 @@ public class McpStatelessSyncServer {
 	 * @param promptSpecification The prompt handler to add
 	 */
 	public void addPrompt(McpStatelessServerFeatures.SyncPromptSpecification promptSpecification) {
-		this.asyncServer
-			.addPrompt(McpStatelessServerFeatures.AsyncPromptSpecification.fromSync(promptSpecification,
-					this.immediateExecution))
-			.block();
+		this.asyncServer.addPrompt(promptSpecification).block();
 	}
 
 	/**
-	 * List all registered prompts.
-	 * @return A list of all registered prompts
+	 * List prompts without a client request context.
+	 * @return A list of context-free visible prompts
 	 */
 	public List<McpSchema.Prompt> listPrompts() {
 		return this.asyncServer.listPrompts().collectList().block();

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/PromptsRepository.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/PromptsRepository.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import java.util.Optional;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * Repository contract for listing, resolving, and getting stateless prompts from the
+ * current MCP request context.
+ * <p>
+ * Context-free server-side helper calls receive {@link McpTransportContext#EMPTY}.
+ *
+ * @author Taewoong Kim
+ */
+public interface PromptsRepository {
+
+	/**
+	 * List prompts visible for the current request context.
+	 * @param request the paginated list request
+	 * @param transportContext the transport context for the current request, or
+	 * {@link McpTransportContext#EMPTY} for a context-free server-side call
+	 * @return the prompts visible for the current request
+	 */
+	McpSchema.ListPromptsResult listPrompts(McpSchema.PaginatedRequest request, McpTransportContext transportContext);
+
+	/**
+	 * Resolve prompt metadata for the current request context.
+	 * @param name the prompt name
+	 * @param transportContext the transport context for the current request
+	 * @return the matching prompt metadata, if any
+	 */
+	Optional<McpSchema.Prompt> resolvePrompt(String name, McpTransportContext transportContext);
+
+	/**
+	 * Get a prompt for the current request context.
+	 * @param request the prompt get request
+	 * @param transportContext the transport context for the current request
+	 * @return the prompt result
+	 */
+	McpSchema.GetPromptResult getPrompt(McpSchema.GetPromptRequest request, McpTransportContext transportContext);
+
+	/**
+	 * Add a prompt to repositories that support runtime mutation.
+	 * <p>
+	 * The default implementation throws {@link UnsupportedOperationException}.
+	 * @param promptSpecification the prompt specification to add
+	 */
+	default void addPrompt(McpStatelessServerFeatures.SyncPromptSpecification promptSpecification) {
+		throw new UnsupportedOperationException("Prompts repository does not support adding prompts");
+	}
+
+	/**
+	 * Remove a prompt from repositories that support runtime mutation.
+	 * <p>
+	 * The default implementation throws {@link UnsupportedOperationException}.
+	 * @param promptName the prompt name to remove
+	 * @return {@code true} if a prompt was removed
+	 */
+	default boolean removePrompt(String promptName) {
+		throw new UnsupportedOperationException("Prompts repository does not support removing prompts");
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/ResourcesRepository.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/ResourcesRepository.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import java.util.Optional;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * Repository contract for listing, resolving, and reading stateless resources from the
+ * current MCP request context.
+ * <p>
+ * Context-free server-side helper calls receive {@link McpTransportContext#EMPTY}.
+ *
+ * @author Taewoong Kim
+ */
+public interface ResourcesRepository {
+
+	/**
+	 * List resources visible for the current request context.
+	 * @param request the paginated list request
+	 * @param transportContext the transport context for the current request, or
+	 * {@link McpTransportContext#EMPTY} for a context-free server-side call
+	 * @return the resources visible for the current request
+	 */
+	McpSchema.ListResourcesResult listResources(McpSchema.PaginatedRequest request,
+			McpTransportContext transportContext);
+
+	/**
+	 * List resource templates visible for the current request context.
+	 * @param request the paginated list request
+	 * @param transportContext the transport context for the current request, or
+	 * {@link McpTransportContext#EMPTY} for a context-free server-side call
+	 * @return the resource templates visible for the current request
+	 */
+	McpSchema.ListResourceTemplatesResult listResourceTemplates(McpSchema.PaginatedRequest request,
+			McpTransportContext transportContext);
+
+	/**
+	 * Resolve resource metadata for the current request context.
+	 * @param uri the requested resource URI
+	 * @param transportContext the transport context for the current request
+	 * @return the matching resource metadata, if any
+	 */
+	Optional<McpSchema.Resource> resolveResource(String uri, McpTransportContext transportContext);
+
+	/**
+	 * Resolve resource-template metadata for the current request context.
+	 * @param uri the requested resource URI
+	 * @param transportContext the transport context for the current request
+	 * @return the matching resource-template metadata, if any
+	 */
+	Optional<McpSchema.ResourceTemplate> resolveResourceTemplate(String uri, McpTransportContext transportContext);
+
+	/**
+	 * Read a resource for the current request context.
+	 * @param request the resource read request
+	 * @param transportContext the transport context for the current request
+	 * @return the resource read result
+	 */
+	McpSchema.ReadResourceResult readResource(McpSchema.ReadResourceRequest request,
+			McpTransportContext transportContext);
+
+	/**
+	 * Add a resource to repositories that support runtime mutation.
+	 * <p>
+	 * The default implementation throws {@link UnsupportedOperationException}.
+	 * @param resourceSpecification the resource specification to add
+	 */
+	default void addResource(McpStatelessServerFeatures.SyncResourceSpecification resourceSpecification) {
+		throw new UnsupportedOperationException("Resources repository does not support adding resources");
+	}
+
+	/**
+	 * Remove a resource from repositories that support runtime mutation.
+	 * <p>
+	 * The default implementation throws {@link UnsupportedOperationException}.
+	 * @param resourceUri the resource URI to remove
+	 * @return {@code true} if a resource was removed
+	 */
+	default boolean removeResource(String resourceUri) {
+		throw new UnsupportedOperationException("Resources repository does not support removing resources");
+	}
+
+	/**
+	 * Add a resource template to repositories that support runtime mutation.
+	 * <p>
+	 * The default implementation throws {@link UnsupportedOperationException}.
+	 * @param resourceTemplateSpecification the resource template specification to add
+	 */
+	default void addResourceTemplate(
+			McpStatelessServerFeatures.SyncResourceTemplateSpecification resourceTemplateSpecification) {
+		throw new UnsupportedOperationException("Resources repository does not support adding resource templates");
+	}
+
+	/**
+	 * Remove a resource template from repositories that support runtime mutation.
+	 * <p>
+	 * The default implementation throws {@link UnsupportedOperationException}.
+	 * @param uriTemplate the resource template URI template to remove
+	 * @return {@code true} if a resource template was removed
+	 */
+	default boolean removeResourceTemplate(String uriTemplate) {
+		throw new UnsupportedOperationException("Resources repository does not support removing resource templates");
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/SyncRepositoryCallAdapter.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/SyncRepositoryCallAdapter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import java.util.function.Supplier;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Adapts synchronous repository calls to the stateless asynchronous server core.
+ *
+ * @author Taewoong Kim
+ */
+final class SyncRepositoryCallAdapter {
+
+	private final boolean immediateExecution;
+
+	SyncRepositoryCallAdapter(boolean immediateExecution) {
+		this.immediateExecution = immediateExecution;
+	}
+
+	<T> Mono<T> invoke(Supplier<T> supplier) {
+		Mono<T> result = Mono.fromCallable(supplier::get);
+		return this.immediateExecution ? result : result.subscribeOn(Schedulers.boundedElastic());
+	}
+
+	Mono<Void> run(Runnable runnable) {
+		Mono<Void> result = Mono.fromRunnable(runnable);
+		return this.immediateExecution ? result : result.subscribeOn(Schedulers.boundedElastic());
+	}
+
+}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/ToolsRepository.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/ToolsRepository.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import java.util.Optional;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+
+/**
+ * Repository contract for listing, resolving, and calling stateless tools from the
+ * current MCP request context.
+ * <p>
+ * Context-free server-side helper calls receive {@link McpTransportContext#EMPTY}.
+ *
+ * @author Taewoong Kim
+ */
+public interface ToolsRepository {
+
+	/**
+	 * List tools visible for the current request context.
+	 * @param request the paginated list request
+	 * @param transportContext the transport context for the current request, or
+	 * {@link McpTransportContext#EMPTY} for a context-free server-side call
+	 * @return the tools visible for the current request
+	 */
+	McpSchema.ListToolsResult listTools(McpSchema.PaginatedRequest request, McpTransportContext transportContext);
+
+	/**
+	 * Resolve tool metadata for the current request context.
+	 * @param name the tool name
+	 * @param transportContext the transport context for the current request
+	 * @return the matching tool metadata, if any
+	 */
+	Optional<McpSchema.Tool> resolveTool(String name, McpTransportContext transportContext);
+
+	/**
+	 * Call a tool for the current request context.
+	 * @param request the tool call request
+	 * @param transportContext the transport context for the current request
+	 * @return the tool call result
+	 */
+	CallToolResult callTool(McpSchema.CallToolRequest request, McpTransportContext transportContext);
+
+	/**
+	 * Add a tool to repositories that support runtime mutation.
+	 * <p>
+	 * The default implementation throws {@link UnsupportedOperationException}.
+	 * @param toolSpecification the tool specification to add
+	 */
+	default void addTool(McpStatelessServerFeatures.SyncToolSpecification toolSpecification) {
+		throw new UnsupportedOperationException("Tools repository does not support adding tools");
+	}
+
+	/**
+	 * Remove a tool from repositories that support runtime mutation.
+	 * <p>
+	 * The default implementation throws {@link UnsupportedOperationException}.
+	 * @param toolName the tool name to remove
+	 * @return {@code true} if a tool was removed
+	 */
+	default boolean removeTool(String toolName) {
+		throw new UnsupportedOperationException("Tools repository does not support removing tools");
+	}
+
+}

--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/StatelessRepositoriesTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/StatelessRepositoriesTests.java
@@ -1,0 +1,746 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
+import io.modelcontextprotocol.json.schema.JsonSchemaValidator.ValidationResponse;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpStatelessServerTransport;
+import io.modelcontextprotocol.spec.json.gson.GsonMcpJsonMapper;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for stateless primitive repositories.
+ *
+ * @author Taewoong Kim
+ */
+class StatelessRepositoriesTests {
+
+	private static final String USER_KEY = "X-User";
+
+	private static final JsonSchemaValidator VALID_SCHEMA_VALIDATOR = (schema, structuredContent) -> ValidationResponse
+		.asValid(null);
+
+	private static final McpJsonMapper JSON_MAPPER = new PassThroughMcpJsonMapper();
+
+	@Test
+	void statelessRepositoriesResolvePrimitivesFromTransportContext() {
+		var transport = new MockStatelessServerTransport();
+		var repository = new ContextAwareRepository();
+
+		McpServer.sync(transport)
+			.jsonMapper(JSON_MAPPER)
+			.jsonSchemaValidator(VALID_SCHEMA_VALIDATOR)
+			.toolsRepository(repository)
+			.resourcesRepository(repository)
+			.promptsRepository(repository)
+			.completionsRepository(repository)
+			.build();
+
+		McpSchema.ListToolsResult tools = result(transport, "alice", McpSchema.METHOD_TOOLS_LIST,
+				new McpSchema.PaginatedRequest());
+		assertThat(tools.tools()).extracting(McpSchema.Tool::name).containsExactly("alice-tool");
+
+		McpSchema.CallToolResult toolResult = result(transport, "alice", McpSchema.METHOD_TOOLS_CALL,
+				McpSchema.CallToolRequest.builder("alice-tool").build());
+		assertThat(text(toolResult.content().get(0))).isEqualTo("tool:alice");
+
+		McpSchema.ListResourcesResult resources = result(transport, "alice", McpSchema.METHOD_RESOURCES_LIST,
+				new McpSchema.PaginatedRequest());
+		assertThat(resources.resources()).extracting(McpSchema.Resource::uri).containsExactly("test://resources/alice");
+
+		McpSchema.ReadResourceResult resourceResult = result(transport, "alice", McpSchema.METHOD_RESOURCES_READ,
+				McpSchema.ReadResourceRequest.builder("test://resources/alice").build());
+		assertThat(((McpSchema.TextResourceContents) resourceResult.contents().get(0)).text())
+			.isEqualTo("resource:alice");
+
+		McpSchema.ListResourceTemplatesResult templates = result(transport, "alice",
+				McpSchema.METHOD_RESOURCES_TEMPLATES_LIST, new McpSchema.PaginatedRequest());
+		assertThat(templates.resourceTemplates()).extracting(McpSchema.ResourceTemplate::uriTemplate)
+			.containsExactly("test://resource-templates/alice/{name}");
+
+		McpSchema.ReadResourceResult templateResult = result(transport, "alice", McpSchema.METHOD_RESOURCES_READ,
+				McpSchema.ReadResourceRequest.builder("test://resource-templates/alice/guide").build());
+		assertThat(((McpSchema.TextResourceContents) templateResult.contents().get(0)).text())
+			.isEqualTo("resource-template:alice");
+
+		McpSchema.ListPromptsResult prompts = result(transport, "alice", McpSchema.METHOD_PROMPT_LIST,
+				new McpSchema.PaginatedRequest());
+		assertThat(prompts.prompts()).extracting(McpSchema.Prompt::name).containsExactly("alice-prompt");
+
+		McpSchema.GetPromptResult promptResult = result(transport, "alice", McpSchema.METHOD_PROMPT_GET,
+				McpSchema.GetPromptRequest.builder("alice-prompt").build());
+		assertThat(text(promptResult.messages().get(0).content())).isEqualTo("prompt:alice");
+
+		McpSchema.CompleteResult completeResult = result(transport, "alice", McpSchema.METHOD_COMPLETION_COMPLETE,
+				McpSchema.CompleteRequest
+					.builder(new McpSchema.PromptReference("alice-prompt"),
+							new McpSchema.CompleteRequest.CompleteArgument("name", "a"))
+					.build());
+		assertThat(completeResult.completion().values()).containsExactly("completion:alice");
+
+		McpSchema.CompleteResult resourceCompleteResult = result(transport, "alice",
+				McpSchema.METHOD_COMPLETION_COMPLETE,
+				McpSchema.CompleteRequest
+					.builder(new McpSchema.ResourceReference("test://resource-templates/alice/{name}"),
+							new McpSchema.CompleteRequest.CompleteArgument("name", "g"))
+					.build());
+		assertThat(resourceCompleteResult.completion().values()).containsExactly("completion:alice");
+
+		McpSchema.ListToolsResult bobTools = result(transport, "bob", McpSchema.METHOD_TOOLS_LIST,
+				new McpSchema.PaginatedRequest());
+		assertThat(bobTools.tools()).extracting(McpSchema.Tool::name).containsExactly("bob-tool");
+
+		McpSchema.CallToolResult bobToolResult = result(transport, "bob", McpSchema.METHOD_TOOLS_CALL,
+				McpSchema.CallToolRequest.builder("bob-tool").build());
+		assertThat(text(bobToolResult.content().get(0))).isEqualTo("tool:bob");
+
+		McpSchema.JSONRPCResponse hiddenResource = response(transport, "bob", McpSchema.METHOD_RESOURCES_READ,
+				McpSchema.ReadResourceRequest.builder("test://resources/alice").build());
+		assertThat(hiddenResource.error()).isNotNull();
+		assertThat(hiddenResource.error().code()).isEqualTo(McpSchema.ErrorCodes.RESOURCE_NOT_FOUND);
+	}
+
+	@Test
+	void statelessRepositoriesReceivePaginatedListRequests() {
+		var transport = new MockStatelessServerTransport();
+		var repository = new ContextAwareRepository();
+
+		McpServer.sync(transport)
+			.jsonMapper(JSON_MAPPER)
+			.jsonSchemaValidator(VALID_SCHEMA_VALIDATOR)
+			.toolsRepository(repository)
+			.resourcesRepository(repository)
+			.promptsRepository(repository)
+			.build();
+
+		McpSchema.ListToolsResult tools = result(transport, "alice", McpSchema.METHOD_TOOLS_LIST,
+				new McpSchema.PaginatedRequest("tools-cursor"));
+		assertThat(tools.nextCursor()).isEqualTo("tools-cursor");
+
+		McpSchema.ListResourcesResult resources = result(transport, "alice", McpSchema.METHOD_RESOURCES_LIST,
+				new McpSchema.PaginatedRequest("resources-cursor"));
+		assertThat(resources.nextCursor()).isEqualTo("resources-cursor");
+
+		McpSchema.ListResourceTemplatesResult templates = result(transport, "alice",
+				McpSchema.METHOD_RESOURCES_TEMPLATES_LIST, new McpSchema.PaginatedRequest("templates-cursor"));
+		assertThat(templates.nextCursor()).isEqualTo("templates-cursor");
+
+		McpSchema.ListPromptsResult prompts = result(transport, "alice", McpSchema.METHOD_PROMPT_LIST,
+				new McpSchema.PaginatedRequest("prompts-cursor"));
+		assertThat(prompts.nextCursor()).isEqualTo("prompts-cursor");
+	}
+
+	@Test
+	void statelessRepositorySupportsRuntimeToolMutation() {
+		var transport = new MockStatelessServerTransport();
+		var repository = new MutableRepository();
+
+		McpStatelessSyncServer server = McpServer.sync(transport)
+			.jsonMapper(JSON_MAPPER)
+			.jsonSchemaValidator(VALID_SCHEMA_VALIDATOR)
+			.toolsRepository(repository)
+			.build();
+
+		server.addTool(toolSpec("runtime-tool", "runtime"));
+
+		McpSchema.ListToolsResult tools = result(transport, "alice", McpSchema.METHOD_TOOLS_LIST,
+				new McpSchema.PaginatedRequest());
+		assertThat(tools.tools()).extracting(McpSchema.Tool::name).containsExactly("runtime-tool");
+
+		server.removeTool("runtime-tool");
+
+		McpSchema.ListToolsResult emptyTools = result(transport, "alice", McpSchema.METHOD_TOOLS_LIST,
+				new McpSchema.PaginatedRequest());
+		assertThat(emptyTools.tools()).isEmpty();
+	}
+
+	@Test
+	void statelessRepositoriesSupportRuntimeResourceAndPromptMutation() {
+		var transport = new MockStatelessServerTransport();
+		var repository = new MutableRepository();
+
+		McpStatelessSyncServer server = McpServer.sync(transport)
+			.jsonMapper(JSON_MAPPER)
+			.jsonSchemaValidator(VALID_SCHEMA_VALIDATOR)
+			.resourcesRepository(repository)
+			.promptsRepository(repository)
+			.build();
+
+		server.addResource(resourceSpec("test://resources/runtime", "runtime-resource", "resource-runtime"));
+		server.addResourceTemplate(resourceTemplateSpec("test://resource-templates/runtime/{name}",
+				"runtime-resource-template", "template-runtime"));
+		server.addPrompt(promptSpec("runtime-prompt", "prompt-runtime"));
+
+		McpSchema.ListResourcesResult resources = result(transport, "alice", McpSchema.METHOD_RESOURCES_LIST,
+				new McpSchema.PaginatedRequest());
+		assertThat(resources.resources()).extracting(McpSchema.Resource::uri)
+			.containsExactly("test://resources/runtime");
+		McpSchema.ListResourceTemplatesResult templates = result(transport, "alice",
+				McpSchema.METHOD_RESOURCES_TEMPLATES_LIST, new McpSchema.PaginatedRequest());
+		assertThat(templates.resourceTemplates()).extracting(McpSchema.ResourceTemplate::uriTemplate)
+			.containsExactly("test://resource-templates/runtime/{name}");
+		McpSchema.ListPromptsResult prompts = result(transport, "alice", McpSchema.METHOD_PROMPT_LIST,
+				new McpSchema.PaginatedRequest());
+		assertThat(prompts.prompts()).extracting(McpSchema.Prompt::name).containsExactly("runtime-prompt");
+
+		McpSchema.ReadResourceResult resourceResult = result(transport, "alice", McpSchema.METHOD_RESOURCES_READ,
+				McpSchema.ReadResourceRequest.builder("test://resources/runtime").build());
+		assertThat(((McpSchema.TextResourceContents) resourceResult.contents().get(0)).text())
+			.isEqualTo("resource-runtime");
+		McpSchema.ReadResourceResult templateResult = result(transport, "alice", McpSchema.METHOD_RESOURCES_READ,
+				McpSchema.ReadResourceRequest.builder("test://resource-templates/runtime/guide").build());
+		assertThat(((McpSchema.TextResourceContents) templateResult.contents().get(0)).text())
+			.isEqualTo("template-runtime");
+		McpSchema.GetPromptResult promptResult = result(transport, "alice", McpSchema.METHOD_PROMPT_GET,
+				McpSchema.GetPromptRequest.builder("runtime-prompt").build());
+		assertThat(text(promptResult.messages().get(0).content())).isEqualTo("prompt-runtime");
+
+		server.removeResource("test://resources/runtime");
+		server.removeResourceTemplate("test://resource-templates/runtime/{name}");
+		server.removePrompt("runtime-prompt");
+
+		McpSchema.ListResourcesResult emptyResources = result(transport, "alice", McpSchema.METHOD_RESOURCES_LIST,
+				new McpSchema.PaginatedRequest());
+		assertThat(emptyResources.resources()).isEmpty();
+		McpSchema.ListResourceTemplatesResult emptyTemplates = result(transport, "alice",
+				McpSchema.METHOD_RESOURCES_TEMPLATES_LIST, new McpSchema.PaginatedRequest());
+		assertThat(emptyTemplates.resourceTemplates()).isEmpty();
+		McpSchema.ListPromptsResult emptyPrompts = result(transport, "alice", McpSchema.METHOD_PROMPT_LIST,
+				new McpSchema.PaginatedRequest());
+		assertThat(emptyPrompts.prompts()).isEmpty();
+	}
+
+	@Test
+	void statelessRuntimeMutationRequiresRepositoryMutationSupport() {
+		var transport = new MockStatelessServerTransport();
+		var repository = new ContextAwareRepository();
+
+		McpStatelessSyncServer server = McpServer.sync(transport)
+			.jsonMapper(JSON_MAPPER)
+			.jsonSchemaValidator(VALID_SCHEMA_VALIDATOR)
+			.toolsRepository(repository)
+			.resourcesRepository(repository)
+			.promptsRepository(repository)
+			.build();
+
+		assertThatThrownBy(() -> server.addTool(toolSpec("runtime-tool", "runtime")))
+			.isInstanceOf(UnsupportedOperationException.class)
+			.hasMessageContaining("does not support adding tools");
+		assertThatThrownBy(() -> server.removeTool("runtime-tool")).isInstanceOf(UnsupportedOperationException.class)
+			.hasMessageContaining("does not support removing tools");
+
+		assertThatThrownBy(() -> server
+			.addResource(resourceSpec("test://resources/runtime", "runtime-resource", "resource-runtime")))
+			.isInstanceOf(UnsupportedOperationException.class)
+			.hasMessageContaining("does not support adding resources");
+		assertThatThrownBy(() -> server.removeResource("test://resources/runtime"))
+			.isInstanceOf(UnsupportedOperationException.class)
+			.hasMessageContaining("does not support removing resources");
+
+		assertThatThrownBy(
+				() -> server.addResourceTemplate(resourceTemplateSpec("test://resource-templates/runtime/{name}",
+						"runtime-resource-template", "template-runtime")))
+			.isInstanceOf(UnsupportedOperationException.class)
+			.hasMessageContaining("does not support adding resource templates");
+		assertThatThrownBy(() -> server.removeResourceTemplate("test://resource-templates/runtime/{name}"))
+			.isInstanceOf(UnsupportedOperationException.class)
+			.hasMessageContaining("does not support removing resource templates");
+
+		assertThatThrownBy(() -> server.addPrompt(promptSpec("runtime-prompt", "prompt-runtime")))
+			.isInstanceOf(UnsupportedOperationException.class)
+			.hasMessageContaining("does not support adding prompts");
+		assertThatThrownBy(() -> server.removePrompt("runtime-prompt"))
+			.isInstanceOf(UnsupportedOperationException.class)
+			.hasMessageContaining("does not support removing prompts");
+	}
+
+	@Test
+	void statelessBuilderRejectsRepositoriesMixedWithStaticRegistrations() {
+		var tool = tool("static-tool");
+		var prompt = McpSchema.Prompt.builder("static-prompt").build();
+		var resource = McpSchema.Resource.builder("test://resources/static", "static-resource").build();
+		var reference = new McpSchema.PromptReference("static-prompt");
+
+		assertThatThrownBy(() -> McpServer.sync(new MockStatelessServerTransport())
+			.jsonSchemaValidator(VALID_SCHEMA_VALIDATOR)
+			.toolsRepository(new MutableRepository())
+			.toolCall(tool, (context, request) -> McpSchema.CallToolResult.builder().build()))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("toolsRepository");
+		assertThatThrownBy(() -> McpServer.sync(new MockStatelessServerTransport())
+			.jsonSchemaValidator(VALID_SCHEMA_VALIDATOR)
+			.toolCall(tool, (context, request) -> McpSchema.CallToolResult.builder().build())
+			.toolsRepository(new MutableRepository())).isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("toolsRepository");
+
+		assertThatThrownBy(() -> McpServer.sync(new MockStatelessServerTransport())
+			.resourcesRepository(new MutableRepository())
+			.resources(new McpStatelessServerFeatures.SyncResourceSpecification(resource,
+					(context, request) -> McpSchema.ReadResourceResult.builder(List.of()).build())))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("resourcesRepository");
+		assertThatThrownBy(() -> McpServer.sync(new MockStatelessServerTransport())
+			.resources(new McpStatelessServerFeatures.SyncResourceSpecification(resource,
+					(context, request) -> McpSchema.ReadResourceResult.builder(List.of()).build()))
+			.resourcesRepository(new MutableRepository())).isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("resourcesRepository");
+
+		assertThatThrownBy(() -> McpServer.sync(new MockStatelessServerTransport())
+			.promptsRepository(new MutableRepository())
+			.prompts(new McpStatelessServerFeatures.SyncPromptSpecification(prompt,
+					(context, request) -> McpSchema.GetPromptResult.builder(List.of()).build())))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("promptsRepository");
+		assertThatThrownBy(() -> McpServer.sync(new MockStatelessServerTransport())
+			.prompts(new McpStatelessServerFeatures.SyncPromptSpecification(prompt,
+					(context, request) -> McpSchema.GetPromptResult.builder(List.of()).build()))
+			.promptsRepository(new MutableRepository())).isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("promptsRepository");
+
+		assertThatThrownBy(() -> McpServer.sync(new MockStatelessServerTransport())
+			.completionsRepository(new MutableRepository())
+			.completions(new McpStatelessServerFeatures.SyncCompletionSpecification(reference,
+					(context, request) -> new McpSchema.CompleteResult(
+							new McpSchema.CompleteResult.CompleteCompletion(List.of())))))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("completionsRepository");
+		assertThatThrownBy(() -> McpServer.sync(new MockStatelessServerTransport())
+			.completions(new McpStatelessServerFeatures.SyncCompletionSpecification(reference,
+					(context, request) -> new McpSchema.CompleteResult(
+							new McpSchema.CompleteResult.CompleteCompletion(List.of()))))
+			.completionsRepository(new MutableRepository())).isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("completionsRepository");
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> T result(MockStatelessServerTransport transport, String user, String method, Object params) {
+		McpSchema.JSONRPCResponse response = response(transport, user, method, params);
+		assertThat(response).isNotNull();
+		assertThat(response.error()).isNull();
+		return (T) response.result();
+	}
+
+	private static McpSchema.JSONRPCResponse response(MockStatelessServerTransport transport, String user,
+			String method, Object params) {
+		return transport.handler
+			.handleRequest(McpTransportContext.create(Map.of(USER_KEY, user)),
+					new McpSchema.JSONRPCRequest(method, method + "-id", params))
+			.block();
+	}
+
+	private static McpStatelessServerFeatures.SyncToolSpecification toolSpec(String name, String responseText) {
+		return new McpStatelessServerFeatures.SyncToolSpecification(tool(name),
+				(context, request) -> McpSchema.CallToolResult.builder().addTextContent(responseText).build());
+	}
+
+	private static McpStatelessServerFeatures.SyncResourceSpecification resourceSpec(String uri, String name,
+			String responseText) {
+		var resource = McpSchema.Resource.builder(uri, name).build();
+		return new McpStatelessServerFeatures.SyncResourceSpecification(resource,
+				(context, request) -> McpSchema.ReadResourceResult
+					.builder(List.of(McpSchema.TextResourceContents.builder(request.uri(), responseText).build()))
+					.build());
+	}
+
+	private static McpStatelessServerFeatures.SyncResourceTemplateSpecification resourceTemplateSpec(String uriTemplate,
+			String name, String responseText) {
+		var resourceTemplate = McpSchema.ResourceTemplate.builder(uriTemplate, name).build();
+		return new McpStatelessServerFeatures.SyncResourceTemplateSpecification(resourceTemplate,
+				(context, request) -> McpSchema.ReadResourceResult
+					.builder(List.of(McpSchema.TextResourceContents.builder(request.uri(), responseText).build()))
+					.build());
+	}
+
+	private static McpStatelessServerFeatures.SyncPromptSpecification promptSpec(String name, String responseText) {
+		var prompt = McpSchema.Prompt.builder(name).build();
+		return new McpStatelessServerFeatures.SyncPromptSpecification(prompt,
+				(context,
+						request) -> McpSchema.GetPromptResult.builder(List.of(McpSchema.PromptMessage
+							.builder(McpSchema.Role.USER, McpSchema.TextContent.builder(responseText).build())
+							.build())).build());
+	}
+
+	private static McpSchema.Tool tool(String name) {
+		return McpSchema.Tool.builder(name, Map.of("type", "object")).build();
+	}
+
+	private static String text(McpSchema.Content content) {
+		return ((McpSchema.TextContent) content).text();
+	}
+
+	private static String user(McpTransportContext transportContext) {
+		Object user = transportContext.get(USER_KEY);
+		return (user != null) ? user.toString() : "anonymous";
+	}
+
+	private static final class PassThroughMcpJsonMapper implements McpJsonMapper {
+
+		private final GsonMcpJsonMapper delegate = new GsonMcpJsonMapper();
+
+		@Override
+		public <T> T readValue(String content, Class<T> type) throws IOException {
+			return this.delegate.readValue(content, type);
+		}
+
+		@Override
+		public <T> T readValue(byte[] content, Class<T> type) throws IOException {
+			return this.delegate.readValue(content, type);
+		}
+
+		@Override
+		public <T> T readValue(String content, TypeRef<T> type) throws IOException {
+			return this.delegate.readValue(content, type);
+		}
+
+		@Override
+		public <T> T readValue(byte[] content, TypeRef<T> type) throws IOException {
+			return this.delegate.readValue(content, type);
+		}
+
+		@Override
+		public <T> T convertValue(Object fromValue, Class<T> type) {
+			if (type.isInstance(fromValue)) {
+				return type.cast(fromValue);
+			}
+			return this.delegate.convertValue(fromValue, type);
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public <T> T convertValue(Object fromValue, TypeRef<T> type) {
+			Type targetType = type.getType();
+			if (targetType instanceof Class<?> targetClass && targetClass.isInstance(fromValue)) {
+				return (T) fromValue;
+			}
+			return this.delegate.convertValue(fromValue, type);
+		}
+
+		@Override
+		public String writeValueAsString(Object value) throws IOException {
+			return this.delegate.writeValueAsString(value);
+		}
+
+		@Override
+		public byte[] writeValueAsBytes(Object value) throws IOException {
+			return this.delegate.writeValueAsBytes(value);
+		}
+
+	}
+
+	private static final class MockStatelessServerTransport implements McpStatelessServerTransport {
+
+		private McpStatelessServerHandler handler;
+
+		@Override
+		public void setMcpHandler(McpStatelessServerHandler mcpHandler) {
+			this.handler = mcpHandler;
+		}
+
+		@Override
+		public Mono<Void> closeGracefully() {
+			return Mono.empty();
+		}
+
+	}
+
+	private static final class ContextAwareRepository
+			implements ToolsRepository, ResourcesRepository, PromptsRepository, CompletionsRepository {
+
+		@Override
+		public McpSchema.ListToolsResult listTools(McpSchema.PaginatedRequest request,
+				McpTransportContext transportContext) {
+			return McpSchema.ListToolsResult.builder(List.of(tool(user(transportContext) + "-tool")))
+				.nextCursor(request.cursor())
+				.build();
+		}
+
+		@Override
+		public Optional<McpSchema.Tool> resolveTool(String name, McpTransportContext transportContext) {
+			String user = user(transportContext);
+			if (!name.equals(user + "-tool")) {
+				return Optional.empty();
+			}
+			return Optional.of(tool(name));
+		}
+
+		@Override
+		public McpSchema.CallToolResult callTool(McpSchema.CallToolRequest request,
+				McpTransportContext transportContext) {
+			return McpSchema.CallToolResult.builder().addTextContent("tool:" + user(transportContext)).build();
+		}
+
+		@Override
+		public McpSchema.ListResourcesResult listResources(McpSchema.PaginatedRequest request,
+				McpTransportContext transportContext) {
+			String user = user(transportContext);
+			return McpSchema.ListResourcesResult
+				.builder(List.of(McpSchema.Resource.builder("test://resources/" + user, user + "-resource").build()))
+				.nextCursor(request.cursor())
+				.build();
+		}
+
+		@Override
+		public McpSchema.ListResourceTemplatesResult listResourceTemplates(McpSchema.PaginatedRequest request,
+				McpTransportContext transportContext) {
+			String user = user(transportContext);
+			return McpSchema.ListResourceTemplatesResult.builder(List.of(McpSchema.ResourceTemplate
+				.builder("test://resource-templates/" + user + "/{name}", user + "-resource-template")
+				.build())).nextCursor(request.cursor()).build();
+		}
+
+		@Override
+		public Optional<McpSchema.Resource> resolveResource(String uri, McpTransportContext transportContext) {
+			String user = user(transportContext);
+			if (!uri.equals("test://resources/" + user)) {
+				return Optional.empty();
+			}
+			return Optional.of(McpSchema.Resource.builder(uri, user + "-resource").build());
+		}
+
+		@Override
+		public Optional<McpSchema.ResourceTemplate> resolveResourceTemplate(String uri,
+				McpTransportContext transportContext) {
+			String user = user(transportContext);
+			if (!uri.equals("test://resource-templates/" + user + "/{name}")
+					&& !uri.equals("test://resource-templates/" + user + "/guide")) {
+				return Optional.empty();
+			}
+			return Optional.of(McpSchema.ResourceTemplate
+				.builder("test://resource-templates/" + user + "/{name}", user + "-resource-template")
+				.build());
+		}
+
+		@Override
+		public McpSchema.ReadResourceResult readResource(McpSchema.ReadResourceRequest request,
+				McpTransportContext transportContext) {
+			String user = user(transportContext);
+			String content = request.uri().equals("test://resources/" + user) ? "resource:" + user
+					: "resource-template:" + user;
+			return McpSchema.ReadResourceResult
+				.builder(List.of(McpSchema.TextResourceContents.builder(request.uri(), content).build()))
+				.build();
+		}
+
+		@Override
+		public McpSchema.ListPromptsResult listPrompts(McpSchema.PaginatedRequest request,
+				McpTransportContext transportContext) {
+			String user = user(transportContext);
+			return McpSchema.ListPromptsResult.builder(List.of(McpSchema.Prompt.builder(user + "-prompt")
+				.arguments(List.of(McpSchema.PromptArgument.builder("name").build()))
+				.build())).nextCursor(request.cursor()).build();
+		}
+
+		@Override
+		public Optional<McpSchema.Prompt> resolvePrompt(String name, McpTransportContext transportContext) {
+			String user = user(transportContext);
+			if (!name.equals(user + "-prompt")) {
+				return Optional.empty();
+			}
+			return Optional.of(McpSchema.Prompt.builder(name)
+				.arguments(List.of(McpSchema.PromptArgument.builder("name").build()))
+				.build());
+		}
+
+		@Override
+		public McpSchema.GetPromptResult getPrompt(McpSchema.GetPromptRequest request,
+				McpTransportContext transportContext) {
+			return McpSchema.GetPromptResult
+				.builder(
+						List.of(McpSchema.PromptMessage
+							.builder(McpSchema.Role.USER,
+									McpSchema.TextContent.builder("prompt:" + user(transportContext)).build())
+							.build()))
+				.build();
+		}
+
+		@Override
+		public McpSchema.CompleteResult complete(McpSchema.CompleteRequest request,
+				McpTransportContext transportContext) {
+			return new McpSchema.CompleteResult(
+					new McpSchema.CompleteResult.CompleteCompletion(List.of("completion:" + user(transportContext))));
+		}
+
+	}
+
+	private static final class MutableRepository
+			implements ToolsRepository, ResourcesRepository, PromptsRepository, CompletionsRepository {
+
+		private final Map<String, McpStatelessServerFeatures.SyncToolSpecification> tools = new LinkedHashMap<>();
+
+		private final Map<String, McpStatelessServerFeatures.SyncResourceSpecification> resources = new LinkedHashMap<>();
+
+		private final Map<String, McpStatelessServerFeatures.SyncResourceTemplateSpecification> resourceTemplates = new LinkedHashMap<>();
+
+		private final Map<String, McpStatelessServerFeatures.SyncPromptSpecification> prompts = new LinkedHashMap<>();
+
+		@Override
+		public McpSchema.ListToolsResult listTools(McpSchema.PaginatedRequest request,
+				McpTransportContext transportContext) {
+			return McpSchema.ListToolsResult.builder(
+					this.tools.values().stream().map(McpStatelessServerFeatures.SyncToolSpecification::tool).toList())
+				.build();
+		}
+
+		@Override
+		public Optional<McpSchema.Tool> resolveTool(String name, McpTransportContext transportContext) {
+			return Optional.ofNullable(this.tools.get(name))
+				.map(McpStatelessServerFeatures.SyncToolSpecification::tool);
+		}
+
+		@Override
+		public McpSchema.CallToolResult callTool(McpSchema.CallToolRequest request,
+				McpTransportContext transportContext) {
+			return this.tools.get(request.name()).callHandler().apply(transportContext, request);
+		}
+
+		@Override
+		public void addTool(McpStatelessServerFeatures.SyncToolSpecification toolSpecification) {
+			this.tools.put(toolSpecification.tool().name(), toolSpecification);
+		}
+
+		@Override
+		public boolean removeTool(String toolName) {
+			return this.tools.remove(toolName) != null;
+		}
+
+		@Override
+		public McpSchema.ListResourcesResult listResources(McpSchema.PaginatedRequest request,
+				McpTransportContext transportContext) {
+			return McpSchema.ListResourcesResult
+				.builder(this.resources.values()
+					.stream()
+					.map(McpStatelessServerFeatures.SyncResourceSpecification::resource)
+					.toList())
+				.build();
+		}
+
+		@Override
+		public McpSchema.ListResourceTemplatesResult listResourceTemplates(McpSchema.PaginatedRequest request,
+				McpTransportContext transportContext) {
+			return McpSchema.ListResourceTemplatesResult
+				.builder(this.resourceTemplates.values()
+					.stream()
+					.map(McpStatelessServerFeatures.SyncResourceTemplateSpecification::resourceTemplate)
+					.toList())
+				.build();
+		}
+
+		@Override
+		public Optional<McpSchema.Resource> resolveResource(String uri, McpTransportContext transportContext) {
+			return Optional.ofNullable(this.resources.get(uri))
+				.map(McpStatelessServerFeatures.SyncResourceSpecification::resource);
+		}
+
+		@Override
+		public Optional<McpSchema.ResourceTemplate> resolveResourceTemplate(String uri,
+				McpTransportContext transportContext) {
+			return this.resourceTemplates.values()
+				.stream()
+				.filter(resourceTemplate -> matches(resourceTemplate.resourceTemplate().uriTemplate(), uri))
+				.map(McpStatelessServerFeatures.SyncResourceTemplateSpecification::resourceTemplate)
+				.findFirst();
+		}
+
+		@Override
+		public McpSchema.ReadResourceResult readResource(McpSchema.ReadResourceRequest request,
+				McpTransportContext transportContext) {
+			McpStatelessServerFeatures.SyncResourceSpecification resourceSpecification = this.resources
+				.get(request.uri());
+			if (resourceSpecification != null) {
+				return resourceSpecification.readHandler().apply(transportContext, request);
+			}
+			return this.resourceTemplates.values()
+				.stream()
+				.filter(resourceTemplate -> matches(resourceTemplate.resourceTemplate().uriTemplate(), request.uri()))
+				.findFirst()
+				.orElseThrow()
+				.readHandler()
+				.apply(transportContext, request);
+		}
+
+		@Override
+		public void addResource(McpStatelessServerFeatures.SyncResourceSpecification resourceSpecification) {
+			this.resources.put(resourceSpecification.resource().uri(), resourceSpecification);
+		}
+
+		@Override
+		public boolean removeResource(String resourceUri) {
+			return this.resources.remove(resourceUri) != null;
+		}
+
+		@Override
+		public void addResourceTemplate(
+				McpStatelessServerFeatures.SyncResourceTemplateSpecification resourceTemplateSpecification) {
+			this.resourceTemplates.put(resourceTemplateSpecification.resourceTemplate().uriTemplate(),
+					resourceTemplateSpecification);
+		}
+
+		@Override
+		public boolean removeResourceTemplate(String uriTemplate) {
+			return this.resourceTemplates.remove(uriTemplate) != null;
+		}
+
+		@Override
+		public McpSchema.ListPromptsResult listPrompts(McpSchema.PaginatedRequest request,
+				McpTransportContext transportContext) {
+			return McpSchema.ListPromptsResult
+				.builder(this.prompts.values()
+					.stream()
+					.map(McpStatelessServerFeatures.SyncPromptSpecification::prompt)
+					.toList())
+				.build();
+		}
+
+		@Override
+		public Optional<McpSchema.Prompt> resolvePrompt(String name, McpTransportContext transportContext) {
+			return Optional.ofNullable(this.prompts.get(name))
+				.map(McpStatelessServerFeatures.SyncPromptSpecification::prompt);
+		}
+
+		@Override
+		public McpSchema.GetPromptResult getPrompt(McpSchema.GetPromptRequest request,
+				McpTransportContext transportContext) {
+			return this.prompts.get(request.name()).promptHandler().apply(transportContext, request);
+		}
+
+		@Override
+		public void addPrompt(McpStatelessServerFeatures.SyncPromptSpecification promptSpecification) {
+			this.prompts.put(promptSpecification.prompt().name(), promptSpecification);
+		}
+
+		@Override
+		public boolean removePrompt(String promptName) {
+			return this.prompts.remove(promptName) != null;
+		}
+
+		@Override
+		public McpSchema.CompleteResult complete(McpSchema.CompleteRequest request,
+				McpTransportContext transportContext) {
+			return new McpSchema.CompleteResult(new McpSchema.CompleteResult.CompleteCompletion(List.of()));
+		}
+
+		private static boolean matches(String uriTemplate, String uri) {
+			String prefix = uriTemplate.replace("{name}", "");
+			return uriTemplate.equals(uri) || uri.startsWith(prefix);
+		}
+
+	}
+
+}


### PR DESCRIPTION
Adds opt-in sync/stateless repository contracts for dynamic MCP server primitives:
tools, resources, prompts, and completions.

This is a narrower rework of #953 based on the design discussion in #578.

## Motivation and Context

Some MCP servers need to expose different tools, resources, prompts, or completion
handlers depending on the authenticated user, tenant, token, headers, or other
request context.

This PR keeps the first repository shape narrow:

- repository contracts are synchronous and do not expose `Mono<...>`
- repositories are added only to the stateless sync server builder
- repository methods receive typed request inputs or identifiers plus
  `McpTransportContext`
- repository contracts do not expose server exchange objects
- list methods receive `McpSchema.PaginatedRequest`
- existing static registration APIs continue to work

Exchange-dependent flows such as sampling, elicitation, logging, and progress stay
on the existing handler API for now.

## Design Notes

This PR follows the direction discussed in #578:

- **Non-breaking opt-in:** repositories are configured explicitly. Existing static
  registrations remain available.
- **Stateless first:** this starts with the sync/stateless shape instead of adding
  repository variants across the full server matrix.
- **Sync public API:** repository contracts are synchronous, while the current
  stateless async core adapts calls internally using the existing
  immediate-execution/offload model.
- **Transport context instead of exchange:** repositories receive
  `McpTransportContext`, keeping the API focused on request-context based discovery
  and execution.
- **No implicit merging:** static registrations and repositories cannot be
  configured together for the same primitive family.

## How Has This Been Tested?

Added in-process stateless server tests for request-context based discovery and
resolution, completions, paginated list requests, runtime add/remove behavior, and
repository/static registration conflict validation.

I also tested the repository path locally with a small servlet server that resolves
primitives from request context.

## Breaking Changes

None intended.

Existing static registration APIs continue to work. Repositories are opt-in and are
configured through the stateless sync server builder.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
