### PR TITLE
Upgrade to Java 21

### DIFF
--- a/conformance-tests/client-spring-http-client/pom.xml
+++ b/conformance-tests/client-spring-http-client/pom.xml
@@ -21,7 +21,7 @@
 	</scm>
 
 	<properties>
-		<java.version>17</java.version>
+		<java.version>21</java.version>
 		<spring-boot.version>4.1.0</spring-boot.version>
 		<spring-ai.version>2.0.0</spring-ai.version>
 		<spring-ai-mcp-security.version>0.1.13</spring-ai-mcp-security.version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,9 +54,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>17</java.version>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<java.version>21</java.version>
 		<surefireArgLine />
 
 		<assert4j.version>3.27.6</assert4j.version>


### PR DESCRIPTION
Upgrades the build from Java 17 to Java 21 (LTS).

- `pom.xml` and `conformance-tests/client-spring-http-client/pom.xml`: `<java.version>` (compiler target) 17 → 21

**Verification:** the project compiles under JDK 21 and all 1135 tests pass, with none lost versus the JDK-17 baseline. No production or test code changed — only the compiler target.

(Heads-up: raising the SDK baseline to 21 means consumers will need to build/run on JDK 21+. Happy to close this if you intend to keep a Java 17 baseline for broader compatibility — just offering it as a tested option.)



---
### How this was produced
This change was produced by running the OpenRewrite recipe below — the committed diff is the recipe output (no hand-editing):

```yaml
# rewrite.yml
type: specs.openrewrite.org/v1beta/recipe
name: com.example.UpgradeJava
recipeList:
  - org.openrewrite.java.migrate.UpgradePluginsForJava21
  - org.openrewrite.java.migrate.UpgradeBuildToJava21
  - org.openrewrite.java.migrate.UpgradeJavaVersion:
      version: 21
```
```bash
mvn -U org.openrewrite.maven:rewrite-maven-plugin:RELEASE:run \
  -Drewrite.configLocation=$(pwd)/rewrite.yml \
  -Drewrite.activeRecipes=com.example.UpgradeJava \
  -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-migrate-java:RELEASE
```

_Verified: all 1135 tests pass under JDK 21, none lost versus the baseline._
