### PR TITLE
fix: standardize resource not found error code

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -151,7 +151,7 @@ public final class McpSchema {
 		/**
 		 * Resource not found.
 		 */
-		public static final int RESOURCE_NOT_FOUND = -32002;
+		public static final int RESOURCE_NOT_FOUND = INVALID_PARAMS;
 
 		/**
 		 * URL elicitation is required before the request can proceed.

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/McpErrorTest.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/McpErrorTest.java
@@ -14,7 +14,7 @@ class McpErrorTest {
 		String uri = "file:///nonexistent.txt";
 		McpError mcpError = McpError.RESOURCE_NOT_FOUND.apply(uri);
 		assertNotNull(mcpError.getJsonRpcError());
-		assertEquals(-32002, mcpError.getJsonRpcError().code());
+		assertEquals(McpSchema.ErrorCodes.INVALID_PARAMS, mcpError.getJsonRpcError().code());
 		assertEquals("Resource not found", mcpError.getJsonRpcError().message());
 		assertEquals(Map.of("uri", uri), mcpError.getJsonRpcError().data());
 	}


### PR DESCRIPTION
## Summary
- Align `McpError.RESOURCE_NOT_FOUND` with SEP-2164 by using JSON-RPC `INVALID_PARAMS` (`-32602`).
- Update the resource-not-found error code regression expectation.

## Test plan
- `./mvnw -pl mcp-core -Dtest=McpErrorTest test`
- `./mvnw -pl mcp-core test`
- `./mvnw -pl mcp-core spring-javaformat:validate`
- `git diff --check`

Closes #1001