### PR TITLE
docs: fix broken link inside README.md

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,5 +1,5 @@
 # Java MCP SDK
 
 Java SDK implementation of the Model Context Protocol, enabling seamless integration with language models and AI tools.
-For comprehensive guides and API documentation, visit the [MCP Java SDK Reference Documentation](https://modelcontextprotocol.io/sdk/java/mcp-overview).
+For comprehensive guides and API documentation, visit the [MCP Java SDK Reference Documentation](https://java.sdk.modelcontextprotocol.io/latest/overview/).
 


### PR DESCRIPTION
## Motivation and Context
The link in the README.md is now broken since the Java SDK has a standalone website.

## How Has This Been Tested?
This has been tested locally.

## Breaking Changes
No breaking changes unless the link used is incorrect.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

Closes #1043 
