### PR TITLE
fix: serialize ElicitRequest mode discriminator only once

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -4805,7 +4805,7 @@ public final class McpSchema {
 		}
 
 		@Override
-		@JsonProperty("mode")
+		@JsonIgnore
 		public String mode() {
 			return MODE;
 		}
@@ -4931,7 +4931,7 @@ public final class McpSchema {
 		}
 
 		@Override
-		@JsonProperty("mode")
+		@JsonIgnore
 		public String mode() {
 			return MODE;
 		}

--- a/mcp-test/src/test/java/io/modelcontextprotocol/spec/ElicitRequestJsonTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/spec/ElicitRequestJsonTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 - 2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.spec;
+
+import static io.modelcontextprotocol.util.McpJsonMapperUtils.JSON_MAPPER;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Map;
+
+import io.modelcontextprotocol.json.McpJsonMapper;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that every {@link McpSchema.ElicitRequest} subtype serializes with exactly one
+ * {@code mode} property (regression guard for the {@code @JsonIgnore} on the overridden
+ * {@code mode()} accessors, mirroring {@link ContentJsonTests}).
+ */
+class ElicitRequestJsonTests {
+
+	private final McpJsonMapper mapper = JSON_MAPPER;
+
+	@Test
+	void formRequestHasExactlyOneModeProperty() throws IOException {
+		McpSchema.ElicitFormRequest request = McpSchema.ElicitFormRequest.builder("msg", Map.of("type", "object"))
+			.build();
+		String json = mapper.writeValueAsString(request);
+
+		assertExactlyOneModeProperty(json);
+		assertThatJson(json).node("mode").isEqualTo("form");
+	}
+
+	@Test
+	void urlRequestHasExactlyOneModeProperty() throws IOException {
+		McpSchema.ElicitUrlRequest request = McpSchema.ElicitUrlRequest.builder("msg", "https://example.com", "eid")
+			.build();
+		String json = mapper.writeValueAsString(request);
+
+		assertExactlyOneModeProperty(json);
+		assertThatJson(json).node("mode").isEqualTo("url");
+	}
+
+	@Test
+	void formRequestRoundTrip() throws IOException {
+		McpSchema.ElicitFormRequest original = McpSchema.ElicitFormRequest.builder("msg", Map.of("type", "object"))
+			.build();
+		String json = mapper.writeValueAsString(original);
+
+		McpSchema.ElicitRequest decoded = mapper.readValue(json, McpSchema.ElicitRequest.class);
+		assertThat(decoded).isInstanceOf(McpSchema.ElicitFormRequest.class);
+		assertThat(decoded.mode()).isEqualTo("form");
+	}
+
+	@Test
+	void urlRequestRoundTrip() throws IOException {
+		McpSchema.ElicitUrlRequest original = McpSchema.ElicitUrlRequest.builder("msg", "https://example.com", "eid")
+			.build();
+		String json = mapper.writeValueAsString(original);
+
+		McpSchema.ElicitRequest decoded = mapper.readValue(json, McpSchema.ElicitRequest.class);
+		assertThat(decoded).isInstanceOf(McpSchema.ElicitUrlRequest.class);
+		assertThat(decoded.mode()).isEqualTo("url");
+	}
+
+	private static void assertExactlyOneModeProperty(String json) {
+		long count = java.util.Arrays.stream(json.split("\"mode\"")).count() - 1;
+		assertThat(count).as("'mode' property must appear exactly once in: %s", json).isEqualTo(1);
+	}
+
+}


### PR DESCRIPTION
## Problem

`ElicitRequest` declares its subtype discriminator with `@JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "mode")`, so Jackson already writes the `mode` property when serializing an `ElicitFormRequest` or `ElicitUrlRequest`. Both subtypes also annotate their overridden `mode()` accessor with `@JsonProperty("mode")`, so `mode` is written a second time, producing a duplicate JSON key:

```json
{"mode":"form","message":"msg","requestedSchema":{"type":"object"},"mode":"form"}
{"mode":"url","message":"msg","url":"https://example.com","elicitationId":"eid","mode":"url"}
```

Duplicate object keys violate RFC 8259 and can be rejected by strict client-side parsers.

This is the same defect already fixed on the parallel `Content` hierarchy, where `Content.type()` is marked `@JsonIgnore` and `ContentJsonTests` guards it by counting raw `type` occurrences. The elicitation request types were missed.

## Fix

Mark the overridden `mode()` accessors on `ElicitFormRequest` and `ElicitUrlRequest` `@JsonIgnore`, mirroring `Content.type()`. The `@JsonTypeInfo` machinery still writes `mode` exactly once, and deserialization is unaffected since it uses the discriminator plus the `@JsonCreator` `fromJson` factories.

## Tests

`ElicitRequestJsonTests` mirrors `ContentJsonTests`: it asserts each subtype serializes `mode` exactly once (counting raw occurrences, since the existing `assertThatJson` tree comparison silently collapses duplicate keys) and that both round-trip back to the correct subtype.

```
mvn -pl mcp-test -am test -Dtest=ElicitRequestJsonTests,ContentJsonTests,McpSchemaTests
```

All green (195 schema + 5 content + 4 new). Before the change the two count assertions fail (`mode` appears twice); after, they pass.