### PR TITLE
Add initialize request metadata support

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/LifecycleInitializer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/LifecycleInitializer.java
@@ -7,7 +7,9 @@ package io.modelcontextprotocol.client;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
@@ -89,6 +91,8 @@ class LifecycleInitializer {
 
 	private final McpSchema.Implementation clientInfo;
 
+	private final Map<String, Object> initializeRequestMeta;
+
 	private List<String> protocolVersions;
 
 	private final AtomicReference<DefaultInitialization> initializationRef = new AtomicReference<>();
@@ -109,6 +113,15 @@ class LifecycleInitializer {
 			Function<ContextView, McpClientSession> sessionSupplier,
 			Function<Initialization, Mono<Void>> postInitializationHook) {
 
+		this(clientCapabilities, clientInfo, null, protocolVersions, initializationTimeout, sessionSupplier,
+				postInitializationHook);
+	}
+
+	public LifecycleInitializer(McpSchema.ClientCapabilities clientCapabilities, McpSchema.Implementation clientInfo,
+			Map<String, Object> initializeRequestMeta, List<String> protocolVersions, Duration initializationTimeout,
+			Function<ContextView, McpClientSession> sessionSupplier,
+			Function<Initialization, Mono<Void>> postInitializationHook) {
+
 		Assert.notNull(sessionSupplier, "Session supplier must not be null");
 		Assert.notNull(clientCapabilities, "Client capabilities must not be null");
 		Assert.notNull(clientInfo, "Client info must not be null");
@@ -119,9 +132,14 @@ class LifecycleInitializer {
 		this.sessionSupplier = sessionSupplier;
 		this.clientCapabilities = clientCapabilities;
 		this.clientInfo = clientInfo;
+		this.initializeRequestMeta = copyInitializeRequestMeta(initializeRequestMeta);
 		this.protocolVersions = Collections.unmodifiableList(new ArrayList<>(protocolVersions));
 		this.initializationTimeout = initializationTimeout;
 		this.postInitializationHook = postInitializationHook;
+	}
+
+	private static Map<String, Object> copyInitializeRequestMeta(Map<String, Object> initializeRequestMeta) {
+		return initializeRequestMeta != null ? Collections.unmodifiableMap(new HashMap<>(initializeRequestMeta)) : null;
 	}
 
 	/**
@@ -301,9 +319,12 @@ class LifecycleInitializer {
 
 		String latestVersion = this.protocolVersions.get(this.protocolVersions.size() - 1);
 
-		McpSchema.InitializeRequest initializeRequest = McpSchema.InitializeRequest
-			.builder(latestVersion, this.clientCapabilities, this.clientInfo)
-			.build();
+		McpSchema.InitializeRequest.Builder initializeRequestBuilder = McpSchema.InitializeRequest
+			.builder(latestVersion, this.clientCapabilities, this.clientInfo);
+		if (this.initializeRequestMeta != null) {
+			initializeRequestBuilder.meta(this.initializeRequestMeta);
+		}
+		McpSchema.InitializeRequest initializeRequest = initializeRequestBuilder.build();
 
 		Mono<McpSchema.InitializeResult> result = mcpClientSession.sendRequest(McpSchema.METHOD_INITIALIZE,
 				initializeRequest, McpAsyncClient.INITIALIZE_RESULT_TYPE_REF);

--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
@@ -351,9 +351,9 @@ public class McpAsyncClient {
 			}).then();
 		};
 
-		this.initializer = new LifecycleInitializer(clientCapabilities, clientInfo, transport.protocolVersions(),
-				initializationTimeout, ctx -> new McpClientSession(requestTimeout, transport, requestHandlers,
-						notificationHandlers, con -> con.contextWrite(ctx)),
+		this.initializer = new LifecycleInitializer(clientCapabilities, clientInfo, features.initializeRequestMeta(),
+				transport.protocolVersions(), initializationTimeout, ctx -> new McpClientSession(requestTimeout,
+						transport, requestHandlers, notificationHandlers, con -> con.contextWrite(ctx)),
 				postInitializationHook);
 
 		this.transport.setExceptionHandler(this.initializer::handleException);

--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/McpClient.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/McpClient.java
@@ -6,6 +6,7 @@ package io.modelcontextprotocol.client;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -172,6 +173,8 @@ public interface McpClient {
 
 		private Implementation clientInfo = Implementation.builder("Java SDK MCP Client", "0.15.0").build();
 
+		private Map<String, Object> initializeRequestMeta;
+
 		private final Map<String, Root> roots = new HashMap<>();
 
 		private final List<Consumer<List<McpSchema.Tool>>> toolsChangeConsumers = new ArrayList<>();
@@ -260,6 +263,20 @@ public interface McpClient {
 		public SyncSpec clientInfo(Implementation clientInfo) {
 			Assert.notNull(clientInfo, "Client info must not be null");
 			this.clientInfo = clientInfo;
+			return this;
+		}
+
+		/**
+		 * Sets optional metadata to include in the initialization request's {@code _meta}
+		 * field.
+		 * @param initializeRequestMeta Metadata to send with the initialize request. Must
+		 * not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if initializeRequestMeta is null
+		 */
+		public SyncSpec initializeRequestMeta(Map<String, Object> initializeRequestMeta) {
+			Assert.notNull(initializeRequestMeta, "Initialize request metadata must not be null");
+			this.initializeRequestMeta = Collections.unmodifiableMap(new HashMap<>(initializeRequestMeta));
 			return this;
 		}
 
@@ -551,10 +568,11 @@ public interface McpClient {
 		 */
 		public McpSyncClient build() {
 			McpClientFeatures.Sync syncFeatures = new McpClientFeatures.Sync(this.clientInfo, this.capabilities,
-					this.roots, this.toolsChangeConsumers, this.resourcesChangeConsumers, this.resourcesUpdateConsumers,
-					this.promptsChangeConsumers, this.loggingConsumers, this.progressConsumers,
-					this.elicitationCompleteConsumers, this.samplingHandler, this.formElicitationHandler,
-					this.urlElicitationHandler, this.enableCallToolSchemaCaching, this.applyElicitationDefaults);
+					this.initializeRequestMeta, this.roots, this.toolsChangeConsumers, this.resourcesChangeConsumers,
+					this.resourcesUpdateConsumers, this.promptsChangeConsumers, this.loggingConsumers,
+					this.progressConsumers, this.elicitationCompleteConsumers, this.samplingHandler,
+					this.formElicitationHandler, this.urlElicitationHandler, this.enableCallToolSchemaCaching,
+					this.applyElicitationDefaults);
 
 			McpClientFeatures.Async asyncFeatures = McpClientFeatures.Async.fromSync(syncFeatures);
 
@@ -592,6 +610,8 @@ public interface McpClient {
 		private ClientCapabilities capabilities;
 
 		private Implementation clientInfo = Implementation.builder("Java SDK MCP Client", "0.15.0").build();
+
+		private Map<String, Object> initializeRequestMeta;
 
 		private final Map<String, Root> roots = new HashMap<>();
 
@@ -679,6 +699,20 @@ public interface McpClient {
 		public AsyncSpec clientInfo(Implementation clientInfo) {
 			Assert.notNull(clientInfo, "Client info must not be null");
 			this.clientInfo = clientInfo;
+			return this;
+		}
+
+		/**
+		 * Sets optional metadata to include in the initialization request's {@code _meta}
+		 * field.
+		 * @param initializeRequestMeta Metadata to send with the initialize request. Must
+		 * not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if initializeRequestMeta is null
+		 */
+		public AsyncSpec initializeRequestMeta(Map<String, Object> initializeRequestMeta) {
+			Assert.notNull(initializeRequestMeta, "Initialize request metadata must not be null");
+			this.initializeRequestMeta = Collections.unmodifiableMap(new HashMap<>(initializeRequestMeta));
 			return this;
 		}
 
@@ -960,11 +994,11 @@ public interface McpClient {
 					: McpJsonDefaults.getSchemaValidator();
 			return new McpAsyncClient(this.transport, this.requestTimeout, this.initializationTimeout,
 					jsonSchemaValidator,
-					new McpClientFeatures.Async(this.clientInfo, this.capabilities, this.roots,
-							this.toolsChangeConsumers, this.resourcesChangeConsumers, this.resourcesUpdateConsumers,
-							this.promptsChangeConsumers, this.loggingConsumers, this.progressConsumers,
-							this.elicitationCompleteConsumers, this.samplingHandler, this.formElicitationHandler,
-							this.urlElicitationHandler, this.enableCallToolSchemaCaching,
+					new McpClientFeatures.Async(this.clientInfo, this.capabilities, this.initializeRequestMeta,
+							this.roots, this.toolsChangeConsumers, this.resourcesChangeConsumers,
+							this.resourcesUpdateConsumers, this.promptsChangeConsumers, this.loggingConsumers,
+							this.progressConsumers, this.elicitationCompleteConsumers, this.samplingHandler,
+							this.formElicitationHandler, this.urlElicitationHandler, this.enableCallToolSchemaCaching,
 							this.applyElicitationDefaults));
 		}
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/McpClientFeatures.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/McpClientFeatures.java
@@ -5,6 +5,7 @@
 package io.modelcontextprotocol.client;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,6 +55,7 @@ class McpClientFeatures {
 	 *
 	 * @param clientInfo the client implementation information.
 	 * @param clientCapabilities the client capabilities.
+	 * @param initializeRequestMeta metadata to include in the initialize request.
 	 * @param roots the roots.
 	 * @param toolsChangeConsumers the tools change consumers.
 	 * @param resourcesChangeConsumers the resources change consumers.
@@ -68,7 +70,8 @@ class McpClientFeatures {
 	 * in the {@code requestedSchema}.
 	 */
 	record Async(McpSchema.Implementation clientInfo, McpSchema.ClientCapabilities clientCapabilities,
-			Map<String, McpSchema.Root> roots, List<Function<List<McpSchema.Tool>, Mono<Void>>> toolsChangeConsumers,
+			Map<String, Object> initializeRequestMeta, Map<String, McpSchema.Root> roots,
+			List<Function<List<McpSchema.Tool>, Mono<Void>>> toolsChangeConsumers,
 			List<Function<List<McpSchema.Resource>, Mono<Void>>> resourcesChangeConsumers,
 			List<Function<List<McpSchema.ResourceContents>, Mono<Void>>> resourcesUpdateConsumers,
 			List<Function<List<McpSchema.Prompt>, Mono<Void>>> promptsChangeConsumers,
@@ -110,6 +113,43 @@ class McpClientFeatures {
 				Function<McpSchema.ElicitUrlRequest, Mono<McpSchema.ElicitResult>> urlElicitationHandler,
 				boolean enableCallToolSchemaCaching, boolean applyElicitationDefaults) {
 
+			this(clientInfo, clientCapabilities, null, roots, toolsChangeConsumers, resourcesChangeConsumers,
+					resourcesUpdateConsumers, promptsChangeConsumers, loggingConsumers, progressConsumers,
+					elicitationCompleteConsumers, samplingHandler, formElicitationHandler, urlElicitationHandler,
+					enableCallToolSchemaCaching, applyElicitationDefaults);
+		}
+
+		/**
+		 * Create an instance and validate the arguments.
+		 * @param clientCapabilities the client capabilities.
+		 * @param initializeRequestMeta metadata to include in the initialize request.
+		 * @param roots the roots.
+		 * @param toolsChangeConsumers the tools change consumers.
+		 * @param resourcesChangeConsumers the resources change consumers.
+		 * @param promptsChangeConsumers the prompts change consumers.
+		 * @param loggingConsumers the logging consumers.
+		 * @param progressConsumers the progress consumers.
+		 * @param samplingHandler the sampling handler.
+		 * @param formElicitationHandler the elicitation handler.
+		 * @param enableCallToolSchemaCaching whether to enable call tool schema caching.
+		 * @param applyElicitationDefaults whether the client should fill in missing
+		 * fields of an accepted {@code ElicitResult.content} with the {@code default}
+		 * values declared in the {@code requestedSchema}.
+		 */
+		public Async(McpSchema.Implementation clientInfo, McpSchema.ClientCapabilities clientCapabilities,
+				Map<String, Object> initializeRequestMeta, Map<String, McpSchema.Root> roots,
+				List<Function<List<McpSchema.Tool>, Mono<Void>>> toolsChangeConsumers,
+				List<Function<List<McpSchema.Resource>, Mono<Void>>> resourcesChangeConsumers,
+				List<Function<List<McpSchema.ResourceContents>, Mono<Void>>> resourcesUpdateConsumers,
+				List<Function<List<McpSchema.Prompt>, Mono<Void>>> promptsChangeConsumers,
+				List<Function<McpSchema.LoggingMessageNotification, Mono<Void>>> loggingConsumers,
+				List<Function<McpSchema.ProgressNotification, Mono<Void>>> progressConsumers,
+				List<Function<McpSchema.ElicitationCompleteNotification, Mono<Void>>> elicitationCompleteConsumers,
+				Function<McpSchema.CreateMessageRequest, Mono<McpSchema.CreateMessageResult>> samplingHandler,
+				Function<McpSchema.ElicitFormRequest, Mono<McpSchema.ElicitResult>> formElicitationHandler,
+				Function<McpSchema.ElicitUrlRequest, Mono<McpSchema.ElicitResult>> urlElicitationHandler,
+				boolean enableCallToolSchemaCaching, boolean applyElicitationDefaults) {
+
 			Assert.notNull(clientInfo, "Client info must not be null");
 			this.clientInfo = clientInfo;
 			this.clientCapabilities = (clientCapabilities != null) ? clientCapabilities
@@ -117,6 +157,7 @@ class McpClientFeatures {
 							!Utils.isEmpty(roots) ? new McpSchema.ClientCapabilities.RootCapabilities(false) : null,
 							samplingHandler != null ? new McpSchema.ClientCapabilities.Sampling() : null,
 							elicitationCapabilities(formElicitationHandler, urlElicitationHandler));
+			this.initializeRequestMeta = copyInitializeRequestMeta(initializeRequestMeta);
 			this.roots = roots != null ? new ConcurrentHashMap<>(roots) : new ConcurrentHashMap<>();
 
 			this.toolsChangeConsumers = toolsChangeConsumers != null ? toolsChangeConsumers : List.of();
@@ -219,11 +260,11 @@ class McpClientFeatures {
 							.subscribeOn(Schedulers.boundedElastic())
 						: null;
 
-			return new Async(syncSpec.clientInfo(), syncSpec.clientCapabilities(), syncSpec.roots(),
-					toolsChangeConsumers, resourcesChangeConsumers, resourcesUpdateConsumers, promptsChangeConsumers,
-					loggingConsumers, progressConsumers, elicitationCompleteConsumers, samplingHandler,
-					formElicitationHandler, urlElicitationHandler, syncSpec.enableCallToolSchemaCaching,
-					syncSpec.applyElicitationDefaults);
+			return new Async(syncSpec.clientInfo(), syncSpec.clientCapabilities(), syncSpec.initializeRequestMeta(),
+					syncSpec.roots(), toolsChangeConsumers, resourcesChangeConsumers, resourcesUpdateConsumers,
+					promptsChangeConsumers, loggingConsumers, progressConsumers, elicitationCompleteConsumers,
+					samplingHandler, formElicitationHandler, urlElicitationHandler,
+					syncSpec.enableCallToolSchemaCaching, syncSpec.applyElicitationDefaults);
 		}
 
 	}
@@ -234,6 +275,7 @@ class McpClientFeatures {
 	 *
 	 * @param clientInfo the client implementation information.
 	 * @param clientCapabilities the client capabilities.
+	 * @param initializeRequestMeta metadata to include in the initialize request.
 	 * @param roots the roots.
 	 * @param toolsChangeConsumers the tools change consumers.
 	 * @param resourcesChangeConsumers the resources change consumers.
@@ -248,7 +290,8 @@ class McpClientFeatures {
 	 * in the {@code requestedSchema}.
 	 */
 	public record Sync(McpSchema.Implementation clientInfo, McpSchema.ClientCapabilities clientCapabilities,
-			Map<String, McpSchema.Root> roots, List<Consumer<List<McpSchema.Tool>>> toolsChangeConsumers,
+			Map<String, Object> initializeRequestMeta, Map<String, McpSchema.Root> roots,
+			List<Consumer<List<McpSchema.Tool>>> toolsChangeConsumers,
 			List<Consumer<List<McpSchema.Resource>>> resourcesChangeConsumers,
 			List<Consumer<List<McpSchema.ResourceContents>>> resourcesUpdateConsumers,
 			List<Consumer<List<McpSchema.Prompt>>> promptsChangeConsumers,
@@ -291,6 +334,45 @@ class McpClientFeatures {
 				Function<McpSchema.ElicitUrlRequest, McpSchema.ElicitResult> urlElicitationHandler,
 				boolean enableCallToolSchemaCaching, boolean applyElicitationDefaults) {
 
+			this(clientInfo, clientCapabilities, null, roots, toolsChangeConsumers, resourcesChangeConsumers,
+					resourcesUpdateConsumers, promptsChangeConsumers, loggingConsumers, progressConsumers,
+					elicitationCompleteConsumers, samplingHandler, formElicitationHandler, urlElicitationHandler,
+					enableCallToolSchemaCaching, applyElicitationDefaults);
+		}
+
+		/**
+		 * Create an instance and validate the arguments.
+		 * @param clientInfo the client implementation information.
+		 * @param clientCapabilities the client capabilities.
+		 * @param initializeRequestMeta metadata to include in the initialize request.
+		 * @param roots the roots.
+		 * @param toolsChangeConsumers the tools change consumers.
+		 * @param resourcesChangeConsumers the resources change consumers.
+		 * @param resourcesUpdateConsumers the resource update consumers.
+		 * @param promptsChangeConsumers the prompts change consumers.
+		 * @param loggingConsumers the logging consumers.
+		 * @param progressConsumers the progress consumers.
+		 * @param samplingHandler the sampling handler.
+		 * @param formElicitationHandler the elicitation handler.
+		 * @param enableCallToolSchemaCaching whether to enable call tool schema caching.
+		 * @param applyElicitationDefaults whether the client should fill in missing
+		 * fields of an accepted {@code ElicitResult.content} with the {@code default}
+		 * values declared in the {@code requestedSchema}.
+		 */
+		public Sync(McpSchema.Implementation clientInfo, McpSchema.ClientCapabilities clientCapabilities,
+				Map<String, Object> initializeRequestMeta, Map<String, McpSchema.Root> roots,
+				List<Consumer<List<McpSchema.Tool>>> toolsChangeConsumers,
+				List<Consumer<List<McpSchema.Resource>>> resourcesChangeConsumers,
+				List<Consumer<List<McpSchema.ResourceContents>>> resourcesUpdateConsumers,
+				List<Consumer<List<McpSchema.Prompt>>> promptsChangeConsumers,
+				List<Consumer<McpSchema.LoggingMessageNotification>> loggingConsumers,
+				List<Consumer<McpSchema.ProgressNotification>> progressConsumers,
+				List<Consumer<McpSchema.ElicitationCompleteNotification>> elicitationCompleteConsumers,
+				Function<McpSchema.CreateMessageRequest, McpSchema.CreateMessageResult> samplingHandler,
+				Function<McpSchema.ElicitFormRequest, McpSchema.ElicitResult> formElicitationHandler,
+				Function<McpSchema.ElicitUrlRequest, McpSchema.ElicitResult> urlElicitationHandler,
+				boolean enableCallToolSchemaCaching, boolean applyElicitationDefaults) {
+
 			Assert.notNull(clientInfo, "Client info must not be null");
 			this.clientInfo = clientInfo;
 			this.clientCapabilities = (clientCapabilities != null) ? clientCapabilities
@@ -298,6 +380,7 @@ class McpClientFeatures {
 							!Utils.isEmpty(roots) ? new McpSchema.ClientCapabilities.RootCapabilities(false) : null,
 							samplingHandler != null ? new McpSchema.ClientCapabilities.Sampling() : null,
 							elicitationCapabilities(formElicitationHandler, urlElicitationHandler));
+			this.initializeRequestMeta = copyInitializeRequestMeta(initializeRequestMeta);
 			this.roots = roots != null ? new HashMap<>(roots) : new HashMap<>();
 
 			this.toolsChangeConsumers = toolsChangeConsumers != null ? toolsChangeConsumers : List.of();
@@ -331,6 +414,10 @@ class McpClientFeatures {
 					resourcesUpdateConsumers, promptsChangeConsumers, loggingConsumers, List.of(), List.of(),
 					samplingHandler, formElicitationHandler, urlElicitationHandler, false, false);
 		}
+	}
+
+	private static Map<String, Object> copyInitializeRequestMeta(Map<String, Object> initializeRequestMeta) {
+		return initializeRequestMeta != null ? Collections.unmodifiableMap(new HashMap<>(initializeRequestMeta)) : null;
 	}
 
 	private static McpSchema.ClientCapabilities.Elicitation elicitationCapabilities(

--- a/mcp-core/src/test/java/io/modelcontextprotocol/client/LifecycleInitializerTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/client/LifecycleInitializerTests.java
@@ -5,7 +5,9 @@
 package io.modelcontextprotocol.client;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -147,6 +149,34 @@ class LifecycleInitializerTests {
 				assertThat(capturedRequest.get().clientInfo()).isEqualTo(CLIENT_INFO);
 			})
 			.verifyComplete();
+	}
+
+	@Test
+	void shouldIncludeInitializeRequestMeta() {
+		Map<String, Object> initializeRequestMeta = new HashMap<>();
+		initializeRequestMeta.put("traceId", "abc-123");
+		initializeRequestMeta.put("client", Map.of("name", "test-client"));
+
+		LifecycleInitializer initializerWithMeta = new LifecycleInitializer(CLIENT_CAPABILITIES, CLIENT_INFO,
+				initializeRequestMeta, PROTOCOL_VERSIONS, INITIALIZATION_TIMEOUT, mockSessionSupplier,
+				mockPostInitializationHook);
+		initializeRequestMeta.put("traceId", "changed");
+
+		AtomicReference<McpSchema.InitializeRequest> capturedRequest = new AtomicReference<>();
+
+		when(mockClientSession.sendRequest(eq(McpSchema.METHOD_INITIALIZE), any(), any())).thenAnswer(invocation -> {
+			capturedRequest.set((McpSchema.InitializeRequest) invocation.getArgument(1));
+			return Mono.just(MOCK_INIT_RESULT);
+		});
+
+		StepVerifier.create(initializerWithMeta.withInitialization("test", init -> Mono.just(init.initializeResult())))
+			.expectNext(MOCK_INIT_RESULT)
+			.verifyComplete();
+
+		assertThat(capturedRequest.get().meta()).containsEntry("traceId", "abc-123")
+			.containsEntry("client", Map.of("name", "test-client"));
+		assertThatThrownBy(() -> capturedRequest.get().meta().put("new", "value"))
+			.isInstanceOf(UnsupportedOperationException.class);
 	}
 
 	@Test

--- a/mcp-core/src/test/java/io/modelcontextprotocol/client/McpAsyncClientTest.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/client/McpAsyncClientTest.java
@@ -4,14 +4,20 @@
 
 package io.modelcontextprotocol.client;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
+import io.modelcontextprotocol.MockMcpClientTransport;
 import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.ProtocolVersions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -26,6 +32,36 @@ class McpAsyncClientTest {
 
 	@Nested
 	class ClientBuilder {
+
+		@Test
+		void initializeRequestMetaIsPropagatedToInitializeRequest() {
+			AtomicReference<McpSchema.InitializeRequest> capturedRequest = new AtomicReference<>();
+			McpSchema.InitializeResult initializeResult = McpSchema.InitializeResult
+				.builder(ProtocolVersions.MCP_2025_11_25, McpSchema.ServerCapabilities.builder().build(),
+						McpSchema.Implementation.builder("test-server", "1.0.0").build())
+				.build();
+			MockMcpClientTransport transport = new MockMcpClientTransport((mockTransport, message) -> {
+				if (message instanceof McpSchema.JSONRPCRequest request
+						&& McpSchema.METHOD_INITIALIZE.equals(request.method())) {
+					capturedRequest.set((McpSchema.InitializeRequest) request.params());
+					mockTransport
+						.simulateIncomingMessage(McpSchema.JSONRPCResponse.result(request.id(), initializeResult));
+				}
+			});
+
+			Map<String, Object> initializeRequestMeta = new HashMap<>();
+			initializeRequestMeta.put("traceId", "abc-123");
+
+			McpAsyncClient client = McpClient.async(transport)
+				.initializeRequestMeta(initializeRequestMeta)
+				.jsonSchemaValidator(mock(JsonSchemaValidator.class))
+				.build();
+			initializeRequestMeta.put("traceId", "changed");
+
+			StepVerifier.create(client.initialize()).expectNext(initializeResult).verifyComplete();
+
+			assertThat(capturedRequest.get().meta()).containsEntry("traceId", "abc-123");
+		}
 
 		@Nested
 		class ElicitationHandlers {

--- a/mcp-core/src/test/java/io/modelcontextprotocol/client/McpSyncClientTest.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/client/McpSyncClientTest.java
@@ -4,11 +4,16 @@
 
 package io.modelcontextprotocol.client;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
+import io.modelcontextprotocol.MockMcpClientTransport;
 import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.ProtocolVersions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -20,6 +25,34 @@ import static org.mockito.Mockito.when;
  * @author Daniel Garnier-Moiroux
  */
 class McpSyncClientTest {
+
+	@Test
+	void initializeRequestMetaIsPropagatedToInitializeRequest() {
+		AtomicReference<McpSchema.InitializeRequest> capturedRequest = new AtomicReference<>();
+		McpSchema.InitializeResult initializeResult = McpSchema.InitializeResult
+			.builder(ProtocolVersions.MCP_2025_11_25, McpSchema.ServerCapabilities.builder().build(),
+					McpSchema.Implementation.builder("test-server", "1.0.0").build())
+			.build();
+		MockMcpClientTransport transport = new MockMcpClientTransport((mockTransport, message) -> {
+			if (message instanceof McpSchema.JSONRPCRequest request
+					&& McpSchema.METHOD_INITIALIZE.equals(request.method())) {
+				capturedRequest.set((McpSchema.InitializeRequest) request.params());
+				mockTransport.simulateIncomingMessage(McpSchema.JSONRPCResponse.result(request.id(), initializeResult));
+			}
+		});
+
+		Map<String, Object> initializeRequestMeta = new HashMap<>();
+		initializeRequestMeta.put("traceId", "abc-123");
+
+		McpSyncClient client = McpClient.sync(transport)
+			.initializeRequestMeta(initializeRequestMeta)
+			.jsonSchemaValidator(mock(JsonSchemaValidator.class))
+			.build();
+		initializeRequestMeta.put("traceId", "changed");
+
+		assertThat(client.initialize()).isEqualTo(initializeResult);
+		assertThat(capturedRequest.get().meta()).containsEntry("traceId", "abc-123");
+	}
 
 	@Nested
 	class ClientCapabilities {


### PR DESCRIPTION
## Summary
- add optional `_meta` support for MCP initialize requests
- expose initialize-request metadata on async and sync client builders
- propagate metadata through lifecycle initialization while defensively copying user-provided maps

## Validation
- `.\mvnw.cmd -pl mcp-core "-Dtest=LifecycleInitializerTests,McpAsyncClientTest,McpSyncClientTest" test`
- Result: `BUILD SUCCESS`; `Tests run: 37, Failures: 0, Errors: 0, Skipped: 0`

Fixes #940