### PR TITLE
fix(client): ignore unknown SSE fields instead of erroring the stream

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/ResponseSubscribers.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/ResponseSubscribers.java
@@ -15,7 +15,6 @@ import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.modelcontextprotocol.spec.McpTransportException;
 import reactor.core.publisher.BaseSubscriber;
 import reactor.core.publisher.FluxSink;
 
@@ -180,10 +179,11 @@ class ResponseSubscribers {
 					upstream().request(1);
 				}
 				else {
-					// If the response is not successful, emit an error
-					this.sink.error(new McpTransportException(
-							"Invalid SSE response. Status code: " + this.responseInfo.statusCode() + " Line: " + line));
-
+					// Per the SSE spec, fields the client does not recognize (e.g.
+					// "retry:")
+					// must be ignored rather than treated as an invalid response.
+					logger.debug("Ignoring unrecognized SSE line: {}", line);
+					upstream().request(1);
 				}
 			}
 		}

--- a/mcp-core/src/test/java/io/modelcontextprotocol/client/transport/ResponseSubscribersTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/client/transport/ResponseSubscribersTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+package io.modelcontextprotocol.client.transport;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import io.modelcontextprotocol.client.transport.ResponseSubscribers.ResponseEvent;
+import io.modelcontextprotocol.client.transport.ResponseSubscribers.SseResponseEvent;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+
+/**
+ * Tests for {@link ResponseSubscribers} SSE line parsing.
+ *
+ * @author Iman Rastkhadiv
+ */
+class ResponseSubscribersTests {
+
+	private static HttpResponse.ResponseInfo responseInfo(int statusCode) {
+		return new HttpResponse.ResponseInfo() {
+			@Override
+			public int statusCode() {
+				return statusCode;
+			}
+
+			@Override
+			public HttpHeaders headers() {
+				return HttpHeaders.of(Map.of(), (k, v) -> true);
+			}
+
+			@Override
+			public HttpClient.Version version() {
+				return HttpClient.Version.HTTP_1_1;
+			}
+		};
+	}
+
+	private List<ResponseEvent> parse(List<String> lines) {
+		return Flux
+			.<ResponseEvent>create(sink -> Flux.fromIterable(lines)
+				.subscribe(new ResponseSubscribers.SseLineSubscriber(responseInfo(200), sink)))
+			.collectList()
+			.block(Duration.ofSeconds(5));
+	}
+
+	@Test
+	void retryFieldIsNotRejected() {
+		// `retry:` is a valid SSE field. The client does not support resumability, but a
+		// server may still send it; it must be ignored, not error the stream.
+		List<ResponseEvent> events = parse(List.of("id: event-1", "retry: 500", "data: hello", ""));
+
+		assertThat(events).singleElement().asInstanceOf(type(SseResponseEvent.class)).satisfies(e -> {
+			assertThat(e.sseEvent().id()).isEqualTo("event-1");
+			assertThat(e.sseEvent().data()).isEqualTo("hello");
+		});
+	}
+
+	@Test
+	void unknownFieldIsIgnored() {
+		// Per the SSE spec, fields the client does not recognize must be ignored rather
+		// than treated as an invalid response.
+		List<ResponseEvent> events = parse(List.of("id: event-1", "someFutureField: whatever", "data: hello", ""));
+
+		assertThat(events).singleElement().asInstanceOf(type(SseResponseEvent.class)).satisfies(e -> {
+			assertThat(e.sseEvent().id()).isEqualTo("event-1");
+			assertThat(e.sseEvent().data()).isEqualTo("hello");
+		});
+	}
+
+}


### PR DESCRIPTION
## Summary
The client SSE line parser in `ResponseSubscribers` errored the whole stream on any line it didn't recognize — e.g. the standard `retry:` field — throwing:

```
io.modelcontextprotocol.spec.McpTransportException: Invalid SSE response. Status code: 200 Line: retry: 500
```

Per the [SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html), a client must **ignore fields it does not recognize** rather than treat them as an invalid response. This change makes the parser log unrecognized lines at `debug` and continue.

This addresses the "ignore unknown fields" ask in #1047. As discussed there, resumability / `retry:` reconnection timing is intentionally **not** implemented (it is being removed in the 2026-07-28 spec).

## Changes
- `ResponseSubscribers.SseLineSubscriber`: the fall-through `else` now ignores unrecognized SSE lines instead of emitting `McpTransportException`. Removed the now-unused import.
- No API change.

## Testing
- New `ResponseSubscribersTests` (2 tests): a `retry:` line no longer errors the stream and the event still parses; an arbitrary unknown field is ignored.
- `./mvnw test -pl mcp-core` → green.

## Notes
- The conformance `sse-retry` scenario stays listed in `conformance-tests/conformance-baseline.yml`: this fix removes the crash, but the scenario's retry-timing check is a resumability behavior that is intentionally out of scope.

Refs #1047
