### PR TITLE
Deprecate roots, sampling, and logging APIs

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/McpAsyncClient.java
@@ -492,7 +492,9 @@ public class McpAsyncClient {
 	 * Adds a new root to the client's root list.
 	 * @param root The root to add.
 	 * @return A Mono that completes when the root is added and notifications are sent.
+	 * @deprecated Roots are deprecated in the 2026-07-28 MCP specification.
 	 */
+	@Deprecated
 	public Mono<Void> addRoot(Root root) {
 
 		if (root == null) {
@@ -524,7 +526,9 @@ public class McpAsyncClient {
 	 * Removes a root from the client's root list.
 	 * @param rootUri The URI of the root to remove.
 	 * @return A Mono that completes when the root is removed and notifications are sent.
+	 * @deprecated Roots are deprecated in the 2026-07-28 MCP specification.
 	 */
+	@Deprecated
 	public Mono<Void> removeRoot(String rootUri) {
 
 		if (rootUri == null) {
@@ -555,7 +559,9 @@ public class McpAsyncClient {
 	 * methods automatically send the roots/list_changed notification if the client is in
 	 * an initialized state.
 	 * @return A Mono that completes when the notification is sent.
+	 * @deprecated Roots are deprecated in the 2026-07-28 MCP specification.
 	 */
+	@Deprecated
 	public Mono<Void> rootsListChangedNotification() {
 		return this.initializer.withInitialization("sending roots list changed notification",
 				init -> init.mcpSession().sendNotification(McpSchema.METHOD_NOTIFICATION_ROOTS_LIST_CHANGED));
@@ -1110,7 +1116,9 @@ public class McpAsyncClient {
 	 * @param loggingLevel The minimum logging level to receive.
 	 * @return A Mono that completes when the logging level is set.
 	 * @see McpSchema.LoggingLevel
+	 * @deprecated Logging is deprecated in the 2026-07-28 MCP specification.
 	 */
+	@Deprecated
 	public Mono<Void> setLoggingLevel(LoggingLevel loggingLevel) {
 		if (loggingLevel == null) {
 			return Mono.error(new IllegalArgumentException("Logging level must not be null"));

--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/McpClient.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/McpClient.java
@@ -270,7 +270,9 @@ public interface McpClient {
 		 * @param roots A list of root definitions. Must not be null.
 		 * @return This builder instance for method chaining
 		 * @throws IllegalArgumentException if roots is null
+		 * @deprecated Roots are deprecated in the 2026-07-28 MCP specification.
 		 */
+		@Deprecated
 		public SyncSpec roots(List<Root> roots) {
 			Assert.notNull(roots, "Roots must not be null");
 			for (Root root : roots) {
@@ -286,7 +288,9 @@ public interface McpClient {
 		 * @return This builder instance for method chaining
 		 * @throws IllegalArgumentException if roots is null
 		 * @see #roots(List)
+		 * @deprecated Roots are deprecated in the 2026-07-28 MCP specification.
 		 */
+		@Deprecated
 		public SyncSpec roots(Root... roots) {
 			Assert.notNull(roots, "Roots must not be null");
 			for (Root root : roots) {
@@ -303,7 +307,9 @@ public interface McpClient {
 		 * results. Must not be null.
 		 * @return This builder instance for method chaining
 		 * @throws IllegalArgumentException if samplingHandler is null
+		 * @deprecated Sampling is deprecated in the 2026-07-28 MCP specification.
 		 */
+		@Deprecated
 		public SyncSpec sampling(Function<CreateMessageRequest, CreateMessageResult> samplingHandler) {
 			Assert.notNull(samplingHandler, "Sampling handler must not be null");
 			this.samplingHandler = samplingHandler;
@@ -408,7 +414,9 @@ public interface McpClient {
 		 * @param loggingConsumer A consumer that receives logging messages. Must not be
 		 * null.
 		 * @return This builder instance for method chaining
+		 * @deprecated Logging is deprecated in the 2026-07-28 MCP specification.
 		 */
+		@Deprecated
 		public SyncSpec loggingConsumer(Consumer<McpSchema.LoggingMessageNotification> loggingConsumer) {
 			Assert.notNull(loggingConsumer, "Logging consumer must not be null");
 			this.loggingConsumers.add(loggingConsumer);
@@ -422,7 +430,9 @@ public interface McpClient {
 		 * @param loggingConsumers A list of consumers that receive logging messages. Must
 		 * not be null.
 		 * @return This builder instance for method chaining
+		 * @deprecated Logging is deprecated in the 2026-07-28 MCP specification.
 		 */
+		@Deprecated
 		public SyncSpec loggingConsumers(List<Consumer<McpSchema.LoggingMessageNotification>> loggingConsumers) {
 			Assert.notNull(loggingConsumers, "Logging consumers must not be null");
 			this.loggingConsumers.addAll(loggingConsumers);
@@ -689,7 +699,9 @@ public interface McpClient {
 		 * @param roots A list of root definitions. Must not be null.
 		 * @return This builder instance for method chaining
 		 * @throws IllegalArgumentException if roots is null
+		 * @deprecated Roots are deprecated in the 2026-07-28 MCP specification.
 		 */
+		@Deprecated
 		public AsyncSpec roots(List<Root> roots) {
 			Assert.notNull(roots, "Roots must not be null");
 			for (Root root : roots) {
@@ -705,7 +717,9 @@ public interface McpClient {
 		 * @return This builder instance for method chaining
 		 * @throws IllegalArgumentException if roots is null
 		 * @see #roots(List)
+		 * @deprecated Roots are deprecated in the 2026-07-28 MCP specification.
 		 */
+		@Deprecated
 		public AsyncSpec roots(Root... roots) {
 			Assert.notNull(roots, "Roots must not be null");
 			for (Root root : roots) {
@@ -722,7 +736,9 @@ public interface McpClient {
 		 * results. Must not be null.
 		 * @return This builder instance for method chaining
 		 * @throws IllegalArgumentException if samplingHandler is null
+		 * @deprecated Sampling is deprecated in the 2026-07-28 MCP specification.
 		 */
+		@Deprecated
 		public AsyncSpec sampling(Function<CreateMessageRequest, Mono<CreateMessageResult>> samplingHandler) {
 			Assert.notNull(samplingHandler, "Sampling handler must not be null");
 			this.samplingHandler = samplingHandler;
@@ -829,7 +845,9 @@ public interface McpClient {
 		 * @param loggingConsumer A consumer that receives logging messages. Must not be
 		 * null.
 		 * @return This builder instance for method chaining
+		 * @deprecated Logging is deprecated in the 2026-07-28 MCP specification.
 		 */
+		@Deprecated
 		public AsyncSpec loggingConsumer(Function<McpSchema.LoggingMessageNotification, Mono<Void>> loggingConsumer) {
 			Assert.notNull(loggingConsumer, "Logging consumer must not be null");
 			this.loggingConsumers.add(loggingConsumer);
@@ -843,7 +861,9 @@ public interface McpClient {
 		 * @param loggingConsumers A list of consumers that receive logging messages. Must
 		 * not be null.
 		 * @return This builder instance for method chaining
+		 * @deprecated Logging is deprecated in the 2026-07-28 MCP specification.
 		 */
+		@Deprecated
 		public AsyncSpec loggingConsumers(
 				List<Function<McpSchema.LoggingMessageNotification, Mono<Void>>> loggingConsumers) {
 			Assert.notNull(loggingConsumers, "Logging consumers must not be null");

--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/McpClientFeatures.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/McpClientFeatures.java
@@ -68,14 +68,15 @@ class McpClientFeatures {
 	 * in the {@code requestedSchema}.
 	 */
 	record Async(McpSchema.Implementation clientInfo, McpSchema.ClientCapabilities clientCapabilities,
-			Map<String, McpSchema.Root> roots, List<Function<List<McpSchema.Tool>, Mono<Void>>> toolsChangeConsumers,
+			@Deprecated Map<String, McpSchema.Root> roots,
+			List<Function<List<McpSchema.Tool>, Mono<Void>>> toolsChangeConsumers,
 			List<Function<List<McpSchema.Resource>, Mono<Void>>> resourcesChangeConsumers,
 			List<Function<List<McpSchema.ResourceContents>, Mono<Void>>> resourcesUpdateConsumers,
 			List<Function<List<McpSchema.Prompt>, Mono<Void>>> promptsChangeConsumers,
-			List<Function<McpSchema.LoggingMessageNotification, Mono<Void>>> loggingConsumers,
+			@Deprecated List<Function<McpSchema.LoggingMessageNotification, Mono<Void>>> loggingConsumers,
 			List<Function<McpSchema.ProgressNotification, Mono<Void>>> progressConsumers,
 			List<Function<McpSchema.ElicitationCompleteNotification, Mono<Void>>> elicitationCompleteConsumers,
-			Function<McpSchema.CreateMessageRequest, Mono<McpSchema.CreateMessageResult>> samplingHandler,
+			@Deprecated Function<McpSchema.CreateMessageRequest, Mono<McpSchema.CreateMessageResult>> samplingHandler,
 			Function<McpSchema.ElicitFormRequest, Mono<McpSchema.ElicitResult>> formElicitationHandler,
 			Function<McpSchema.ElicitUrlRequest, Mono<McpSchema.ElicitResult>> urlElicitationHandler,
 			boolean enableCallToolSchemaCaching, boolean applyElicitationDefaults) {
@@ -95,7 +96,10 @@ class McpClientFeatures {
 		 * @param applyElicitationDefaults whether the client should fill in missing
 		 * fields of an accepted {@code ElicitResult.content} with the {@code default}
 		 * values declared in the {@code requestedSchema}.
+		 * @deprecated Roots, sampling, and logging are deprecated in the 2026-07-28 MCP
+		 * specification.
 		 */
+		@Deprecated
 		public Async(McpSchema.Implementation clientInfo, McpSchema.ClientCapabilities clientCapabilities,
 				Map<String, McpSchema.Root> roots,
 				List<Function<List<McpSchema.Tool>, Mono<Void>>> toolsChangeConsumers,
@@ -137,6 +141,7 @@ class McpClientFeatures {
 		/**
 		 * @deprecated Only exists for backwards-compatibility purposes.
 		 */
+		@Deprecated
 		public Async(McpSchema.Implementation clientInfo, McpSchema.ClientCapabilities clientCapabilities,
 				Map<String, McpSchema.Root> roots,
 				List<Function<List<McpSchema.Tool>, Mono<Void>>> toolsChangeConsumers,
@@ -248,14 +253,14 @@ class McpClientFeatures {
 	 * in the {@code requestedSchema}.
 	 */
 	public record Sync(McpSchema.Implementation clientInfo, McpSchema.ClientCapabilities clientCapabilities,
-			Map<String, McpSchema.Root> roots, List<Consumer<List<McpSchema.Tool>>> toolsChangeConsumers,
+			@Deprecated Map<String, McpSchema.Root> roots, List<Consumer<List<McpSchema.Tool>>> toolsChangeConsumers,
 			List<Consumer<List<McpSchema.Resource>>> resourcesChangeConsumers,
 			List<Consumer<List<McpSchema.ResourceContents>>> resourcesUpdateConsumers,
 			List<Consumer<List<McpSchema.Prompt>>> promptsChangeConsumers,
-			List<Consumer<McpSchema.LoggingMessageNotification>> loggingConsumers,
+			@Deprecated List<Consumer<McpSchema.LoggingMessageNotification>> loggingConsumers,
 			List<Consumer<McpSchema.ProgressNotification>> progressConsumers,
 			List<Consumer<McpSchema.ElicitationCompleteNotification>> elicitationCompleteConsumers,
-			Function<McpSchema.CreateMessageRequest, McpSchema.CreateMessageResult> samplingHandler,
+			@Deprecated Function<McpSchema.CreateMessageRequest, McpSchema.CreateMessageResult> samplingHandler,
 			Function<McpSchema.ElicitFormRequest, McpSchema.ElicitResult> formElicitationHandler,
 			Function<McpSchema.ElicitUrlRequest, McpSchema.ElicitResult> urlElicitationHandler,
 			boolean enableCallToolSchemaCaching, boolean applyElicitationDefaults) {
@@ -277,7 +282,10 @@ class McpClientFeatures {
 		 * @param applyElicitationDefaults whether the client should fill in missing
 		 * fields of an accepted {@code ElicitResult.content} with the {@code default}
 		 * values declared in the {@code requestedSchema}.
+		 * @deprecated Roots, sampling, and logging are deprecated in the 2026-07-28 MCP
+		 * specification.
 		 */
+		@Deprecated
 		public Sync(McpSchema.Implementation clientInfo, McpSchema.ClientCapabilities clientCapabilities,
 				Map<String, McpSchema.Root> roots, List<Consumer<List<McpSchema.Tool>>> toolsChangeConsumers,
 				List<Consumer<List<McpSchema.Resource>>> resourcesChangeConsumers,
@@ -318,6 +326,7 @@ class McpClientFeatures {
 		/**
 		 * @deprecated Only exists for backwards-compatibility purposes.
 		 */
+		@Deprecated
 		public Sync(McpSchema.Implementation clientInfo, McpSchema.ClientCapabilities clientCapabilities,
 				Map<String, McpSchema.Root> roots, List<Consumer<List<McpSchema.Tool>>> toolsChangeConsumers,
 				List<Consumer<List<McpSchema.Resource>>> resourcesChangeConsumers,

--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/McpSyncClient.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/McpSyncClient.java
@@ -192,21 +192,27 @@ public class McpSyncClient implements AutoCloseable {
 
 	/**
 	 * Send a roots/list_changed notification.
+	 * @deprecated Roots are deprecated in the 2026-07-28 MCP specification.
 	 */
+	@Deprecated
 	public void rootsListChangedNotification() {
 		withProvidedContext(this.delegate.rootsListChangedNotification()).block();
 	}
 
 	/**
 	 * Add a roots dynamically.
+	 * @deprecated Roots are deprecated in the 2026-07-28 MCP specification.
 	 */
+	@Deprecated
 	public void addRoot(McpSchema.Root root) {
 		this.delegate.addRoot(root).block();
 	}
 
 	/**
 	 * Remove a root dynamically.
+	 * @deprecated Roots are deprecated in the 2026-07-28 MCP specification.
 	 */
+	@Deprecated
 	public void removeRoot(String rootUri) {
 		this.delegate.removeRoot(rootUri).block();
 	}
@@ -426,7 +432,9 @@ public class McpSyncClient implements AutoCloseable {
 	/**
 	 * Client can set the minimum logging level it wants to receive from the server.
 	 * @param loggingLevel the min logging level
+	 * @deprecated Logging is deprecated in the 2026-07-28 MCP specification.
 	 */
+	@Deprecated
 	public void setLoggingLevel(McpSchema.LoggingLevel loggingLevel) {
 		withProvidedContext(this.delegate.setLoggingLevel(loggingLevel)).block();
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
@@ -234,7 +234,9 @@ public class McpAsyncServerExchange {
 	 * minimum logging level will be filtered out.
 	 * @param loggingMessageNotification The logging message to send
 	 * @return A Mono that completes when the notification has been sent
+	 * @deprecated Logging is deprecated in the 2026-07-28 MCP specification.
 	 */
+	@Deprecated
 	public Mono<Void> loggingNotification(LoggingMessageNotification loggingMessageNotification) {
 
 		if (loggingMessageNotification == null) {

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServer.java
@@ -745,7 +745,9 @@ public interface McpServer {
 		 * interact with the connected client. The second argument is the list of roots.
 		 * @return This builder instance for method chaining
 		 * @throws IllegalArgumentException if consumer is null
+		 * @deprecated Roots are deprecated in the 2026-07-28 MCP specification.
 		 */
+		@Deprecated
 		public AsyncSpecification<S> rootsChangeHandler(
 				BiFunction<McpAsyncServerExchange, List<McpSchema.Root>, Mono<Void>> handler) {
 			Assert.notNull(handler, "Consumer must not be null");
@@ -761,7 +763,9 @@ public interface McpServer {
 		 * @return This builder instance for method chaining
 		 * @throws IllegalArgumentException if consumers is null
 		 * @see #rootsChangeHandler(BiFunction)
+		 * @deprecated Roots are deprecated in the 2026-07-28 MCP specification.
 		 */
+		@Deprecated
 		public AsyncSpecification<S> rootsChangeHandlers(
 				List<BiFunction<McpAsyncServerExchange, List<McpSchema.Root>, Mono<Void>>> handlers) {
 			Assert.notNull(handlers, "Handlers list must not be null");
@@ -777,7 +781,9 @@ public interface McpServer {
 		 * @return This builder instance for method chaining
 		 * @throws IllegalArgumentException if consumers is null
 		 * @see #rootsChangeHandlers(List)
+		 * @deprecated Roots are deprecated in the 2026-07-28 MCP specification.
 		 */
+		@Deprecated
 		public AsyncSpecification<S> rootsChangeHandlers(
 				@SuppressWarnings("unchecked") BiFunction<McpAsyncServerExchange, List<McpSchema.Root>, Mono<Void>>... handlers) {
 			Assert.notNull(handlers, "Handlers list must not be null");
@@ -1347,7 +1353,9 @@ public interface McpServer {
 		 * with the connected client. The second argument is the list of roots.
 		 * @return This builder instance for method chaining
 		 * @throws IllegalArgumentException if consumer is null
+		 * @deprecated Roots are deprecated in the 2026-07-28 MCP specification.
 		 */
+		@Deprecated
 		public SyncSpecification<S> rootsChangeHandler(
 				BiConsumer<McpSyncServerExchange, List<McpSchema.Root>> handler) {
 			Assert.notNull(handler, "Consumer must not be null");
@@ -1363,7 +1371,9 @@ public interface McpServer {
 		 * @return This builder instance for method chaining
 		 * @throws IllegalArgumentException if consumers is null
 		 * @see #rootsChangeHandler(BiConsumer)
+		 * @deprecated Roots are deprecated in the 2026-07-28 MCP specification.
 		 */
+		@Deprecated
 		public SyncSpecification<S> rootsChangeHandlers(
 				List<BiConsumer<McpSyncServerExchange, List<McpSchema.Root>>> handlers) {
 			Assert.notNull(handlers, "Handlers list must not be null");
@@ -1379,7 +1389,9 @@ public interface McpServer {
 		 * @return This builder instance for method chaining
 		 * @throws IllegalArgumentException if consumers is null
 		 * @see #rootsChangeHandlers(List)
+		 * @deprecated Roots are deprecated in the 2026-07-28 MCP specification.
 		 */
+		@Deprecated
 		public SyncSpecification<S> rootsChangeHandlers(
 				BiConsumer<McpSyncServerExchange, List<McpSchema.Root>>... handlers) {
 			Assert.notNull(handlers, "Handlers list must not be null");

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServerFeatures.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServerFeatures.java
@@ -44,7 +44,7 @@ public class McpServerFeatures {
 			Map<String, McpServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates,
 			Map<String, McpServerFeatures.AsyncPromptSpecification> prompts,
 			Map<McpSchema.CompleteReference, McpServerFeatures.AsyncCompletionSpecification> completions,
-			List<BiFunction<McpAsyncServerExchange, List<McpSchema.Root>, Mono<Void>>> rootsChangeConsumers,
+			@Deprecated List<BiFunction<McpAsyncServerExchange, List<McpSchema.Root>, Mono<Void>>> rootsChangeConsumers,
 			String instructions) {
 
 		/**
@@ -58,7 +58,10 @@ public class McpServerFeatures {
 		 * @param rootsChangeConsumers The list of consumers that will be notified when
 		 * the roots list changes
 		 * @param instructions The server instructions text
+		 * @deprecated Roots and logging are deprecated in the 2026-07-28 MCP
+		 * specification.
 		 */
+		@Deprecated
 		Async(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
 				List<McpServerFeatures.AsyncToolSpecification> tools, Map<String, AsyncResourceSpecification> resources,
 				Map<String, McpServerFeatures.AsyncResourceTemplateSpecification> resourceTemplates,
@@ -161,7 +164,8 @@ public class McpServerFeatures {
 			Map<String, McpServerFeatures.SyncResourceTemplateSpecification> resourceTemplates,
 			Map<String, McpServerFeatures.SyncPromptSpecification> prompts,
 			Map<McpSchema.CompleteReference, McpServerFeatures.SyncCompletionSpecification> completions,
-			List<BiConsumer<McpSyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumers, String instructions) {
+			@Deprecated List<BiConsumer<McpSyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumers,
+			String instructions) {
 
 		/**
 		 * Create an instance and validate the arguments.
@@ -174,7 +178,10 @@ public class McpServerFeatures {
 		 * @param rootsChangeConsumers The list of consumers that will be notified when
 		 * the roots list changes
 		 * @param instructions The server instructions text
+		 * @deprecated Roots and logging are deprecated in the 2026-07-28 MCP
+		 * specification.
 		 */
+		@Deprecated
 		Sync(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
 				List<McpServerFeatures.SyncToolSpecification> tools,
 				Map<String, McpServerFeatures.SyncResourceSpecification> resources,

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpSyncServerExchange.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpSyncServerExchange.java
@@ -121,7 +121,9 @@ public class McpSyncServerExchange {
 	 * Send a logging message notification to the client. Messages below the current
 	 * minimum logging level will be filtered out.
 	 * @param loggingMessageNotification The logging message to send
+	 * @deprecated Logging is deprecated in the 2026-07-28 MCP specification.
 	 */
+	@Deprecated
 	public void loggingNotification(LoggingMessageNotification loggingMessageNotification) {
 		this.exchange.loggingNotification(loggingMessageNotification).block();
 	}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -98,16 +98,32 @@ public final class McpSchema {
 	public static final String METHOD_COMPLETION_COMPLETE = "completion/complete";
 
 	// Logging Methods
+	/**
+	 * @deprecated Logging is deprecated in the 2026-07-28 MCP specification.
+	 */
+	@Deprecated
 	public static final String METHOD_LOGGING_SET_LEVEL = "logging/setLevel";
 
 	public static final String METHOD_NOTIFICATION_MESSAGE = "notifications/message";
 
 	// Roots Methods
+	/**
+	 * @deprecated Roots are deprecated in the 2026-07-28 MCP specification.
+	 */
+	@Deprecated
 	public static final String METHOD_ROOTS_LIST = "roots/list";
 
+	/**
+	 * @deprecated Roots are deprecated in the 2026-07-28 MCP specification.
+	 */
+	@Deprecated
 	public static final String METHOD_NOTIFICATION_ROOTS_LIST_CHANGED = "notifications/roots/list_changed";
 
 	// Sampling Methods
+	/**
+	 * @deprecated Sampling is deprecated in the 2026-07-28 MCP specification.
+	 */
+	@Deprecated
 	public static final String METHOD_SAMPLING_CREATE_MESSAGE = "sampling/createMessage";
 
 	// Elicitation Methods
@@ -582,7 +598,9 @@ public final class McpSchema {
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ClientCapabilities( // @formatter:off
 		@JsonProperty("experimental") Map<String, Object> experimental,
+		@Deprecated
 		@JsonProperty("roots") RootCapabilities roots,
+		@Deprecated
 		@JsonProperty("sampling") Sampling sampling,
 		@JsonProperty("elicitation") Elicitation elicitation) { // @formatter:on
 
@@ -591,7 +609,9 @@ public final class McpSchema {
 		 *
 		 * @param listChanged Whether the client supports notifications for changes to the
 		 * roots list
+		 * @deprecated Roots are deprecated in the 2026-07-28 MCP specification.
 		 */
+		@Deprecated
 		@JsonInclude(JsonInclude.Include.NON_ABSENT)
 		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record RootCapabilities(@JsonProperty("listChanged") Boolean listChanged) {
@@ -623,7 +643,10 @@ public final class McpSchema {
 		 * servers to leverage AI capabilities—with no server API keys necessary. Servers
 		 * can request text or image-based interactions and optionally include context
 		 * from MCP servers in their prompts.
+		 *
+		 * @deprecated Sampling is deprecated in the 2026-07-28 MCP specification.
 		 */
+		@Deprecated
 		@JsonInclude(JsonInclude.Include.NON_ABSENT)
 		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record Sampling() {
@@ -728,11 +751,19 @@ public final class McpSchema {
 				return this;
 			}
 
+			/**
+			 * @deprecated Roots are deprecated in the 2026-07-28 MCP specification.
+			 */
+			@Deprecated
 			public Builder roots(Boolean listChanged) {
 				this.roots = new RootCapabilities(listChanged);
 				return this;
 			}
 
+			/**
+			 * @deprecated Sampling is deprecated in the 2026-07-28 MCP specification.
+			 */
+			@Deprecated
 			public Builder sampling() {
 				this.sampling = new Sampling();
 				return this;
@@ -791,6 +822,7 @@ public final class McpSchema {
 	public record ServerCapabilities( // @formatter:off
 		@JsonProperty("completions") CompletionCapabilities completions,
 		@JsonProperty("experimental") Map<String, Object> experimental,
+		@Deprecated
 		@JsonProperty("logging") LoggingCapabilities logging,
 		@JsonProperty("prompts") PromptCapabilities prompts,
 		@JsonProperty("resources") ResourceCapabilities resources,
@@ -806,7 +838,10 @@ public final class McpSchema {
 
 		/**
 		 * Present if the server supports sending log messages to the client.
+		 *
+		 * @deprecated Logging is deprecated in the 2026-07-28 MCP specification.
 		 */
+		@Deprecated
 		@JsonInclude(JsonInclude.Include.NON_ABSENT)
 		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record LoggingCapabilities() {
@@ -954,6 +989,10 @@ public final class McpSchema {
 				return this;
 			}
 
+			/**
+			 * @deprecated Logging is deprecated in the 2026-07-28 MCP specification.
+			 */
+			@Deprecated
 			public Builder logging() {
 				this.logging = new LoggingCapabilities();
 				return this;
@@ -3468,7 +3507,9 @@ public final class McpSchema {
 	 * Note: {@code role} and {@code content} are required by the MCP specification.
 	 * Deserialization accepts missing values and substitutes defaults to avoid breaking
 	 * existing integrations that may omit these fields.
+	 * @deprecated Sampling is deprecated in the 2026-07-28 MCP specification.
 	 */
+	@Deprecated
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record SamplingMessage( // @formatter:off
@@ -3547,7 +3588,9 @@ public final class McpSchema {
 	 * Note: {@code messages} and {@code maxTokens} are required by the MCP specification.
 	 * Deserialization accepts missing values and substitutes defaults to avoid breaking
 	 * existing integrations that may omit these fields.
+	 * @deprecated Sampling is deprecated in the 2026-07-28 MCP specification.
 	 */
+	@Deprecated
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record CreateMessageRequest( // @formatter:off
@@ -3730,7 +3773,9 @@ public final class McpSchema {
 	 * @param model The name of the model that generated the message
 	 * @param stopReason The reason why sampling stopped, if known
 	 * @param meta See specification for notes on _meta usage
+	 * @deprecated Sampling is deprecated in the 2026-07-28 MCP specification.
 	 */
+	@Deprecated
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record CreateMessageResult( // @formatter:off
@@ -5326,7 +5371,9 @@ public final class McpSchema {
 	 * Note: {@code level} and {@code data} are required by the MCP specification.
 	 * Deserialization accepts missing values and substitutes defaults to avoid breaking
 	 * existing integrations that may omit these fields.
+	 * @deprecated Logging is deprecated in the 2026-07-28 MCP specification.
 	 */
+	@Deprecated
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record LoggingMessageNotification( // @formatter:off
@@ -5440,7 +5487,10 @@ public final class McpSchema {
 	 * Severity levels for MCP log messages, ordered from least to most severe. The
 	 * numeric {@link #level()} can be used to compare severities. Deserialization is
 	 * case-insensitive and returns {@code null} for unrecognized values.
+	 *
+	 * @deprecated Logging is deprecated in the 2026-07-28 MCP specification.
 	 */
+	@Deprecated
 	public enum LoggingLevel {
 
 	// @formatter:off
@@ -5488,7 +5538,9 @@ public final class McpSchema {
 	 * @param level The level of logging that the client wants to receive from the server.
 	 * The server should send all logs at this level and higher (i.e., more severe) to the
 	 * client as notifications/message
+	 * @deprecated Logging is deprecated in the 2026-07-28 MCP specification.
 	 */
+	@Deprecated
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record SetLevelRequest(@JsonProperty("level") LoggingLevel level) {
@@ -6323,7 +6375,9 @@ public final class McpSchema {
 	 * human-readable identifier for the root, which may be useful for display purposes or
 	 * for referencing the root in other parts of the application.
 	 * @param meta See specification for notes on _meta usage
+	 * @deprecated Roots are deprecated in the 2026-07-28 MCP specification.
 	 */
+	@Deprecated
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record Root( // @formatter:off
@@ -6394,7 +6448,9 @@ public final class McpSchema {
 	 * are more roots available. The client can use this cursor to request the next page
 	 * of results by sending a roots/list request with the cursor parameter set to this
 	 * @param meta See specification for notes on _meta usage
+	 * @deprecated Roots are deprecated in the 2026-07-28 MCP specification.
 	 */
+	@Deprecated
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ListRootsResult( // @formatter:off


### PR DESCRIPTION
Deprecate Roots, Sampling, and Logging APIs for SEP-2577.

## Motivation and Context

Roots, Sampling, and Logging are deprecated in the 2026-07-28 MCP specification release. This change marks the corresponding Java SDK schema types, constants, client APIs, server APIs, and feature configuration surfaces as deprecated while keeping behavior unchanged.

## How Has This Been Tested?

- `mvn clean install` was run with JDK 21 and Docker/Testcontainers enabled.
- The build was resumed from `:mcp-test` after an initial fork interruption.
- Final result: `BUILD SUCCESS`; `mcp-test` [completed](https://github.com/user-attachments/files/29615537/test_result.txt) with 933 tests run, 0 failures, 0 errors, 0 skipped.

## Breaking Changes

None. This is a non-breaking deprecation-only change. Existing APIs remain functional but now emit Java deprecation warnings.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

This change uses standard Java deprecation with `@Deprecated` and Javadoc `@deprecated` tags. No runtime behavior was removed or altered.

Resolves #1012 