### PR TITLE
fix: fail fast on uninitialized server requests

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
@@ -297,6 +297,12 @@ public class McpServerSession implements McpLoggableSession {
 								McpSchema.ErrorCodes.METHOD_NOT_FOUND, error.message(), error.data())));
 				}
 
+				if (this.state.get() == STATE_UNINITIALIZED) {
+					return Mono.just(McpSchema.JSONRPCResponse.error(request.id(),
+							new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INVALID_REQUEST,
+									"Session is not initialized. Send an initialize request first.")));
+				}
+
 				resultMono = this.exchangeSink.asMono()
 					.flatMap(exchange -> handler.handle(copyExchange(exchange, transportContext), request.params()));
 			}

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/McpServerSessionTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/McpServerSessionTests.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ */
+
+package io.modelcontextprotocol.spec;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import io.modelcontextprotocol.json.McpJsonDefaults;
+import io.modelcontextprotocol.json.TypeRef;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link McpServerSession}.
+ */
+class McpServerSessionTests {
+
+	private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+
+	@Test
+	void handleRequestBeforeInitializationReturnsInvalidRequest() {
+		var transport = new TestMcpServerTransport();
+		var session = newSession(transport);
+
+		StepVerifier
+			.create(session.handle(new McpSchema.JSONRPCRequest(McpSchema.METHOD_TOOLS_LIST, "test-id"))
+				.timeout(Duration.ofMillis(200)))
+			.verifyComplete();
+
+		assertThat(transport.sentMessages()).hasSize(1);
+		assertThat(transport.sentMessages().get(0)).isInstanceOf(McpSchema.JSONRPCResponse.class);
+		var response = (McpSchema.JSONRPCResponse) transport.sentMessages().get(0);
+		assertThat(response.id()).isEqualTo("test-id");
+		assertThat(response.result()).isNull();
+		assertThat(response.error()).isNotNull();
+		assertThat(response.error().code()).isEqualTo(McpSchema.ErrorCodes.INVALID_REQUEST);
+		assertThat(response.error().message()).contains("not initialized");
+	}
+
+	private static McpServerSession newSession(TestMcpServerTransport transport) {
+		return new McpServerSession("test-session", REQUEST_TIMEOUT, transport,
+				initializeRequest -> Mono.just(
+						McpSchema.InitializeResult
+							.builder("2025-11-25", McpSchema.ServerCapabilities.builder().build(),
+									McpSchema.Implementation.builder("test-server", "1.0.0").build())
+							.build()),
+				Map.of(McpSchema.METHOD_TOOLS_LIST,
+						(exchange, params) -> Mono.just(McpSchema.ListToolsResult.builder(List.of()).build())),
+				Map.of());
+	}
+
+	private static final class TestMcpServerTransport implements McpServerTransport {
+
+		private final List<McpSchema.JSONRPCMessage> sentMessages = new ArrayList<>();
+
+		@Override
+		public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
+			this.sentMessages.add(message);
+			return Mono.empty();
+		}
+
+		List<McpSchema.JSONRPCMessage> sentMessages() {
+			return this.sentMessages;
+		}
+
+		@Override
+		public Mono<Void> closeGracefully() {
+			return Mono.empty();
+		}
+
+		@Override
+		public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+			return McpJsonDefaults.getMapper().convertValue(data, typeRef);
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Summary

Fixes #275.

Registered server requests received before session initialization now return a JSON-RPC `INVALID_REQUEST` response instead of waiting indefinitely for the server exchange.

## Changes

- Return `INVALID_REQUEST` when a non-`initialize` request has a registered handler but the `McpServerSession` is still `UNINITIALIZED`.
- Add a focused regression test that sends `tools/list` before initialization and asserts an immediate JSON-RPC error response.

## Verification

```bash
./mvnw -pl mcp-core -Dtest=McpServerSessionTests test
./mvnw -pl mcp-core test
```
