### PR TITLE
Upgrade Jackson 3.0.3 to 3.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
 
 		<slf4j-api.version>2.0.16</slf4j-api.version>
 		<logback.version>1.5.15</logback.version>
-		<jackson-annotations.version>2.20</jackson-annotations.version>
+		<jackson-annotations.version>2.21</jackson-annotations.version>
 		<jackson2.version>2.20.1</jackson2.version>
-		<jackson3.version>3.0.3</jackson3.version>
+		<jackson3.version>3.1.4</jackson3.version>
 		<springframework.version>6.2.1</springframework.version>
 
 		<!-- plugin versions -->


### PR DESCRIPTION
## Motivation and Context
Upgrades `jackson3.version` from 3.0.3 to 3.1.4 and `jackson-annotations.version` from 2.20 to 2.21.

This aligns Jackson to the latest LTS and fixes security warnings, see https://mvnrepository.com/artifact/tools.jackson.core/jackson-databind

The annotations bump is required: Jackson databind 3.1's `JacksonAnnotationIntrospector` references `@JsonSerializeAs`, which was added in jackson-annotations 2.21. With 2.20 on the classpath, any Jackson 3 mapper fails at runtime with `NoClassDefFoundError`.

## How Has This Been Tested?
Ran the existing test suite locally with `./mvnw -pl mcp-core -am test`; all 339 tests pass.

## Breaking Changes
No breaking changes. This is a dependency version bump only.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
