### PR TITLE
Bump json-schema-validator to 2.0.4 / 3.0.6, jackson to 2.21.1 / 3.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
 
 		<slf4j-api.version>2.0.16</slf4j-api.version>
 		<logback.version>1.5.15</logback.version>
-		<jackson-annotations.version>2.20</jackson-annotations.version>
-		<jackson2.version>2.20.1</jackson2.version>
-		<jackson3.version>3.0.3</jackson3.version>
+		<jackson-annotations.version>2.21</jackson-annotations.version>
+		<jackson2.version>2.21.1</jackson2.version>
+		<jackson3.version>3.1.4</jackson3.version>
 		<springframework.version>6.2.1</springframework.version>
 
 		<!-- plugin versions -->
@@ -97,8 +97,8 @@
 		<awaitility.version>4.2.0</awaitility.version>
 		<bnd-maven-plugin.version>7.1.0</bnd-maven-plugin.version>
 		<json-unit-assertj.version>4.1.0</json-unit-assertj.version>
-		<json-schema-validator-jackson2.version>2.0.0</json-schema-validator-jackson2.version>
-		<json-schema-validator-jackson3.version>3.0.0</json-schema-validator-jackson3.version>
+		<json-schema-validator-jackson2.version>2.0.4</json-schema-validator-jackson2.version>
+		<json-schema-validator-jackson3.version>3.0.6</json-schema-validator-jackson3.version>
 
 	</properties>
 


### PR DESCRIPTION
Bumps `json-schema-validator` to **2.0.4** (Jackson 2) / **3.0.6** (Jackson 3) to adopt the OSGi class-loading fix, and moves the Jackson floors those releases require.

Fixes #992

## Motivation and Context

`DefaultJsonSchemaValidator` eagerly loads the bundled Draft 2020-12 meta-schema, and `json-schema-validator` resolved it through the thread context class loader only — under OSGi that loader cannot see the validator's own jar, so every server failed at startup with `FileNotFoundException: classpath:draft/2020-12/schema`. Fixed upstream in networknt/json-schema-validator#1265 / networknt/json-schema-validator#1266, released as 3.0.6 / 2.0.4.

json-schema-validator 3.0.6 is built against Jackson 3.1.4 and requires `jackson-annotations` 2.21, so those floors move with it; `jackson-annotations` is shared through `mcp-core`, so the Jackson 2 line is aligned to 2.21.1.

## How Has This Been Tested?

Two ways, independently:
- I verified that this resolves an issue I encountered in an OSGi application — the same failure reported in #992.
- Separately, on a minimal embedded Apache Felix reproducer: with a thread context class loader that cannot see the bundled meta-schema, `DefaultJsonSchemaValidator` threw before this change and constructs cleanly after it, for both the Jackson 2 and Jackson 3 modules.

Module test suites pass locally.

## Breaking Changes

None in the SDK itself (pom-only). The validator patch releases include upstream validation bug fixes, and the transitive Jackson floor rises (Jackson 3 → 3.1.4, `jackson-annotations` → 2.21, Jackson 2 → 2.21.1) — consumers pinning older Jackson will need to match it.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling — n/a, dependency version bump only
- [ ] I have added or updated documentation as needed — n/a

## Additional context

pom-only change (5 version properties). The upstream regression was introduced in the schema-retrieval refactor (networknt/json-schema-validator#931) and affected every 2.x/3.x release until 2.0.4 / 3.0.6.