### PR TITLE
Fix README link to Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This SDK enables Java applications to interact with AI models and tools through 
 For comprehensive guides and SDK API documentation
 
 - [Features](https://modelcontextprotocol.github.io/java-sdk/#features) - Overview the features provided by the Java MCP SDK
-- [Architecture](https://modelcontextprotocol.github.io/java-sdk/#architecture) - Java MCP SDK architecture overview.
+- [Architecture](https://java.sdk.modelcontextprotocol.io/latest/overview/#architecture) - Java MCP SDK architecture overview.
 - [Java Dependencies / BOM](https://java.sdk.modelcontextprotocol.io/latest/quickstart/#dependencies) - Java dependencies and BOM.
 - [Java MCP Client](https://java.sdk.modelcontextprotocol.io/latest/client/) - Learn how to use the MCP client to interact with MCP servers.
 - [Java MCP Server](https://java.sdk.modelcontextprotocol.io/latest/server/) - Learn how to implement and configure a MCP servers.


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Changed the Java MCP SDK architecture overview link in the README from https://modelcontextprotocol.github.io/java-sdk/#architecture to https://modelcontextprotocol.github.io/java-sdk/#architecture.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The page referenced by the old link does not have the Java MCP SDK architecture overview.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
N/A, documentation changes

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
