### PR TITLE
Add ttlMs and cacheScope to cacheable result records (SEP-2549)

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -540,7 +540,7 @@ public class McpAsyncServer {
 			List<Tool> tools = this.tools.stream().map(McpServerFeatures.AsyncToolSpecification::tool).toList();
 
 			return Mono.just(McpSchema.ListToolsResult.builder(tools)
-				.ttlMs(0)
+				.ttlMs(0L)
 				.cacheScope(McpSchema.CacheScope.PUBLIC)
 				.build());
 		};
@@ -795,7 +795,7 @@ public class McpAsyncServer {
 				.map(McpServerFeatures.AsyncResourceSpecification::resource)
 				.toList();
 			return Mono.just(McpSchema.ListResourcesResult.builder(resourceList)
-				.ttlMs(0)
+				.ttlMs(0L)
 				.cacheScope(McpSchema.CacheScope.PUBLIC)
 				.build());
 		};
@@ -808,7 +808,7 @@ public class McpAsyncServer {
 				.map(McpServerFeatures.AsyncResourceTemplateSpecification::resourceTemplate)
 				.toList();
 			return Mono.just(McpSchema.ListResourceTemplatesResult.builder(resourceList)
-				.ttlMs(0)
+				.ttlMs(0L)
 				.cacheScope(McpSchema.CacheScope.PUBLIC)
 				.build());
 		};
@@ -840,8 +840,8 @@ public class McpAsyncServer {
 		if (result.ttlMs() == null || result.cacheScope() == null) {
 			return McpSchema.ReadResourceResult.builder(result.contents())
 				.meta(result.meta())
-				.ttlMs(result.ttlMs() != null ? result.ttlMs() : 0)
-				.cacheScope(result.cacheScope() != null ? result.cacheScope() : McpSchema.CacheScope.PUBLIC)
+				.ttlMs(result.ttlMs() != null ? result.ttlMs() : 0L)
+				.cacheScope(result.cacheScope() != null ? result.cacheScope() : McpSchema.CacheScope.PRIVATE)
 				.build();
 		}
 		return result;
@@ -974,7 +974,7 @@ public class McpAsyncServer {
 				.toList();
 
 			return Mono.just(McpSchema.ListPromptsResult.builder(promptList)
-				.ttlMs(0)
+				.ttlMs(0L)
 				.cacheScope(McpSchema.CacheScope.PUBLIC)
 				.build());
 		};

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -539,7 +539,10 @@ public class McpAsyncServer {
 		return (exchange, params) -> {
 			List<Tool> tools = this.tools.stream().map(McpServerFeatures.AsyncToolSpecification::tool).toList();
 
-			return Mono.just(McpSchema.ListToolsResult.builder(tools).build());
+			return Mono.just(McpSchema.ListToolsResult.builder(tools)
+				.ttlMs(0)
+				.cacheScope(McpSchema.CacheScope.PUBLIC)
+				.build());
 		};
 	}
 
@@ -791,7 +794,10 @@ public class McpAsyncServer {
 				.stream()
 				.map(McpServerFeatures.AsyncResourceSpecification::resource)
 				.toList();
-			return Mono.just(McpSchema.ListResourcesResult.builder(resourceList).build());
+			return Mono.just(McpSchema.ListResourcesResult.builder(resourceList)
+				.ttlMs(0)
+				.cacheScope(McpSchema.CacheScope.PUBLIC)
+				.build());
 		};
 	}
 
@@ -801,7 +807,10 @@ public class McpAsyncServer {
 				.stream()
 				.map(McpServerFeatures.AsyncResourceTemplateSpecification::resourceTemplate)
 				.toList();
-			return Mono.just(McpSchema.ListResourceTemplatesResult.builder(resourceList).build());
+			return Mono.just(McpSchema.ListResourceTemplatesResult.builder(resourceList)
+				.ttlMs(0)
+				.cacheScope(McpSchema.CacheScope.PUBLIC)
+				.build());
 		};
 	}
 
@@ -822,8 +831,20 @@ public class McpAsyncServer {
 					return this.findResourceTemplateSpecification(resourceUri)
 						.map(spec -> spec.readHandler().apply(ex, resourceRequest))
 						.orElseGet(() -> Mono.error(RESOURCE_NOT_FOUND.apply(resourceUri)));
-				});
+				})
+				.map(McpAsyncServer::withCacheDefaults);
 		};
+	}
+
+	private static McpSchema.ReadResourceResult withCacheDefaults(McpSchema.ReadResourceResult result) {
+		if (result.ttlMs() == null || result.cacheScope() == null) {
+			return McpSchema.ReadResourceResult.builder(result.contents())
+				.meta(result.meta())
+				.ttlMs(result.ttlMs() != null ? result.ttlMs() : 0)
+				.cacheScope(result.cacheScope() != null ? result.cacheScope() : McpSchema.CacheScope.PUBLIC)
+				.build();
+		}
+		return result;
 	}
 
 	private Optional<McpServerFeatures.AsyncResourceSpecification> findResourceSpecification(String uri) {
@@ -952,7 +973,10 @@ public class McpAsyncServer {
 				.map(McpServerFeatures.AsyncPromptSpecification::prompt)
 				.toList();
 
-			return Mono.just(McpSchema.ListPromptsResult.builder(promptList).build());
+			return Mono.just(McpSchema.ListPromptsResult.builder(promptList)
+				.ttlMs(0)
+				.cacheScope(McpSchema.CacheScope.PUBLIC)
+				.build());
 		};
 	}
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
@@ -421,7 +421,7 @@ public class McpStatelessAsyncServer {
 				.map(McpStatelessServerFeatures.AsyncToolSpecification::tool)
 				.toList();
 			return Mono.just(McpSchema.ListToolsResult.builder(tools)
-				.ttlMs(0)
+				.ttlMs(0L)
 				.cacheScope(McpSchema.CacheScope.PUBLIC)
 				.build());
 		};
@@ -588,7 +588,7 @@ public class McpStatelessAsyncServer {
 				.map(McpStatelessServerFeatures.AsyncResourceSpecification::resource)
 				.toList();
 			return Mono.just(McpSchema.ListResourcesResult.builder(resourceList)
-				.ttlMs(0)
+				.ttlMs(0L)
 				.cacheScope(McpSchema.CacheScope.PUBLIC)
 				.build());
 		};
@@ -601,7 +601,7 @@ public class McpStatelessAsyncServer {
 				.map(AsyncResourceTemplateSpecification::resourceTemplate)
 				.toList();
 			return Mono.just(McpSchema.ListResourceTemplatesResult.builder(resourceList)
-				.ttlMs(0)
+				.ttlMs(0L)
 				.cacheScope(McpSchema.CacheScope.PUBLIC)
 				.build());
 		};
@@ -633,8 +633,8 @@ public class McpStatelessAsyncServer {
 		if (result.ttlMs() == null || result.cacheScope() == null) {
 			return McpSchema.ReadResourceResult.builder(result.contents())
 				.meta(result.meta())
-				.ttlMs(result.ttlMs() != null ? result.ttlMs() : 0)
-				.cacheScope(result.cacheScope() != null ? result.cacheScope() : McpSchema.CacheScope.PUBLIC)
+				.ttlMs(result.ttlMs() != null ? result.ttlMs() : 0L)
+				.cacheScope(result.cacheScope() != null ? result.cacheScope() : McpSchema.CacheScope.PRIVATE)
 				.build();
 		}
 		return result;
@@ -736,7 +736,7 @@ public class McpStatelessAsyncServer {
 				.toList();
 
 			return Mono.just(McpSchema.ListPromptsResult.builder(promptList)
-				.ttlMs(0)
+				.ttlMs(0L)
 				.cacheScope(McpSchema.CacheScope.PUBLIC)
 				.build());
 		};

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpStatelessAsyncServer.java
@@ -420,7 +420,10 @@ public class McpStatelessAsyncServer {
 			List<Tool> tools = this.tools.stream()
 				.map(McpStatelessServerFeatures.AsyncToolSpecification::tool)
 				.toList();
-			return Mono.just(McpSchema.ListToolsResult.builder(tools).build());
+			return Mono.just(McpSchema.ListToolsResult.builder(tools)
+				.ttlMs(0)
+				.cacheScope(McpSchema.CacheScope.PUBLIC)
+				.build());
 		};
 	}
 
@@ -584,7 +587,10 @@ public class McpStatelessAsyncServer {
 				.stream()
 				.map(McpStatelessServerFeatures.AsyncResourceSpecification::resource)
 				.toList();
-			return Mono.just(McpSchema.ListResourcesResult.builder(resourceList).build());
+			return Mono.just(McpSchema.ListResourcesResult.builder(resourceList)
+				.ttlMs(0)
+				.cacheScope(McpSchema.CacheScope.PUBLIC)
+				.build());
 		};
 	}
 
@@ -594,7 +600,10 @@ public class McpStatelessAsyncServer {
 				.stream()
 				.map(AsyncResourceTemplateSpecification::resourceTemplate)
 				.toList();
-			return Mono.just(McpSchema.ListResourceTemplatesResult.builder(resourceList).build());
+			return Mono.just(McpSchema.ListResourceTemplatesResult.builder(resourceList)
+				.ttlMs(0)
+				.cacheScope(McpSchema.CacheScope.PUBLIC)
+				.build());
 		};
 	}
 
@@ -614,9 +623,21 @@ public class McpStatelessAsyncServer {
 					return this.findResourceTemplateSpecification(resourceUri)
 						.map(spec -> spec.readHandler().apply(ctx, resourceRequest))
 						.orElseGet(() -> Mono.error(RESOURCE_NOT_FOUND.apply(resourceUri)));
-				});
+				})
+				.map(McpStatelessAsyncServer::withCacheDefaults);
 
 		};
+	}
+
+	private static McpSchema.ReadResourceResult withCacheDefaults(McpSchema.ReadResourceResult result) {
+		if (result.ttlMs() == null || result.cacheScope() == null) {
+			return McpSchema.ReadResourceResult.builder(result.contents())
+				.meta(result.meta())
+				.ttlMs(result.ttlMs() != null ? result.ttlMs() : 0)
+				.cacheScope(result.cacheScope() != null ? result.cacheScope() : McpSchema.CacheScope.PUBLIC)
+				.build();
+		}
+		return result;
 	}
 
 	private Optional<McpStatelessServerFeatures.AsyncResourceSpecification> findResourceSpecification(String uri) {
@@ -714,7 +735,10 @@ public class McpStatelessAsyncServer {
 				.map(McpStatelessServerFeatures.AsyncPromptSpecification::prompt)
 				.toList();
 
-			return Mono.just(McpSchema.ListPromptsResult.builder(promptList).build());
+			return Mono.just(McpSchema.ListPromptsResult.builder(promptList)
+				.ttlMs(0)
+				.cacheScope(McpSchema.CacheScope.PUBLIC)
+				.build());
 		};
 	}
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -190,6 +190,21 @@ public final class McpSchema {
 
 	}
 
+	/**
+	 * Indicates the intended scope of a cached response, analogous to HTTP
+	 * {@code Cache-Control: public} vs {@code Cache-Control: private}.
+	 *
+	 * @see <a href=
+	 * "https://spec.modelcontextprotocol.io/specification/draft/server/utilities/caching/">Specification:
+	 * Caching</a>
+	 */
+	public enum CacheScope {
+
+	// @formatter:off
+		@JsonProperty("private") PRIVATE,
+		@JsonProperty("public") PUBLIC
+	} // @formatter:on
+
 	public interface Notification extends Meta {
 
 	}
@@ -1604,13 +1619,18 @@ public final class McpSchema {
 	 * @param nextCursor An opaque token representing the pagination position after the
 	 * last returned result. If present, there may be more results available
 	 * @param meta See specification for notes on _meta usage
+	 * @param ttlMs A hint from the server indicating how long (in milliseconds) the
+	 * client may cache this response before re-fetching
+	 * @param cacheScope Indicates the intended scope of the cached response
 	 */
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ListResourcesResult( // @formatter:off
 		@JsonProperty("resources") List<Resource> resources,
 		@JsonProperty("nextCursor") String nextCursor,
-		@JsonProperty("_meta") Map<String, Object> meta) implements Result { // @formatter:on
+		@JsonProperty("_meta") Map<String, Object> meta,
+		@JsonProperty("ttlMs") Integer ttlMs,
+		@JsonProperty("cacheScope") CacheScope cacheScope) implements Result { // @formatter:on
 
 		public ListResourcesResult {
 			Assert.notNull(resources, "resources must not be null");
@@ -1618,13 +1638,19 @@ public final class McpSchema {
 
 		@JsonCreator
 		static ListResourcesResult fromJson(@JsonProperty("resources") List<Resource> resources,
-				@JsonProperty("nextCursor") String nextCursor, @JsonProperty("_meta") Map<String, Object> meta) {
+				@JsonProperty("nextCursor") String nextCursor, @JsonProperty("_meta") Map<String, Object> meta,
+				@JsonProperty("ttlMs") Integer ttlMs, @JsonProperty("cacheScope") CacheScope cacheScope) {
 			if (resources == null) {
 				logger.warn(
 						"ListResourcesResult: missing required field 'resources' during deserialization, using default []");
 				resources = List.of();
 			}
-			return new ListResourcesResult(resources, nextCursor, meta);
+			return new ListResourcesResult(resources, nextCursor, meta, ttlMs, cacheScope);
+		}
+
+		@Deprecated
+		public ListResourcesResult(List<Resource> resources, String nextCursor, Map<String, Object> meta) {
+			this(resources, nextCursor, meta, null, null);
 		}
 
 		@Deprecated
@@ -1644,6 +1670,10 @@ public final class McpSchema {
 
 			private Map<String, Object> meta;
 
+			private Integer ttlMs;
+
+			private CacheScope cacheScope;
+
 			private Builder(List<Resource> resources) {
 				Assert.notNull(resources, "resources must not be null");
 				this.resources = resources;
@@ -1659,8 +1689,18 @@ public final class McpSchema {
 				return this;
 			}
 
+			public Builder ttlMs(Integer ttlMs) {
+				this.ttlMs = ttlMs;
+				return this;
+			}
+
+			public Builder cacheScope(CacheScope cacheScope) {
+				this.cacheScope = cacheScope;
+				return this;
+			}
+
 			public ListResourcesResult build() {
-				return new ListResourcesResult(resources, nextCursor, meta);
+				return new ListResourcesResult(resources, nextCursor, meta, ttlMs, cacheScope);
 			}
 
 		}
@@ -1673,13 +1713,18 @@ public final class McpSchema {
 	 * @param nextCursor An opaque token representing the pagination position after the
 	 * last returned result. If present, there may be more results available
 	 * @param meta See specification for notes on _meta usage
+	 * @param ttlMs A hint from the server indicating how long (in milliseconds) the
+	 * client may cache this response before re-fetching
+	 * @param cacheScope Indicates the intended scope of the cached response
 	 */
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ListResourceTemplatesResult( // @formatter:off
 		@JsonProperty("resourceTemplates") List<ResourceTemplate> resourceTemplates,
 		@JsonProperty("nextCursor") String nextCursor,
-		@JsonProperty("_meta") Map<String, Object> meta) implements Result { // @formatter:on
+		@JsonProperty("_meta") Map<String, Object> meta,
+		@JsonProperty("ttlMs") Integer ttlMs,
+		@JsonProperty("cacheScope") CacheScope cacheScope) implements Result { // @formatter:on
 
 		public ListResourceTemplatesResult {
 			Assert.notNull(resourceTemplates, "resourceTemplates must not be null");
@@ -1688,13 +1733,20 @@ public final class McpSchema {
 		@JsonCreator
 		static ListResourceTemplatesResult fromJson(
 				@JsonProperty("resourceTemplates") List<ResourceTemplate> resourceTemplates,
-				@JsonProperty("nextCursor") String nextCursor, @JsonProperty("_meta") Map<String, Object> meta) {
+				@JsonProperty("nextCursor") String nextCursor, @JsonProperty("_meta") Map<String, Object> meta,
+				@JsonProperty("ttlMs") Integer ttlMs, @JsonProperty("cacheScope") CacheScope cacheScope) {
 			if (resourceTemplates == null) {
 				logger.warn(
 						"ListResourceTemplatesResult: missing required field 'resourceTemplates' during deserialization, using default []");
 				resourceTemplates = List.of();
 			}
-			return new ListResourceTemplatesResult(resourceTemplates, nextCursor, meta);
+			return new ListResourceTemplatesResult(resourceTemplates, nextCursor, meta, ttlMs, cacheScope);
+		}
+
+		@Deprecated
+		public ListResourceTemplatesResult(List<ResourceTemplate> resourceTemplates, String nextCursor,
+				Map<String, Object> meta) {
+			this(resourceTemplates, nextCursor, meta, null, null);
 		}
 
 		@Deprecated
@@ -1714,6 +1766,10 @@ public final class McpSchema {
 
 			private Map<String, Object> meta;
 
+			private Integer ttlMs;
+
+			private CacheScope cacheScope;
+
 			private Builder(List<ResourceTemplate> resourceTemplates) {
 				Assert.notNull(resourceTemplates, "resourceTemplates must not be null");
 				this.resourceTemplates = resourceTemplates;
@@ -1729,8 +1785,18 @@ public final class McpSchema {
 				return this;
 			}
 
+			public Builder ttlMs(Integer ttlMs) {
+				this.ttlMs = ttlMs;
+				return this;
+			}
+
+			public Builder cacheScope(CacheScope cacheScope) {
+				this.cacheScope = cacheScope;
+				return this;
+			}
+
 			public ListResourceTemplatesResult build() {
-				return new ListResourceTemplatesResult(resourceTemplates, nextCursor, meta);
+				return new ListResourceTemplatesResult(resourceTemplates, nextCursor, meta, ttlMs, cacheScope);
 			}
 
 		}
@@ -1801,12 +1867,17 @@ public final class McpSchema {
 	 *
 	 * @param contents The contents of the resource
 	 * @param meta See specification for notes on _meta usage
+	 * @param ttlMs A hint from the server indicating how long (in milliseconds) the
+	 * client may cache this response before re-fetching
+	 * @param cacheScope Indicates the intended scope of the cached response
 	 */
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ReadResourceResult( // @formatter:off
 		@JsonProperty("contents") List<ResourceContents> contents,
-		@JsonProperty("_meta") Map<String, Object> meta) implements Result { // @formatter:on
+		@JsonProperty("_meta") Map<String, Object> meta,
+		@JsonProperty("ttlMs") Integer ttlMs,
+		@JsonProperty("cacheScope") CacheScope cacheScope) implements Result { // @formatter:on
 
 		public ReadResourceResult {
 			Assert.notNull(contents, "contents must not be null");
@@ -1814,13 +1885,19 @@ public final class McpSchema {
 
 		@JsonCreator
 		static ReadResourceResult fromJson(@JsonProperty("contents") List<ResourceContents> contents,
-				@JsonProperty("_meta") Map<String, Object> meta) {
+				@JsonProperty("_meta") Map<String, Object> meta, @JsonProperty("ttlMs") Integer ttlMs,
+				@JsonProperty("cacheScope") CacheScope cacheScope) {
 			if (contents == null) {
 				logger.warn(
 						"ReadResourceResult: missing required field 'contents' during deserialization, using default []");
 				contents = List.of();
 			}
-			return new ReadResourceResult(contents, meta);
+			return new ReadResourceResult(contents, meta, ttlMs, cacheScope);
+		}
+
+		@Deprecated
+		public ReadResourceResult(List<ResourceContents> contents, Map<String, Object> meta) {
+			this(contents, meta, null, null);
 		}
 
 		@Deprecated
@@ -1838,6 +1915,10 @@ public final class McpSchema {
 
 			private Map<String, Object> meta;
 
+			private Integer ttlMs;
+
+			private CacheScope cacheScope;
+
 			private Builder(List<ResourceContents> contents) {
 				Assert.notNull(contents, "contents must not be null");
 				this.contents = contents;
@@ -1848,8 +1929,18 @@ public final class McpSchema {
 				return this;
 			}
 
+			public Builder ttlMs(Integer ttlMs) {
+				this.ttlMs = ttlMs;
+				return this;
+			}
+
+			public Builder cacheScope(CacheScope cacheScope) {
+				this.cacheScope = cacheScope;
+				return this;
+			}
+
 			public ReadResourceResult build() {
-				return new ReadResourceResult(contents, meta);
+				return new ReadResourceResult(contents, meta, ttlMs, cacheScope);
 			}
 
 		}
@@ -2411,13 +2502,18 @@ public final class McpSchema {
 	 * @param nextCursor An optional cursor for pagination. If present, indicates there
 	 * are more prompts available.
 	 * @param meta See specification for notes on _meta usage
+	 * @param ttlMs A hint from the server indicating how long (in milliseconds) the
+	 * client may cache this response before re-fetching
+	 * @param cacheScope Indicates the intended scope of the cached response
 	 */
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ListPromptsResult( // @formatter:off
 		@JsonProperty("prompts") List<Prompt> prompts,
 		@JsonProperty("nextCursor") String nextCursor,
-		@JsonProperty("_meta") Map<String, Object> meta) implements Result  { // @formatter:on
+		@JsonProperty("_meta") Map<String, Object> meta,
+		@JsonProperty("ttlMs") Integer ttlMs,
+		@JsonProperty("cacheScope") CacheScope cacheScope) implements Result  { // @formatter:on
 
 		public ListPromptsResult {
 			Assert.notNull(prompts, "prompts must not be null");
@@ -2425,13 +2521,19 @@ public final class McpSchema {
 
 		@JsonCreator
 		static ListPromptsResult fromJson(@JsonProperty("prompts") List<Prompt> prompts,
-				@JsonProperty("nextCursor") String nextCursor, @JsonProperty("_meta") Map<String, Object> meta) {
+				@JsonProperty("nextCursor") String nextCursor, @JsonProperty("_meta") Map<String, Object> meta,
+				@JsonProperty("ttlMs") Integer ttlMs, @JsonProperty("cacheScope") CacheScope cacheScope) {
 			if (prompts == null) {
 				logger.warn(
 						"ListPromptsResult: missing required field 'prompts' during deserialization, using default []");
 				prompts = List.of();
 			}
-			return new ListPromptsResult(prompts, nextCursor, meta);
+			return new ListPromptsResult(prompts, nextCursor, meta, ttlMs, cacheScope);
+		}
+
+		@Deprecated
+		public ListPromptsResult(List<Prompt> prompts, String nextCursor, Map<String, Object> meta) {
+			this(prompts, nextCursor, meta, null, null);
 		}
 
 		@Deprecated
@@ -2451,6 +2553,10 @@ public final class McpSchema {
 
 			private Map<String, Object> meta;
 
+			private Integer ttlMs;
+
+			private CacheScope cacheScope;
+
 			private Builder(List<Prompt> prompts) {
 				Assert.notNull(prompts, "prompts must not be null");
 				this.prompts = prompts;
@@ -2466,8 +2572,18 @@ public final class McpSchema {
 				return this;
 			}
 
+			public Builder ttlMs(Integer ttlMs) {
+				this.ttlMs = ttlMs;
+				return this;
+			}
+
+			public Builder cacheScope(CacheScope cacheScope) {
+				this.cacheScope = cacheScope;
+				return this;
+			}
+
 			public ListPromptsResult build() {
-				return new ListPromptsResult(prompts, nextCursor, meta);
+				return new ListPromptsResult(prompts, nextCursor, meta, ttlMs, cacheScope);
 			}
 
 		}
@@ -2620,13 +2736,18 @@ public final class McpSchema {
 	 * @param nextCursor An optional cursor for pagination. If present, indicates there
 	 * are more tools available.
 	 * @param meta See specification for notes on _meta usage
+	 * @param ttlMs A hint from the server indicating how long (in milliseconds) the
+	 * client may cache this response before re-fetching
+	 * @param cacheScope Indicates the intended scope of the cached response
 	 */
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ListToolsResult( // @formatter:off
 		@JsonProperty("tools") List<Tool> tools,
 		@JsonProperty("nextCursor") String nextCursor,
-		@JsonProperty("_meta") Map<String, Object> meta) implements Result { // @formatter:on
+		@JsonProperty("_meta") Map<String, Object> meta,
+		@JsonProperty("ttlMs") Integer ttlMs,
+		@JsonProperty("cacheScope") CacheScope cacheScope) implements Result { // @formatter:on
 
 		public ListToolsResult {
 			Assert.notNull(tools, "tools must not be null");
@@ -2634,12 +2755,18 @@ public final class McpSchema {
 
 		@JsonCreator
 		static ListToolsResult fromJson(@JsonProperty("tools") List<Tool> tools,
-				@JsonProperty("nextCursor") String nextCursor, @JsonProperty("_meta") Map<String, Object> meta) {
+				@JsonProperty("nextCursor") String nextCursor, @JsonProperty("_meta") Map<String, Object> meta,
+				@JsonProperty("ttlMs") Integer ttlMs, @JsonProperty("cacheScope") CacheScope cacheScope) {
 			if (tools == null) {
 				logger.warn("ListToolsResult: missing required field 'tools' during deserialization, using default []");
 				tools = List.of();
 			}
-			return new ListToolsResult(tools, nextCursor, meta);
+			return new ListToolsResult(tools, nextCursor, meta, ttlMs, cacheScope);
+		}
+
+		@Deprecated
+		public ListToolsResult(List<Tool> tools, String nextCursor, Map<String, Object> meta) {
+			this(tools, nextCursor, meta, null, null);
 		}
 
 		@Deprecated
@@ -2659,6 +2786,10 @@ public final class McpSchema {
 
 			private Map<String, Object> meta;
 
+			private Integer ttlMs;
+
+			private CacheScope cacheScope;
+
 			private Builder(List<Tool> tools) {
 				Assert.notNull(tools, "tools must not be null");
 				this.tools = tools;
@@ -2674,8 +2805,18 @@ public final class McpSchema {
 				return this;
 			}
 
+			public Builder ttlMs(Integer ttlMs) {
+				this.ttlMs = ttlMs;
+				return this;
+			}
+
+			public Builder cacheScope(CacheScope cacheScope) {
+				this.cacheScope = cacheScope;
+				return this;
+			}
+
 			public ListToolsResult build() {
-				return new ListToolsResult(tools, nextCursor, meta);
+				return new ListToolsResult(tools, nextCursor, meta, ttlMs, cacheScope);
 			}
 
 		}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -1629,7 +1629,7 @@ public final class McpSchema {
 		@JsonProperty("resources") List<Resource> resources,
 		@JsonProperty("nextCursor") String nextCursor,
 		@JsonProperty("_meta") Map<String, Object> meta,
-		@JsonProperty("ttlMs") Integer ttlMs,
+		@JsonProperty("ttlMs") Long ttlMs,
 		@JsonProperty("cacheScope") CacheScope cacheScope) implements Result { // @formatter:on
 
 		public ListResourcesResult {
@@ -1639,7 +1639,7 @@ public final class McpSchema {
 		@JsonCreator
 		static ListResourcesResult fromJson(@JsonProperty("resources") List<Resource> resources,
 				@JsonProperty("nextCursor") String nextCursor, @JsonProperty("_meta") Map<String, Object> meta,
-				@JsonProperty("ttlMs") Integer ttlMs, @JsonProperty("cacheScope") CacheScope cacheScope) {
+				@JsonProperty("ttlMs") Long ttlMs, @JsonProperty("cacheScope") CacheScope cacheScope) {
 			if (resources == null) {
 				logger.warn(
 						"ListResourcesResult: missing required field 'resources' during deserialization, using default []");
@@ -1670,7 +1670,7 @@ public final class McpSchema {
 
 			private Map<String, Object> meta;
 
-			private Integer ttlMs;
+			private Long ttlMs;
 
 			private CacheScope cacheScope;
 
@@ -1689,7 +1689,7 @@ public final class McpSchema {
 				return this;
 			}
 
-			public Builder ttlMs(Integer ttlMs) {
+			public Builder ttlMs(Long ttlMs) {
 				this.ttlMs = ttlMs;
 				return this;
 			}
@@ -1723,7 +1723,7 @@ public final class McpSchema {
 		@JsonProperty("resourceTemplates") List<ResourceTemplate> resourceTemplates,
 		@JsonProperty("nextCursor") String nextCursor,
 		@JsonProperty("_meta") Map<String, Object> meta,
-		@JsonProperty("ttlMs") Integer ttlMs,
+		@JsonProperty("ttlMs") Long ttlMs,
 		@JsonProperty("cacheScope") CacheScope cacheScope) implements Result { // @formatter:on
 
 		public ListResourceTemplatesResult {
@@ -1734,7 +1734,7 @@ public final class McpSchema {
 		static ListResourceTemplatesResult fromJson(
 				@JsonProperty("resourceTemplates") List<ResourceTemplate> resourceTemplates,
 				@JsonProperty("nextCursor") String nextCursor, @JsonProperty("_meta") Map<String, Object> meta,
-				@JsonProperty("ttlMs") Integer ttlMs, @JsonProperty("cacheScope") CacheScope cacheScope) {
+				@JsonProperty("ttlMs") Long ttlMs, @JsonProperty("cacheScope") CacheScope cacheScope) {
 			if (resourceTemplates == null) {
 				logger.warn(
 						"ListResourceTemplatesResult: missing required field 'resourceTemplates' during deserialization, using default []");
@@ -1766,7 +1766,7 @@ public final class McpSchema {
 
 			private Map<String, Object> meta;
 
-			private Integer ttlMs;
+			private Long ttlMs;
 
 			private CacheScope cacheScope;
 
@@ -1785,7 +1785,7 @@ public final class McpSchema {
 				return this;
 			}
 
-			public Builder ttlMs(Integer ttlMs) {
+			public Builder ttlMs(Long ttlMs) {
 				this.ttlMs = ttlMs;
 				return this;
 			}
@@ -1876,7 +1876,7 @@ public final class McpSchema {
 	public record ReadResourceResult( // @formatter:off
 		@JsonProperty("contents") List<ResourceContents> contents,
 		@JsonProperty("_meta") Map<String, Object> meta,
-		@JsonProperty("ttlMs") Integer ttlMs,
+		@JsonProperty("ttlMs") Long ttlMs,
 		@JsonProperty("cacheScope") CacheScope cacheScope) implements Result { // @formatter:on
 
 		public ReadResourceResult {
@@ -1885,7 +1885,7 @@ public final class McpSchema {
 
 		@JsonCreator
 		static ReadResourceResult fromJson(@JsonProperty("contents") List<ResourceContents> contents,
-				@JsonProperty("_meta") Map<String, Object> meta, @JsonProperty("ttlMs") Integer ttlMs,
+				@JsonProperty("_meta") Map<String, Object> meta, @JsonProperty("ttlMs") Long ttlMs,
 				@JsonProperty("cacheScope") CacheScope cacheScope) {
 			if (contents == null) {
 				logger.warn(
@@ -1915,7 +1915,7 @@ public final class McpSchema {
 
 			private Map<String, Object> meta;
 
-			private Integer ttlMs;
+			private Long ttlMs;
 
 			private CacheScope cacheScope;
 
@@ -1929,7 +1929,7 @@ public final class McpSchema {
 				return this;
 			}
 
-			public Builder ttlMs(Integer ttlMs) {
+			public Builder ttlMs(Long ttlMs) {
 				this.ttlMs = ttlMs;
 				return this;
 			}
@@ -2512,7 +2512,7 @@ public final class McpSchema {
 		@JsonProperty("prompts") List<Prompt> prompts,
 		@JsonProperty("nextCursor") String nextCursor,
 		@JsonProperty("_meta") Map<String, Object> meta,
-		@JsonProperty("ttlMs") Integer ttlMs,
+		@JsonProperty("ttlMs") Long ttlMs,
 		@JsonProperty("cacheScope") CacheScope cacheScope) implements Result  { // @formatter:on
 
 		public ListPromptsResult {
@@ -2522,7 +2522,7 @@ public final class McpSchema {
 		@JsonCreator
 		static ListPromptsResult fromJson(@JsonProperty("prompts") List<Prompt> prompts,
 				@JsonProperty("nextCursor") String nextCursor, @JsonProperty("_meta") Map<String, Object> meta,
-				@JsonProperty("ttlMs") Integer ttlMs, @JsonProperty("cacheScope") CacheScope cacheScope) {
+				@JsonProperty("ttlMs") Long ttlMs, @JsonProperty("cacheScope") CacheScope cacheScope) {
 			if (prompts == null) {
 				logger.warn(
 						"ListPromptsResult: missing required field 'prompts' during deserialization, using default []");
@@ -2553,7 +2553,7 @@ public final class McpSchema {
 
 			private Map<String, Object> meta;
 
-			private Integer ttlMs;
+			private Long ttlMs;
 
 			private CacheScope cacheScope;
 
@@ -2572,7 +2572,7 @@ public final class McpSchema {
 				return this;
 			}
 
-			public Builder ttlMs(Integer ttlMs) {
+			public Builder ttlMs(Long ttlMs) {
 				this.ttlMs = ttlMs;
 				return this;
 			}
@@ -2746,7 +2746,7 @@ public final class McpSchema {
 		@JsonProperty("tools") List<Tool> tools,
 		@JsonProperty("nextCursor") String nextCursor,
 		@JsonProperty("_meta") Map<String, Object> meta,
-		@JsonProperty("ttlMs") Integer ttlMs,
+		@JsonProperty("ttlMs") Long ttlMs,
 		@JsonProperty("cacheScope") CacheScope cacheScope) implements Result { // @formatter:on
 
 		public ListToolsResult {
@@ -2756,7 +2756,7 @@ public final class McpSchema {
 		@JsonCreator
 		static ListToolsResult fromJson(@JsonProperty("tools") List<Tool> tools,
 				@JsonProperty("nextCursor") String nextCursor, @JsonProperty("_meta") Map<String, Object> meta,
-				@JsonProperty("ttlMs") Integer ttlMs, @JsonProperty("cacheScope") CacheScope cacheScope) {
+				@JsonProperty("ttlMs") Long ttlMs, @JsonProperty("cacheScope") CacheScope cacheScope) {
 			if (tools == null) {
 				logger.warn("ListToolsResult: missing required field 'tools' during deserialization, using default []");
 				tools = List.of();
@@ -2786,7 +2786,7 @@ public final class McpSchema {
 
 			private Map<String, Object> meta;
 
-			private Integer ttlMs;
+			private Long ttlMs;
 
 			private CacheScope cacheScope;
 
@@ -2805,7 +2805,7 @@ public final class McpSchema {
 				return this;
 			}
 
-			public Builder ttlMs(Integer ttlMs) {
+			public Builder ttlMs(Long ttlMs) {
 				this.ttlMs = ttlMs;
 				return this;
 			}

--- a/mcp-test/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
@@ -3038,7 +3038,7 @@ public class McpSchemaTests {
 
 		McpSchema.ListResourcesResult result = McpSchema.ListResourcesResult.builder(List.of(resource))
 			.nextCursor("next")
-			.ttlMs(60000)
+			.ttlMs(60000L)
 			.cacheScope(McpSchema.CacheScope.PUBLIC)
 			.build();
 
@@ -3050,7 +3050,7 @@ public class McpSchemaTests {
 
 		McpSchema.ListResourcesResult deserialized = JSON_MAPPER.readValue(value,
 				McpSchema.ListResourcesResult.class);
-		assertThat(deserialized.ttlMs()).isEqualTo(60000);
+		assertThat(deserialized.ttlMs()).isEqualTo(60000L);
 		assertThat(deserialized.cacheScope()).isEqualTo(McpSchema.CacheScope.PUBLIC);
 		assertThat(deserialized.resources()).hasSize(1);
 	}
@@ -3080,7 +3080,7 @@ public class McpSchemaTests {
 
 		McpSchema.ListResourceTemplatesResult result = McpSchema.ListResourceTemplatesResult
 			.builder(List.of(template))
-			.ttlMs(30000)
+			.ttlMs(30000L)
 			.cacheScope(McpSchema.CacheScope.PRIVATE)
 			.build();
 
@@ -3089,7 +3089,7 @@ public class McpSchemaTests {
 
 		McpSchema.ListResourceTemplatesResult deserialized = JSON_MAPPER.readValue(value,
 				McpSchema.ListResourceTemplatesResult.class);
-		assertThat(deserialized.ttlMs()).isEqualTo(30000);
+		assertThat(deserialized.ttlMs()).isEqualTo(30000L);
 		assertThat(deserialized.cacheScope()).isEqualTo(McpSchema.CacheScope.PRIVATE);
 	}
 
@@ -3118,7 +3118,7 @@ public class McpSchemaTests {
 			.build();
 
 		McpSchema.ReadResourceResult result = McpSchema.ReadResourceResult.builder(List.of(contents))
-			.ttlMs(0)
+			.ttlMs(0L)
 			.cacheScope(McpSchema.CacheScope.PRIVATE)
 			.build();
 
@@ -3127,7 +3127,7 @@ public class McpSchemaTests {
 
 		McpSchema.ReadResourceResult deserialized = JSON_MAPPER.readValue(value,
 				McpSchema.ReadResourceResult.class);
-		assertThat(deserialized.ttlMs()).isEqualTo(0);
+		assertThat(deserialized.ttlMs()).isEqualTo(0L);
 		assertThat(deserialized.cacheScope()).isEqualTo(McpSchema.CacheScope.PRIVATE);
 	}
 
@@ -3155,7 +3155,7 @@ public class McpSchemaTests {
 			.build();
 
 		McpSchema.ListPromptsResult result = McpSchema.ListPromptsResult.builder(List.of(prompt))
-			.ttlMs(120000)
+			.ttlMs(120000L)
 			.cacheScope(McpSchema.CacheScope.PUBLIC)
 			.build();
 
@@ -3164,7 +3164,7 @@ public class McpSchemaTests {
 
 		McpSchema.ListPromptsResult deserialized = JSON_MAPPER.readValue(value,
 				McpSchema.ListPromptsResult.class);
-		assertThat(deserialized.ttlMs()).isEqualTo(120000);
+		assertThat(deserialized.ttlMs()).isEqualTo(120000L);
 		assertThat(deserialized.cacheScope()).isEqualTo(McpSchema.CacheScope.PUBLIC);
 	}
 
@@ -3194,7 +3194,7 @@ public class McpSchemaTests {
 
 		McpSchema.ListToolsResult result = McpSchema.ListToolsResult.builder(List.of(tool))
 			.nextCursor("cursor")
-			.ttlMs(300000)
+			.ttlMs(300000L)
 			.cacheScope(McpSchema.CacheScope.PUBLIC)
 			.build();
 
@@ -3205,7 +3205,7 @@ public class McpSchemaTests {
 			.containsEntry("nextCursor", "cursor");
 
 		McpSchema.ListToolsResult deserialized = JSON_MAPPER.readValue(value, McpSchema.ListToolsResult.class);
-		assertThat(deserialized.ttlMs()).isEqualTo(300000);
+		assertThat(deserialized.ttlMs()).isEqualTo(300000L);
 		assertThat(deserialized.cacheScope()).isEqualTo(McpSchema.CacheScope.PUBLIC);
 		assertThat(deserialized.tools()).hasSize(1);
 		assertThat(deserialized.nextCursor()).isEqualTo("cursor");
@@ -3247,7 +3247,7 @@ public class McpSchemaTests {
 		McpSchema.ListResourcesResult result = JSON_MAPPER.readValue("""
 				{"resources":[],"ttlMs":5000,"cacheScope":"public","futureField":"ignored"}""",
 				McpSchema.ListResourcesResult.class);
-		assertThat(result.ttlMs()).isEqualTo(5000);
+		assertThat(result.ttlMs()).isEqualTo(5000L);
 		assertThat(result.cacheScope()).isEqualTo(McpSchema.CacheScope.PUBLIC);
 	}
 
@@ -3256,7 +3256,7 @@ public class McpSchemaTests {
 		McpSchema.ListResourceTemplatesResult result = JSON_MAPPER.readValue("""
 				{"resourceTemplates":[],"ttlMs":5000,"cacheScope":"private","futureField":"ignored"}""",
 				McpSchema.ListResourceTemplatesResult.class);
-		assertThat(result.ttlMs()).isEqualTo(5000);
+		assertThat(result.ttlMs()).isEqualTo(5000L);
 		assertThat(result.cacheScope()).isEqualTo(McpSchema.CacheScope.PRIVATE);
 	}
 
@@ -3274,7 +3274,7 @@ public class McpSchemaTests {
 		McpSchema.ListPromptsResult result = JSON_MAPPER.readValue("""
 				{"prompts":[],"ttlMs":10000,"cacheScope":"public","futureField":"ignored"}""",
 				McpSchema.ListPromptsResult.class);
-		assertThat(result.ttlMs()).isEqualTo(10000);
+		assertThat(result.ttlMs()).isEqualTo(10000L);
 		assertThat(result.cacheScope()).isEqualTo(McpSchema.CacheScope.PUBLIC);
 	}
 
@@ -3283,7 +3283,7 @@ public class McpSchemaTests {
 		McpSchema.ListToolsResult result = JSON_MAPPER.readValue("""
 				{"tools":[],"ttlMs":60000,"cacheScope":"public","futureField":"ignored"}""",
 				McpSchema.ListToolsResult.class);
-		assertThat(result.ttlMs()).isEqualTo(60000);
+		assertThat(result.ttlMs()).isEqualTo(60000L);
 		assertThat(result.cacheScope()).isEqualTo(McpSchema.CacheScope.PUBLIC);
 	}
 

--- a/mcp-test/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/spec/McpSchemaTests.java
@@ -3027,4 +3027,264 @@ public class McpSchemaTests {
 		assertThat(tool.name()).isEqualTo("test-tool");
 	}
 
+	// TTL / CacheScope Tests (SEP-2549)
+
+	@Test
+	void testListResourcesResultWithTtl() throws Exception {
+		McpSchema.Resource resource = McpSchema.Resource.builder("resource://test", "Test Resource")
+			.description("A test resource")
+			.mimeType("text/plain")
+			.build();
+
+		McpSchema.ListResourcesResult result = McpSchema.ListResourcesResult.builder(List.of(resource))
+			.nextCursor("next")
+			.ttlMs(60000)
+			.cacheScope(McpSchema.CacheScope.PUBLIC)
+			.build();
+
+		String value = JSON_MAPPER.writeValueAsString(result);
+		assertThatJson(value).isObject()
+			.containsEntry("ttlMs", 60000)
+			.containsEntry("cacheScope", "public")
+			.containsEntry("nextCursor", "next");
+
+		McpSchema.ListResourcesResult deserialized = JSON_MAPPER.readValue(value,
+				McpSchema.ListResourcesResult.class);
+		assertThat(deserialized.ttlMs()).isEqualTo(60000);
+		assertThat(deserialized.cacheScope()).isEqualTo(McpSchema.CacheScope.PUBLIC);
+		assertThat(deserialized.resources()).hasSize(1);
+	}
+
+	@Test
+	void testListResourcesResultWithoutTtl() throws Exception {
+		String json = """
+				{"resources":[{"uri":"resource://test","name":"Test"}]}""";
+		McpSchema.ListResourcesResult result = JSON_MAPPER.readValue(json, McpSchema.ListResourcesResult.class);
+		assertThat(result.ttlMs()).isNull();
+		assertThat(result.cacheScope()).isNull();
+		assertThat(result.resources()).hasSize(1);
+	}
+
+	@Test
+	void testListResourcesResultNullTtlOmittedFromJson() throws Exception {
+		McpSchema.ListResourcesResult result = McpSchema.ListResourcesResult.builder(List.of()).build();
+		String value = JSON_MAPPER.writeValueAsString(result);
+		assertThatJson(value).isObject().doesNotContainKey("ttlMs").doesNotContainKey("cacheScope");
+	}
+
+	@Test
+	void testListResourceTemplatesResultWithTtl() throws Exception {
+		McpSchema.ResourceTemplate template = McpSchema.ResourceTemplate
+			.builder("resource://{id}/test", "Test Template")
+			.build();
+
+		McpSchema.ListResourceTemplatesResult result = McpSchema.ListResourceTemplatesResult
+			.builder(List.of(template))
+			.ttlMs(30000)
+			.cacheScope(McpSchema.CacheScope.PRIVATE)
+			.build();
+
+		String value = JSON_MAPPER.writeValueAsString(result);
+		assertThatJson(value).isObject().containsEntry("ttlMs", 30000).containsEntry("cacheScope", "private");
+
+		McpSchema.ListResourceTemplatesResult deserialized = JSON_MAPPER.readValue(value,
+				McpSchema.ListResourceTemplatesResult.class);
+		assertThat(deserialized.ttlMs()).isEqualTo(30000);
+		assertThat(deserialized.cacheScope()).isEqualTo(McpSchema.CacheScope.PRIVATE);
+	}
+
+	@Test
+	void testListResourceTemplatesResultWithoutTtl() throws Exception {
+		String json = """
+				{"resourceTemplates":[{"uriTemplate":"resource://{id}/test","name":"T"}]}""";
+		McpSchema.ListResourceTemplatesResult result = JSON_MAPPER.readValue(json,
+				McpSchema.ListResourceTemplatesResult.class);
+		assertThat(result.ttlMs()).isNull();
+		assertThat(result.cacheScope()).isNull();
+	}
+
+	@Test
+	void testListResourceTemplatesResultNullTtlOmittedFromJson() throws Exception {
+		McpSchema.ListResourceTemplatesResult result = McpSchema.ListResourceTemplatesResult.builder(List.of())
+			.build();
+		String value = JSON_MAPPER.writeValueAsString(result);
+		assertThatJson(value).isObject().doesNotContainKey("ttlMs").doesNotContainKey("cacheScope");
+	}
+
+	@Test
+	void testReadResourceResultWithTtl() throws Exception {
+		McpSchema.TextResourceContents contents = McpSchema.TextResourceContents
+			.builder("resource://test", "content")
+			.build();
+
+		McpSchema.ReadResourceResult result = McpSchema.ReadResourceResult.builder(List.of(contents))
+			.ttlMs(0)
+			.cacheScope(McpSchema.CacheScope.PRIVATE)
+			.build();
+
+		String value = JSON_MAPPER.writeValueAsString(result);
+		assertThatJson(value).isObject().containsEntry("ttlMs", 0).containsEntry("cacheScope", "private");
+
+		McpSchema.ReadResourceResult deserialized = JSON_MAPPER.readValue(value,
+				McpSchema.ReadResourceResult.class);
+		assertThat(deserialized.ttlMs()).isEqualTo(0);
+		assertThat(deserialized.cacheScope()).isEqualTo(McpSchema.CacheScope.PRIVATE);
+	}
+
+	@Test
+	void testReadResourceResultWithoutTtl() throws Exception {
+		String json = """
+				{"contents":[{"uri":"resource://test","text":"content"}]}""";
+		McpSchema.ReadResourceResult result = JSON_MAPPER.readValue(json, McpSchema.ReadResourceResult.class);
+		assertThat(result.ttlMs()).isNull();
+		assertThat(result.cacheScope()).isNull();
+	}
+
+	@Test
+	void testReadResourceResultNullTtlOmittedFromJson() throws Exception {
+		McpSchema.ReadResourceResult result = McpSchema.ReadResourceResult.builder(List.of()).build();
+		String value = JSON_MAPPER.writeValueAsString(result);
+		assertThatJson(value).isObject().doesNotContainKey("ttlMs").doesNotContainKey("cacheScope");
+	}
+
+	@Test
+	void testListPromptsResultWithTtl() throws Exception {
+		McpSchema.Prompt prompt = McpSchema.Prompt.builder("test-prompt")
+			.title("Test")
+			.description("A test prompt")
+			.build();
+
+		McpSchema.ListPromptsResult result = McpSchema.ListPromptsResult.builder(List.of(prompt))
+			.ttlMs(120000)
+			.cacheScope(McpSchema.CacheScope.PUBLIC)
+			.build();
+
+		String value = JSON_MAPPER.writeValueAsString(result);
+		assertThatJson(value).isObject().containsEntry("ttlMs", 120000).containsEntry("cacheScope", "public");
+
+		McpSchema.ListPromptsResult deserialized = JSON_MAPPER.readValue(value,
+				McpSchema.ListPromptsResult.class);
+		assertThat(deserialized.ttlMs()).isEqualTo(120000);
+		assertThat(deserialized.cacheScope()).isEqualTo(McpSchema.CacheScope.PUBLIC);
+	}
+
+	@Test
+	void testListPromptsResultWithoutTtl() throws Exception {
+		String json = """
+				{"prompts":[{"name":"p","title":"P","description":"A prompt"}]}""";
+		McpSchema.ListPromptsResult result = JSON_MAPPER.readValue(json, McpSchema.ListPromptsResult.class);
+		assertThat(result.ttlMs()).isNull();
+		assertThat(result.cacheScope()).isNull();
+	}
+
+	@Test
+	void testListPromptsResultNullTtlOmittedFromJson() throws Exception {
+		McpSchema.ListPromptsResult result = McpSchema.ListPromptsResult.builder(List.of()).build();
+		String value = JSON_MAPPER.writeValueAsString(result);
+		assertThatJson(value).isObject().doesNotContainKey("ttlMs").doesNotContainKey("cacheScope");
+	}
+
+	@Test
+	void testListToolsResultWithTtl() throws Exception {
+		McpSchema.Tool tool = McpSchema.Tool.builder("test-tool")
+			.title("Test Tool")
+			.description("A test tool")
+			.inputSchema(Map.of("type", "object"))
+			.build();
+
+		McpSchema.ListToolsResult result = McpSchema.ListToolsResult.builder(List.of(tool))
+			.nextCursor("cursor")
+			.ttlMs(300000)
+			.cacheScope(McpSchema.CacheScope.PUBLIC)
+			.build();
+
+		String value = JSON_MAPPER.writeValueAsString(result);
+		assertThatJson(value).isObject()
+			.containsEntry("ttlMs", 300000)
+			.containsEntry("cacheScope", "public")
+			.containsEntry("nextCursor", "cursor");
+
+		McpSchema.ListToolsResult deserialized = JSON_MAPPER.readValue(value, McpSchema.ListToolsResult.class);
+		assertThat(deserialized.ttlMs()).isEqualTo(300000);
+		assertThat(deserialized.cacheScope()).isEqualTo(McpSchema.CacheScope.PUBLIC);
+		assertThat(deserialized.tools()).hasSize(1);
+		assertThat(deserialized.nextCursor()).isEqualTo("cursor");
+	}
+
+	@Test
+	void testListToolsResultWithoutTtl() throws Exception {
+		String json = """
+				{"tools":[{"name":"t","inputSchema":{"type":"object"}}]}""";
+		McpSchema.ListToolsResult result = JSON_MAPPER.readValue(json, McpSchema.ListToolsResult.class);
+		assertThat(result.ttlMs()).isNull();
+		assertThat(result.cacheScope()).isNull();
+		assertThat(result.tools()).hasSize(1);
+	}
+
+	@Test
+	void testListToolsResultNullTtlOmittedFromJson() throws Exception {
+		McpSchema.ListToolsResult result = McpSchema.ListToolsResult.builder(List.of()).build();
+		String value = JSON_MAPPER.writeValueAsString(result);
+		assertThatJson(value).isObject().doesNotContainKey("ttlMs").doesNotContainKey("cacheScope");
+	}
+
+	@Test
+	void testCacheScopeSerialization() throws Exception {
+		assertThat(JSON_MAPPER.writeValueAsString(McpSchema.CacheScope.PUBLIC)).isEqualTo("\"public\"");
+		assertThat(JSON_MAPPER.writeValueAsString(McpSchema.CacheScope.PRIVATE)).isEqualTo("\"private\"");
+	}
+
+	@Test
+	void testCacheScopeDeserialization() throws Exception {
+		assertThat(JSON_MAPPER.readValue("\"public\"", McpSchema.CacheScope.class))
+			.isEqualTo(McpSchema.CacheScope.PUBLIC);
+		assertThat(JSON_MAPPER.readValue("\"private\"", McpSchema.CacheScope.class))
+			.isEqualTo(McpSchema.CacheScope.PRIVATE);
+	}
+
+	@Test
+	void testListResourcesResultToleratesUnknownFields() throws Exception {
+		McpSchema.ListResourcesResult result = JSON_MAPPER.readValue("""
+				{"resources":[],"ttlMs":5000,"cacheScope":"public","futureField":"ignored"}""",
+				McpSchema.ListResourcesResult.class);
+		assertThat(result.ttlMs()).isEqualTo(5000);
+		assertThat(result.cacheScope()).isEqualTo(McpSchema.CacheScope.PUBLIC);
+	}
+
+	@Test
+	void testListResourceTemplatesResultToleratesUnknownFields() throws Exception {
+		McpSchema.ListResourceTemplatesResult result = JSON_MAPPER.readValue("""
+				{"resourceTemplates":[],"ttlMs":5000,"cacheScope":"private","futureField":"ignored"}""",
+				McpSchema.ListResourceTemplatesResult.class);
+		assertThat(result.ttlMs()).isEqualTo(5000);
+		assertThat(result.cacheScope()).isEqualTo(McpSchema.CacheScope.PRIVATE);
+	}
+
+	@Test
+	void testReadResourceResultToleratesUnknownFields() throws Exception {
+		McpSchema.ReadResourceResult result = JSON_MAPPER.readValue("""
+				{"contents":[],"ttlMs":0,"cacheScope":"private","futureField":"ignored"}""",
+				McpSchema.ReadResourceResult.class);
+		assertThat(result.ttlMs()).isEqualTo(0);
+		assertThat(result.cacheScope()).isEqualTo(McpSchema.CacheScope.PRIVATE);
+	}
+
+	@Test
+	void testListPromptsResultToleratesUnknownFields() throws Exception {
+		McpSchema.ListPromptsResult result = JSON_MAPPER.readValue("""
+				{"prompts":[],"ttlMs":10000,"cacheScope":"public","futureField":"ignored"}""",
+				McpSchema.ListPromptsResult.class);
+		assertThat(result.ttlMs()).isEqualTo(10000);
+		assertThat(result.cacheScope()).isEqualTo(McpSchema.CacheScope.PUBLIC);
+	}
+
+	@Test
+	void testListToolsResultToleratesUnknownFields() throws Exception {
+		McpSchema.ListToolsResult result = JSON_MAPPER.readValue("""
+				{"tools":[],"ttlMs":60000,"cacheScope":"public","futureField":"ignored"}""",
+				McpSchema.ListToolsResult.class);
+		assertThat(result.ttlMs()).isEqualTo(60000);
+		assertThat(result.cacheScope()).isEqualTo(McpSchema.CacheScope.PUBLIC);
+	}
+
 }


### PR DESCRIPTION
Add ttlMs and cacheScope to cacheable result records (SEP-2549)

## Motivation and Context

SEP-2549 introduces TTL caching hints so clients and intermediaries (gateways, proxies) can cache list and read results without re-fetching on every request. The draft spec adds two fields to cacheable result types:

- `ttlMs` (integer, >= 0): how long in milliseconds the client may consider the response fresh, analogous to HTTP `Cache-Control: max-age`
- `cacheScope` (enum: `"private"` / `"public"`): whether the response may be shared across authorization contexts, analogous to HTTP `Cache-Control: private` vs `public`

This PR adds the schema fields and server-side default stamping. The server now emits `ttlMs=0` (immediately stale) and `cacheScope="public"` on all cacheable responses. Server-side configuration hooks for user-defined TTLs are intentionally left out following @Kehrlann's note that those belong with the repositories refactor in #578 (and the related #1034).

Towards #1009

## How Has This Been Tested?

UT + IT

## Breaking Changes

None. Both fields are optional (nullable), existing constructors are preserved as `@Deprecated` overloads.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

**Remaining work for full #1009 coverage** (follow-up PRs):
- Server configuration API for authors to set TTL per method/resource (dependent on #578)
- Client-side TTL response cache with notification-driven invalidation
