### PR TITLE
feat: add extensions attribute to ClientCapabilities and ServerCapabilities

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -781,22 +781,6 @@ public final class McpSchema {
 				return this;
 			}
 
-			/**
-			 * Adds support for a single extension; {@code null} settings are sent as an
-			 * empty JSON object.
-			 * @param id the extension identifier
-			 * @param settings the per-extension settings, or {@code null}
-			 * @return this builder
-			 */
-			public Builder extension(String id, Map<String, Object> settings) {
-				Assert.hasText(id, "id must not be null or empty");
-				Map<String, Object> merged = (this.extensions != null) ? new HashMap<>(this.extensions)
-						: new HashMap<>();
-				merged.put(id, settings != null ? settings : Map.of());
-				this.extensions = merged;
-				return this;
-			}
-
 			public ClientCapabilities build() {
 				return new ClientCapabilities(experimental, roots, sampling, elicitation, extensions);
 			}
@@ -1021,22 +1005,6 @@ public final class McpSchema {
 
 			public Builder extensions(Map<String, Object> extensions) {
 				this.extensions = extensions;
-				return this;
-			}
-
-			/**
-			 * Adds support for a single extension; {@code null} settings are sent as an
-			 * empty JSON object.
-			 * @param id the extension identifier
-			 * @param settings the per-extension settings, or {@code null}
-			 * @return this builder
-			 */
-			public Builder extension(String id, Map<String, Object> settings) {
-				Assert.hasText(id, "id must not be null or empty");
-				Map<String, Object> merged = (this.extensions != null) ? new HashMap<>(this.extensions)
-						: new HashMap<>();
-				merged.put(id, settings != null ? settings : Map.of());
-				this.extensions = merged;
 				return this;
 			}
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -577,6 +577,8 @@ public final class McpSchema {
 	 * @param roots Present if the client supports listing roots
 	 * @param sampling Present if the client supports sampling from an LLM
 	 * @param elicitation Present if the client supports elicitation from the server
+	 * @param extensions Present if the client supports MCP extensions, keyed by extension
+	 * identifier
 	 */
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
@@ -584,7 +586,14 @@ public final class McpSchema {
 		@JsonProperty("experimental") Map<String, Object> experimental,
 		@JsonProperty("roots") RootCapabilities roots,
 		@JsonProperty("sampling") Sampling sampling,
-		@JsonProperty("elicitation") Elicitation elicitation) { // @formatter:on
+		@JsonProperty("elicitation") Elicitation elicitation,
+		@JsonProperty("extensions") Map<String, Object> extensions) { // @formatter:on
+
+		// Keep the old constructor so existing callers still compile
+		public ClientCapabilities(Map<String, Object> experimental, RootCapabilities roots, Sampling sampling,
+				Elicitation elicitation) {
+			this(experimental, roots, sampling, elicitation, null);
+		}
 
 		/**
 		 * Present if the client supports listing roots.
@@ -723,6 +732,8 @@ public final class McpSchema {
 
 			private Elicitation elicitation;
 
+			private Map<String, Object> extensions;
+
 			public Builder experimental(Map<String, Object> experimental) {
 				this.experimental = experimental;
 				return this;
@@ -765,8 +776,29 @@ public final class McpSchema {
 				return this;
 			}
 
+			public Builder extensions(Map<String, Object> extensions) {
+				this.extensions = extensions;
+				return this;
+			}
+
+			/**
+			 * Adds support for a single extension; {@code null} settings are sent as an
+			 * empty JSON object.
+			 * @param id the extension identifier
+			 * @param settings the per-extension settings, or {@code null}
+			 * @return this builder
+			 */
+			public Builder extension(String id, Map<String, Object> settings) {
+				Assert.hasText(id, "id must not be null or empty");
+				Map<String, Object> merged = (this.extensions != null) ? new HashMap<>(this.extensions)
+						: new HashMap<>();
+				merged.put(id, settings != null ? settings : Map.of());
+				this.extensions = merged;
+				return this;
+			}
+
 			public ClientCapabilities build() {
-				return new ClientCapabilities(experimental, roots, sampling, elicitation);
+				return new ClientCapabilities(experimental, roots, sampling, elicitation, extensions);
 			}
 
 		}

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -817,6 +817,8 @@ public final class McpSchema {
 	 * @param prompts Present if the server offers any prompt templates
 	 * @param resources Present if the server offers any resources to read
 	 * @param tools Present if the server offers any tools to call
+	 * @param extensions Present if the server supports MCP extensions, keyed by extension
+	 * identifier
 	 */
 	@JsonInclude(JsonInclude.Include.NON_ABSENT)
 	@JsonIgnoreProperties(ignoreUnknown = true)
@@ -826,7 +828,15 @@ public final class McpSchema {
 		@JsonProperty("logging") LoggingCapabilities logging,
 		@JsonProperty("prompts") PromptCapabilities prompts,
 		@JsonProperty("resources") ResourceCapabilities resources,
-		@JsonProperty("tools") ToolCapabilities tools) { // @formatter:on
+		@JsonProperty("tools") ToolCapabilities tools,
+		@JsonProperty("extensions") Map<String, Object> extensions) { // @formatter:on
+
+		// Keep the old constructor so existing callers still compile
+		public ServerCapabilities(CompletionCapabilities completions, Map<String, Object> experimental,
+				LoggingCapabilities logging, PromptCapabilities prompts, ResourceCapabilities resources,
+				ToolCapabilities tools) {
+			this(completions, experimental, logging, prompts, resources, tools, null);
+		}
 
 		/**
 		 * Present if the server supports argument autocompletion suggestions.
@@ -955,6 +965,7 @@ public final class McpSchema {
 			builder.prompts = this.prompts;
 			builder.resources = this.resources;
 			builder.tools = this.tools;
+			builder.extensions = this.extensions;
 			return builder;
 		}
 
@@ -975,6 +986,8 @@ public final class McpSchema {
 			private ResourceCapabilities resources;
 
 			private ToolCapabilities tools;
+
+			private Map<String, Object> extensions;
 
 			public Builder completions() {
 				this.completions = new CompletionCapabilities();
@@ -1006,8 +1019,30 @@ public final class McpSchema {
 				return this;
 			}
 
+			public Builder extensions(Map<String, Object> extensions) {
+				this.extensions = extensions;
+				return this;
+			}
+
+			/**
+			 * Adds support for a single extension; {@code null} settings are sent as an
+			 * empty JSON object.
+			 * @param id the extension identifier
+			 * @param settings the per-extension settings, or {@code null}
+			 * @return this builder
+			 */
+			public Builder extension(String id, Map<String, Object> settings) {
+				Assert.hasText(id, "id must not be null or empty");
+				Map<String, Object> merged = (this.extensions != null) ? new HashMap<>(this.extensions)
+						: new HashMap<>();
+				merged.put(id, settings != null ? settings : Map.of());
+				this.extensions = merged;
+				return this;
+			}
+
 			public ServerCapabilities build() {
-				return new ServerCapabilities(completions, experimental, logging, prompts, resources, tools);
+				return new ServerCapabilities(completions, experimental, logging, prompts, resources, tools,
+						extensions);
 			}
 
 		}

--- a/mcp-test/src/test/java/io/modelcontextprotocol/spec/SchemaEvolutionTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/spec/SchemaEvolutionTests.java
@@ -144,6 +144,35 @@ class SchemaEvolutionTests {
 		assertThat(caps.tools().listChanged()).isTrue();
 	}
 
+	@Test
+	void serverCapabilitiesWithoutExtensionsDeserializesAsNull() throws IOException {
+		String json = """
+				{"tools":{"listChanged":true}}
+				""";
+		McpSchema.ServerCapabilities caps = mapper.readValue(json, McpSchema.ServerCapabilities.class);
+		assertThat(caps.extensions()).isNull();
+	}
+
+	@Test
+	void serverCapabilitiesWithNullExtensionsOmitsFieldOnWire() throws IOException {
+		String json = mapper.writeValueAsString(McpSchema.ServerCapabilities.builder().tools(true).build());
+		assertThat(json).doesNotContain("extensions");
+	}
+
+	@Test
+	void serverCapabilitiesExtensionsRoundTrip() throws IOException {
+		McpSchema.ServerCapabilities caps = McpSchema.ServerCapabilities.builder()
+			.extension("com.example/ext-with-settings", Map.of("maxDepth", 3))
+			.extension("com.example/ext-without-settings", null)
+			.build();
+
+		String json = mapper.writeValueAsString(caps);
+		assertThat(json).contains("\"com.example/ext-without-settings\":{}");
+
+		McpSchema.ServerCapabilities parsed = mapper.readValue(json, McpSchema.ServerCapabilities.class);
+		assertThat(parsed.extensions()).isEqualTo(caps.extensions());
+	}
+
 	// -----------------------------------------------------------------------
 	// ClientCapabilities.extensions
 	// -----------------------------------------------------------------------

--- a/mcp-test/src/test/java/io/modelcontextprotocol/spec/SchemaEvolutionTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/spec/SchemaEvolutionTests.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import io.modelcontextprotocol.json.McpJsonMapper;
 import org.junit.jupiter.api.Test;
@@ -141,6 +142,48 @@ class SchemaEvolutionTests {
 		McpSchema.ServerCapabilities caps = mapper.readValue(json, McpSchema.ServerCapabilities.class);
 		assertThat(caps.tools()).isNotNull();
 		assertThat(caps.tools().listChanged()).isTrue();
+	}
+
+	// -----------------------------------------------------------------------
+	// ClientCapabilities.extensions
+	// -----------------------------------------------------------------------
+
+	@Test
+	void clientCapabilitiesWithoutExtensionsDeserializesAsNull() throws IOException {
+		String json = """
+				{"roots":{"listChanged":true},"sampling":{}}
+				""";
+		McpSchema.ClientCapabilities caps = mapper.readValue(json, McpSchema.ClientCapabilities.class);
+		assertThat(caps.extensions()).isNull();
+	}
+
+	@Test
+	void clientCapabilitiesWithNullExtensionsOmitsFieldOnWire() throws IOException {
+		String json = mapper.writeValueAsString(McpSchema.ClientCapabilities.builder().sampling().build());
+		assertThat(json).doesNotContain("extensions");
+	}
+
+	@Test
+	void clientCapabilitiesWithExtensionsUnknownFieldsIgnored() throws IOException {
+		String json = """
+				{"extensions":{"io.modelcontextprotocol/tasks":{}},"futureCapability":{"a":1}}
+				""";
+		McpSchema.ClientCapabilities caps = mapper.readValue(json, McpSchema.ClientCapabilities.class);
+		assertThat(caps.extensions()).containsOnlyKeys("io.modelcontextprotocol/tasks");
+	}
+
+	@Test
+	void clientCapabilitiesExtensionsRoundTrip() throws IOException {
+		McpSchema.ClientCapabilities caps = McpSchema.ClientCapabilities.builder()
+			.extension("com.example/ext-with-settings", Map.of("maxDepth", 3))
+			.extension("com.example/ext-without-settings", null)
+			.build();
+
+		String json = mapper.writeValueAsString(caps);
+		assertThat(json).contains("\"com.example/ext-without-settings\":{}");
+
+		McpSchema.ClientCapabilities parsed = mapper.readValue(json, McpSchema.ClientCapabilities.class);
+		assertThat(parsed.extensions()).isEqualTo(caps.extensions());
 	}
 
 	// -----------------------------------------------------------------------

--- a/mcp-test/src/test/java/io/modelcontextprotocol/spec/SchemaEvolutionTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/spec/SchemaEvolutionTests.java
@@ -161,16 +161,15 @@ class SchemaEvolutionTests {
 
 	@Test
 	void serverCapabilitiesExtensionsRoundTrip() throws IOException {
-		McpSchema.ServerCapabilities caps = McpSchema.ServerCapabilities.builder()
-			.extension("com.example/ext-with-settings", Map.of("maxDepth", 3))
-			.extension("com.example/ext-without-settings", null)
-			.build();
+		Map<String, Object> extensions = Map.of("com.example/ext-with-settings", Map.of("maxDepth", 3),
+				"com.example/ext-without-settings", Map.of());
+		McpSchema.ServerCapabilities caps = McpSchema.ServerCapabilities.builder().extensions(extensions).build();
 
 		String json = mapper.writeValueAsString(caps);
 		assertThat(json).contains("\"com.example/ext-without-settings\":{}");
 
 		McpSchema.ServerCapabilities parsed = mapper.readValue(json, McpSchema.ServerCapabilities.class);
-		assertThat(parsed.extensions()).isEqualTo(caps.extensions());
+		assertThat(parsed.extensions()).isEqualTo(extensions);
 	}
 
 	// -----------------------------------------------------------------------
@@ -203,16 +202,15 @@ class SchemaEvolutionTests {
 
 	@Test
 	void clientCapabilitiesExtensionsRoundTrip() throws IOException {
-		McpSchema.ClientCapabilities caps = McpSchema.ClientCapabilities.builder()
-			.extension("com.example/ext-with-settings", Map.of("maxDepth", 3))
-			.extension("com.example/ext-without-settings", null)
-			.build();
+		Map<String, Object> extensions = Map.of("com.example/ext-with-settings", Map.of("maxDepth", 3),
+				"com.example/ext-without-settings", Map.of());
+		McpSchema.ClientCapabilities caps = McpSchema.ClientCapabilities.builder().extensions(extensions).build();
 
 		String json = mapper.writeValueAsString(caps);
 		assertThat(json).contains("\"com.example/ext-without-settings\":{}");
 
 		McpSchema.ClientCapabilities parsed = mapper.readValue(json, McpSchema.ClientCapabilities.class);
-		assertThat(parsed.extensions()).isEqualTo(caps.extensions());
+		assertThat(parsed.extensions()).isEqualTo(extensions);
 	}
 
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
Add the optional `extensions` field to `ClientCapabilities` and `ServerCapabilities`, mirroring the MCP extensions framework (SEP-2133) as declared in the draft schema and already shipped by the TypeScript, Python, C#, Go, Rust, and Kotlin SDKs.

Refs modelcontextprotocol/java-sdk#785

<!-- Provide a brief summary of your changes -->

## Motivation and Context
## Spec + cross-SDK precedent

- **Spec:** defined on `ClientCapabilities` (and `ServerCapabilities`) in the
  draft schema — [`schema/draft/schema.ts#L785`](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/26897cc322f356487da89113451bd16b520b9288/schema/draft/schema.ts#L785)
  (server twin at [`#L882`](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/26897cc322f356487da89113451bd16b520b9288/schema/draft/schema.ts#L882)) —
  introduced by [SEP-2133](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2133)
  (merged into the spec 2026-01-26). Type: `{ [key: string]: object }`. Keys are
  extension identifiers following `_meta` naming rules; an empty object means
  "supported, no settings". See also the
  [extensions overview docs](https://modelcontextprotocol.io/docs/extensions/overview).
- **Other SDKs already ship it** on `ClientCapabilities`. Java is the only major
  SDK without it:
  - [TypeScript](https://github.com/modelcontextprotocol/typescript-sdk/blob/1480241e2a2a7f0ceee8e7723b2adcf88579bb36/packages/core-internal/src/types/spec.types.2026-07-28.ts#L754) — `extensions?: { [key: string]: JSONObject };`
  - [Python](https://github.com/modelcontextprotocol/python-sdk/blob/3a6f2996cdd8358957479791e8b26198c07d6a75/src/mcp-types/mcp_types/_types.py#L400) — `extensions: dict[str, dict[str, Any]] | None = None`
  - [C#/.NET](https://github.com/modelcontextprotocol/csharp-sdk/blob/0d34048e5fc0a2e5a579a2d48a17308083a50028/src/ModelContextProtocol.Core/Protocol/ClientCapabilities.cs#L86) — `IDictionary<string, object>? Extensions`
  - [Go](https://github.com/modelcontextprotocol/go-sdk/blob/827f90ba0c13edb546028df42fadc9f1211a4ff2/mcp/protocol.go#L475) — `Extensions map[string]any`
  - [Rust](https://github.com/modelcontextprotocol/rust-sdk/blob/bc2c5f3c4a0bfdd91be6c3a49957dc4868a35321/crates/rmcp/src/model/capabilities.rs#L309) — `extensions: Option<ExtensionCapabilities>`
  - [Kotlin](https://github.com/modelcontextprotocol/kotlin-sdk/blob/5cb76fd0401dc33ff279520456dfee62033f363e/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/capabilities.kt#L62) — `Map<String, JsonObject>? = null` 

## How Has This Been Tested?
Added 3 tests per new field per the contributing guidelines.
- Deserialize JSON without the field → succeeds, field is null.
- Serialize an instance with the field unset (null) → the key is absent from output.
- Deserialize JSON with an extra unknown field → succeeds.

## Breaking Changes
No breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
