### PR TITLE
Fix #275: Reject uninitialized session requests with INVALID_REQUEST

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpServerSession.java
@@ -287,8 +287,12 @@ public class McpServerSession implements McpLoggableSession {
 				resultMono = this.initRequestHandler.handle(initializeRequest);
 			}
 			else {
-				// TODO handle errors for communication to this session without
-				// initialization happening first
+				if (this.state.get() != STATE_INITIALIZED) {
+					logger.warn("Rejecting uninitialized request method: {}", request.method());
+					return Mono.just(McpSchema.JSONRPCResponse.error(request.id(),
+							new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INVALID_REQUEST,
+									"Session is not initialized. Cannot process method: " + request.method(), null)));
+				}
 				var handler = this.requestHandlers.get(request.method());
 				if (handler == null) {
 					MethodNotFoundError error = getMethodNotFoundError(request.method());
@@ -326,6 +330,12 @@ public class McpServerSession implements McpLoggableSession {
 				// legacy SSE transport.
 				exchangeSink.tryEmitValue(new McpAsyncServerExchange(this.id, this, clientCapabilities.get(),
 						clientInfo.get(), transportContext, this.jsonSchemaValidator));
+			}
+			else if (this.state.get() != STATE_INITIALIZED) {
+				logger.warn("Rejecting uninitialized notification method: {}", notification.method());
+				return Mono
+					.error(new McpError(new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INVALID_REQUEST,
+							"Session is not initialized. Cannot process method: " + notification.method(), null)));
 			}
 
 			var handler = notificationHandlers.get(notification.method());


### PR DESCRIPTION
Resolves #275 by immediately rejecting requests sent before the session is fully initialized.

## Motivation and Context
Right now, if a client accidentally sends a request (or notification) before completing the `notifications/initialized` handshake, the server just silently hangs. This happens because `McpServerSession` routes it to `exchangeSink.asMono()`, which waits forever since the sink only emits when the init notification arrives. 

This PR fixes that silent failure by returning a proper JSON-RPC `-32600` (`INVALID_REQUEST`) error instead. This gives client devs immediate feedback if they mess up the handshake order. I also added a quick `logger.warn` so server admins can see these rejections.

## How Has This Been Tested?
I tested this locally by running the build and verifying the state machine logic in `McpServerSession`. Since this just intercepts the request before it hits the sink, it's a very straightforward guard clause.

## Breaking Changes
No breaking changes. It just replaces an indefinite hang with a fast-fail error response.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
I made sure to append the method name to the error message string to make it slightly easier to debug on the client side. Also double-checked the MCP spec to ensure rejecting pre-init messages with `INVALID_REQUEST` is fully compliant.
