### PR TITLE
Reject listRoots when client lacks roots capability

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
@@ -225,6 +225,13 @@ public class McpAsyncServerExchange {
 	 * @return A Mono that emits the list of roots result containing
 	 */
 	public Mono<McpSchema.ListRootsResult> listRoots(String cursor) {
+		if (this.clientCapabilities == null) {
+			return Mono
+				.error(new IllegalStateException("Client must be initialized. Call the initialize method first!"));
+		}
+		if (this.clientCapabilities.roots() == null) {
+			return Mono.error(new IllegalStateException("Client must be configured with roots capabilities"));
+		}
 		return this.session.sendRequest(McpSchema.METHOD_ROOTS_LIST, new McpSchema.PaginatedRequest(cursor),
 				LIST_ROOTS_RESULT_TYPE_REF);
 	}

--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/McpAsyncServerExchangeTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/McpAsyncServerExchangeTests.java
@@ -171,6 +171,40 @@ class McpAsyncServerExchangeTests {
 	}
 
 	@Test
+	void testListRootsWithNullCapabilities() {
+		// Given - Create exchange with null capabilities
+		McpAsyncServerExchange exchangeWithNullCapabilities = new McpAsyncServerExchange("testSessionId", mockSession,
+				null, clientInfo, McpTransportContext.EMPTY);
+
+		StepVerifier.create(exchangeWithNullCapabilities.listRoots()).verifyErrorSatisfies(error -> {
+			assertThat(error).isInstanceOf(IllegalStateException.class)
+				.hasMessage("Client must be initialized. Call the initialize method first!");
+		});
+
+		// Verify that sendRequest was never called due to null capabilities
+		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(), any(TypeRef.class));
+	}
+
+	@Test
+	void testListRootsWithoutRootsCapabilities() {
+		// Given - Create exchange without roots capabilities
+		McpSchema.ClientCapabilities capabilitiesWithoutRoots = McpSchema.ClientCapabilities.builder()
+			.sampling()
+			.build();
+
+		McpAsyncServerExchange exchangeWithoutRoots = new McpAsyncServerExchange("testSessionId", mockSession,
+				capabilitiesWithoutRoots, clientInfo, McpTransportContext.EMPTY);
+
+		StepVerifier.create(exchangeWithoutRoots.listRoots()).verifyErrorSatisfies(error -> {
+			assertThat(error).isInstanceOf(IllegalStateException.class)
+				.hasMessage("Client must be configured with roots capabilities");
+		});
+
+		// Verify that sendRequest was never called due to missing roots capabilities
+		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(), any(TypeRef.class));
+	}
+
+	@Test
 	void testListRootsUnmodifiabilityAfterAccumulation() {
 
 		List<McpSchema.Root> page1Roots = new ArrayList<>(

--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/McpSyncServerExchangeTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/McpSyncServerExchangeTests.java
@@ -170,6 +170,39 @@ class McpSyncServerExchangeTests {
 	}
 
 	@Test
+	void testListRootsWithNullCapabilities() {
+		// Given - Create exchange with null capabilities
+		McpAsyncServerExchange asyncExchangeWithNullCapabilities = new McpAsyncServerExchange("testSessionId",
+				mockSession, null, clientInfo, McpTransportContext.EMPTY);
+		McpSyncServerExchange exchangeWithNullCapabilities = new McpSyncServerExchange(
+				asyncExchangeWithNullCapabilities);
+
+		assertThatThrownBy(() -> exchangeWithNullCapabilities.listRoots()).isInstanceOf(IllegalStateException.class)
+			.hasMessage("Client must be initialized. Call the initialize method first!");
+
+		// Verify that sendRequest was never called due to null capabilities
+		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(), any(TypeRef.class));
+	}
+
+	@Test
+	void testListRootsWithoutRootsCapabilities() {
+		// Given - Create exchange without roots capabilities
+		McpSchema.ClientCapabilities capabilitiesWithoutRoots = McpSchema.ClientCapabilities.builder()
+			.sampling()
+			.build();
+
+		McpAsyncServerExchange asyncExchangeWithoutRoots = new McpAsyncServerExchange("testSessionId", mockSession,
+				capabilitiesWithoutRoots, clientInfo, McpTransportContext.EMPTY);
+		McpSyncServerExchange exchangeWithoutRoots = new McpSyncServerExchange(asyncExchangeWithoutRoots);
+
+		assertThatThrownBy(() -> exchangeWithoutRoots.listRoots()).isInstanceOf(IllegalStateException.class)
+			.hasMessage("Client must be configured with roots capabilities");
+
+		// Verify that sendRequest was never called due to missing roots capabilities
+		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(), any(TypeRef.class));
+	}
+
+	@Test
 	void testListRootsUnmodifiabilityAfterAccumulation() {
 
 		List<McpSchema.Root> page1Roots = new ArrayList<>(

--- a/mcp-test/src/main/java/io/modelcontextprotocol/AbstractMcpClientServerIntegrationTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/AbstractMcpClientServerIntegrationTests.java
@@ -1056,12 +1056,10 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			assertThat(mcpClient.initialize()).isNotNull();
 
 			// Attempt to list roots should fail
-			try {
-				mcpClient.callTool(McpSchema.CallToolRequest.builder("tool1").arguments(Map.of()).build());
-			}
-			catch (McpError e) {
-				assertThat(e).isInstanceOf(McpError.class).hasMessage("Roots not supported");
-			}
+			assertThatThrownBy(
+					() -> mcpClient.callTool(McpSchema.CallToolRequest.builder("tool1").arguments(Map.of()).build()))
+				.isInstanceOf(McpError.class)
+				.hasMessage("Client must be configured with roots capabilities");
 		}
 		finally {
 			mcpServer.closeGracefully();


### PR DESCRIPTION
## Motivation and Context

Fixes #1067.

`McpAsyncServerExchange.listRoots()` sends a `roots/list` request even when the client did not declare the roots capability. Depending on the client, that ends in a confusing client-side error after a wire round-trip, or in a hang until `requestTimeout` if the client ignores unknown methods. `createMessage()` and `createElicitation()` in the same class already fail fast on a missing capability; `listRoots()` was the odd one out.

## Description

- `listRoots(String cursor)` now returns `Mono.error(IllegalStateException)` when the client is not initialized or did not declare the roots capability, without sending any request. The guard covers the no-arg `listRoots()` (a pagination aggregator over the cursor variant) and the sync exchange (delegates to async).
- The error message reuses the wording already used for the same situation in `McpAsyncClient`: "Client must be configured with roots capabilities".

## How Has This Been Tested?

Four new unit tests in `McpAsyncServerExchangeTests` and `McpSyncServerExchangeTests` (null capabilities and missing roots capability), each also verifying that `sendRequest` is never called. All four were verified to fail without the production change.

The existing `testRootsWithoutCapability` integration test asserted the old behavior (client-side "Roots not supported" error after the request crossed the wire); it now expects the server-side fail-fast error and asserts strictly that the call throws.

```
./mvnw clean test -pl mcp-core,mcp-test -am
BUILD SUCCESS, 0 failures (mcp-test: 936 tests)
```

## Breaking Changes

None in the semver sense (bug fix aligning behavior with the sibling methods). Behavior change to be aware of: server-side callers of `listRoots()` against a capability-less client now get an immediate `IllegalStateException` instead of a client error or a timeout.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
