### PR TITLE
fix McpTransportContext.create() mutability issue and add tests

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/common/DefaultMcpTransportContext.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/common/DefaultMcpTransportContext.java
@@ -20,7 +20,7 @@ class DefaultMcpTransportContext implements McpTransportContext {
 
 	DefaultMcpTransportContext(Map<String, Object> metadata) {
 		Assert.notNull(metadata, "The metadata cannot be null");
-		this.metadata = metadata;
+		this.metadata = Map.copyOf(metadata);
 	}
 
 	@Override

--- a/mcp-core/src/test/java/io/modelcontextprotocol/common/McpTransportContextTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/common/McpTransportContextTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link McpTransportContext#create(Map)}, which is documented to return an
+ * unmodifiable context.
+ */
+class McpTransportContextTests {
+
+	@Test
+	void createdContextShouldNotSeeLaterWritesToTheSourceMap() {
+		Map<String, Object> metadata = new HashMap<>();
+		metadata.put("tenant", "acme");
+
+		McpTransportContext context = McpTransportContext.create(metadata);
+		metadata.put("tenant", "other");
+
+		assertThat(context.get("tenant")).isEqualTo("acme");
+	}
+
+	@Test
+	void createdContextShouldNotSeeLaterAdditionsToTheSourceMap() {
+		Map<String, Object> metadata = new HashMap<>();
+		metadata.put("tenant", "acme");
+
+		McpTransportContext context = McpTransportContext.create(metadata);
+		metadata.put("added-after-the-fact", "surprise");
+
+		assertThat(context.get("added-after-the-fact")).isNull();
+	}
+
+	@Test
+	void createdContextShouldNotBeEmptiedByClearingTheSourceMap() {
+		Map<String, Object> metadata = new HashMap<>();
+		metadata.put("tenant", "acme");
+
+		McpTransportContext context = McpTransportContext.create(metadata);
+		metadata.clear();
+
+		assertThat(context.get("tenant")).isEqualTo("acme");
+	}
+
+	@Test
+	void createdContextShouldRemainUsableAsAMapKey() {
+		Map<String, Object> metadata = new HashMap<>();
+		metadata.put("tenant", "acme");
+		McpTransportContext context = McpTransportContext.create(metadata);
+
+		Map<McpTransportContext, String> byContext = new HashMap<>();
+		byContext.put(context, "value");
+		metadata.put("tenant", "other");
+
+		assertThat(byContext.get(context)).isEqualTo("value");
+	}
+
+	@Test
+	void twoContextsCreatedFromEqualMapsShouldStayEqual() {
+		Map<String, Object> first = new HashMap<>();
+		first.put("tenant", "acme");
+		Map<String, Object> second = new HashMap<>();
+		second.put("tenant", "acme");
+
+		McpTransportContext firstContext = McpTransportContext.create(first);
+		McpTransportContext secondContext = McpTransportContext.create(second);
+		assertThat(firstContext).isEqualTo(secondContext);
+
+		first.put("tenant", "other");
+
+		assertThat(firstContext).isEqualTo(secondContext);
+	}
+
+	@Test
+	void createdContextFromAnImmutableMapIsAlreadyCorrect() {
+		McpTransportContext context = McpTransportContext.create(Map.of("tenant", "acme"));
+
+		assertThat(context.get("tenant")).isEqualTo("acme");
+	}
+
+}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
Fixes https://github.com/modelcontextprotocol/java-sdk/issues/1077.

## How Has This Been Tested?
Add new tests that reproduce the issue.

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
