### PR TITLE
Add option to disable standalone SSE stream

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -156,12 +156,14 @@ McpTransport transport = new StdioClientTransport(params, McpJsonDefaults.getMap
     McpTransport transport = HttpClientStreamableHttpTransport
         .builder("http://your-mcp-server")
         .endpoint("/mcp")
+        .openSseStream(false) // Optional: use POST request-response mode only
         .build();
     ```
 
     The Streamable HTTP transport supports:
 
     - Resumable streams for connection recovery
+    - Optional standalone GET SSE stream for server-initiated messages
     - Configurable connect timeout
     - Custom HTTP request customization
     - Multiple protocol version negotiation

--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java
@@ -145,6 +145,8 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 
 	private final boolean openConnectionOnStartup;
 
+	private final boolean openSseStream;
+
 	private final McpHttpClientTransportAuthorizationErrorHandler authorizationErrorHandler;
 
 	private final boolean resumableStreams;
@@ -163,7 +165,8 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 
 	private HttpClientStreamableHttpTransport(McpJsonMapper jsonMapper, HttpClient httpClient,
 			HttpRequest.Builder requestBuilder, String baseUri, String endpoint, boolean resumableStreams,
-			boolean openConnectionOnStartup, McpAsyncHttpClientRequestCustomizer httpRequestCustomizer,
+			boolean openConnectionOnStartup, boolean openSseStream,
+			McpAsyncHttpClientRequestCustomizer httpRequestCustomizer,
 			McpHttpClientTransportAuthorizationErrorHandler authorizationErrorHandler,
 			List<String> supportedProtocolVersions) {
 		this.jsonMapper = jsonMapper;
@@ -173,6 +176,7 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 		this.endpoint = endpoint;
 		this.resumableStreams = resumableStreams;
 		this.openConnectionOnStartup = openConnectionOnStartup;
+		this.openSseStream = openSseStream;
 		this.authorizationErrorHandler = authorizationErrorHandler;
 		this.activeSession.set(createTransportSession());
 		this.httpRequestCustomizer = httpRequestCustomizer;
@@ -196,7 +200,7 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 	public Mono<Void> connect(Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>> handler) {
 		return Mono.deferContextual(ctx -> {
 			this.handler.set(handler);
-			if (this.openConnectionOnStartup) {
+			if (this.openConnectionOnStartup && this.openSseStream) {
 				logger.debug("Eagerly opening connection on startup");
 				return this.reconnect(null).onErrorComplete(t -> {
 					logger.warn("Eager connect failed ", t);
@@ -560,8 +564,10 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 							"Authorization error when sending message", requestSnapshot, responseEvent.responseInfo()));
 				}
 
-				if (transportSession.markInitialized(
-						responseEvent.responseInfo().headers().firstValue("mcp-session-id").orElseGet(() -> null))) {
+				if (transportSession.markInitialized(responseEvent.responseInfo()
+					.headers()
+					.firstValue("mcp-session-id")
+					.orElseGet(() -> null)) && this.openSseStream) {
 					// Once we have a session, we try to open an async stream for
 					// the server to send notifications and requests out-of-band.
 
@@ -739,6 +745,8 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 
 		private boolean openConnectionOnStartup = false;
 
+		private boolean openSseStream = true;
+
 		private HttpRequest.Builder requestBuilder = HttpRequest.newBuilder();
 
 		private McpAsyncHttpClientRequestCustomizer httpRequestCustomizer = McpAsyncHttpClientRequestCustomizer.NOOP;
@@ -838,6 +846,20 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 		 */
 		public Builder openConnectionOnStartup(boolean openConnectionOnStartup) {
 			this.openConnectionOnStartup = openConnectionOnStartup;
+			return this;
+		}
+
+		/**
+		 * Configure whether the client should open a standalone SSE stream using an HTTP
+		 * GET request. By default, this value is {@code true}. When disabled, the client
+		 * operates without a standalone SSE stream, but can still process SSE responses
+		 * returned by HTTP POST requests.
+		 * @param openSseStream if {@code true}, the client may open a standalone SSE
+		 * stream
+		 * @return the builder instance
+		 */
+		public Builder openSseStream(boolean openSseStream) {
+			this.openSseStream = openSseStream;
 			return this;
 		}
 
@@ -957,7 +979,7 @@ public class HttpClientStreamableHttpTransport implements McpClientTransport {
 			HttpClient httpClient = this.clientBuilder.connectTimeout(this.connectTimeout).build();
 			return new HttpClientStreamableHttpTransport(jsonMapper == null ? McpJsonDefaults.getMapper() : jsonMapper,
 					httpClient, requestBuilder, baseUri, endpoint, resumableStreams, openConnectionOnStartup,
-					httpRequestCustomizer, authorizationErrorHandler, supportedProtocolVersions);
+					openSseStream, httpRequestCustomizer, authorizationErrorHandler, supportedProtocolVersions);
 		}
 
 	}

--- a/mcp-test/src/test/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransportErrorHandlingTest.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransportErrorHandlingTest.java
@@ -389,6 +389,29 @@ public class HttpClientStreamableHttpTransportErrorHandlingTest {
 		StepVerifier.create(transport.closeGracefully()).verifyComplete();
 	}
 
+	@Test
+	void shouldNotOpenSseStreamWhenDisabled() {
+		currentServerSessionId.set("test-session-123");
+		var getRequestCount = new AtomicInteger();
+		transport = HttpClientStreamableHttpTransport.builder(HOST)
+			.openConnectionOnStartup(true)
+			.openSseStream(false)
+			.asyncHttpRequestCustomizer((builder, method, uri, body, context) -> {
+				if ("GET".equals(method)) {
+					getRequestCount.incrementAndGet();
+				}
+				return Mono.just(builder);
+			})
+			.build();
+
+		StepVerifier.create(transport.connect(msg -> msg)).verifyComplete();
+		StepVerifier.create(transport.sendMessage(createTestRequestMessage())).verifyComplete();
+
+		assertThat(processedMessagesCount.get()).isEqualTo(1);
+		assertThat(getRequestCount.get()).isZero();
+		assertThat(processedSseConnectCount.get()).isZero();
+	}
+
 	@Nested
 	class AuthorizationError {
 


### PR DESCRIPTION
Adds an `openSseStream(boolean)` option to `HttpClientStreamableHttpTransport.Builder`, allowing clients to disable standalone GET SSE connections and operate using POST request-response flows only.

## Motivation and Context

The Streamable HTTP specification makes the standalone GET SSE stream optional, but the transport previously opened one automatically after session initialization.

This meant `openConnectionOnStartup(false)` could prevent the initial eager connection but could not prevent the GET request triggered by the first successful POST response.

When `openSseStream(false)` is configured:

- No GET request is made during `connect()`.
- No GET request is made after session initialization.
- POST responses, including SSE-formatted POST responses, remain supported.
- Server-initiated messages outside POST response streams are not received.

The existing behavior remains the default.

Fixes #1068.

## How Has This Been Tested?

Added a regression test covering both standalone SSE connection paths:

- Eager connection with `openConnectionOnStartup(true)`.
- Automatic connection after receiving a session ID from a POST response.

The test verifies that the POST request succeeds while no GET request is issued.

Automated tests have not been run locally.

## Breaking Changes

No breaking changes. `openSseStream` defaults to `true`, preserving the existing transport behavior.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The new option controls only the standalone SSE stream established with an HTTP GET request. It does not disable processing SSE responses returned from HTTP POST requests.

The option defaults to enabled to maintain backward compatibility:

```
var transport = HttpClientStreamableHttpTransport.builder("https://example.com")
    .openSseStream(false)
    .build();
```