### PR TITLE
fix: ignore SSE retry: field to prevent McpTransportException

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/ResponseSubscribers.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/ResponseSubscribers.java
@@ -179,6 +179,11 @@ class ResponseSubscribers {
 					logger.debug("Ignoring comment line: {}", line);
 					upstream().request(1);
 				}
+				else if (line.startsWith("retry:")) {
+					// Ignore SSE retry directive — only the server controls reconnection
+					logger.debug("Ignoring retry directive: {}", line);
+					upstream().request(1);
+				}
 				else {
 					// If the response is not successful, emit an error
 					this.sink.error(new McpTransportException(


### PR DESCRIPTION
## Problem

The SSE specification includes `retry:` as a valid field. `SseLineSubscriber.hookOnNext()` treats unrecognized lines as errors, crashing when servers emit retry directives.

## Reproduction

Connect to a SurrealDB MCP server (rmcp-based) via Streamable HTTP. The server sends `retry: 3000` in SSE, causing:

```
McpTransportException: Invalid SSE response. Status code: 200 Line: retry: 3000
  at ResponseSubscribers$SseLineSubscriber.hookOnNext(ResponseSubscribers.java:185)
```

## Fix

Ignore `retry:` lines silently, same as `:` comments. The W3C SSE spec defines `retry:` as a valid field.

## Related
#685 (SSE comment handling)