### PR TITLE
fix: do not advertise 2024-11-05 from Streamable HTTP transport providers

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpStreamableServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpStreamableServerTransportProvider.java
@@ -4,6 +4,8 @@
 
 package io.modelcontextprotocol.spec;
 
+import java.util.List;
+
 import reactor.core.publisher.Mono;
 
 /**
@@ -65,5 +67,17 @@ public interface McpStreamableServerTransportProvider extends McpServerTransport
 	 * @return a {@link Mono} that completes when the connections have been closed.
 	 */
 	Mono<Void> closeGracefully();
+
+	/**
+	 * Streamable HTTP was introduced in protocol version {@code 2025-03-26}, so providers
+	 * of this transport cannot serve {@code 2024-11-05} clients and must not advertise
+	 * that version.
+	 * @return the protocol versions supported by Streamable HTTP transport providers
+	 */
+	@Override
+	default List<String> protocolVersions() {
+		return List.of(ProtocolVersions.MCP_2025_03_26, ProtocolVersions.MCP_2025_06_18,
+				ProtocolVersions.MCP_2025_11_25);
+	}
 
 }

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/ServerTransportProtocolVersionsTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/ServerTransportProtocolVersionsTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ */
+
+package io.modelcontextprotocol.spec;
+
+import java.util.List;
+
+import io.modelcontextprotocol.server.McpStatelessServerHandler;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that each server transport abstraction advertises only the protocol versions
+ * it can actually serve.
+ */
+class ServerTransportProtocolVersionsTests {
+
+	private static final List<String> STREAMABLE_HTTP_VERSIONS = List.of(ProtocolVersions.MCP_2025_03_26,
+			ProtocolVersions.MCP_2025_06_18, ProtocolVersions.MCP_2025_11_25);
+
+	private static final McpStreamableServerTransportProvider STREAMABLE_PROVIDER = new McpStreamableServerTransportProvider() {
+		@Override
+		public void setSessionFactory(McpStreamableServerSession.Factory sessionFactory) {
+		}
+
+		@Override
+		public Mono<Void> notifyClients(String method, Object params) {
+			return Mono.empty();
+		}
+
+		@Override
+		public Mono<Void> closeGracefully() {
+			return Mono.empty();
+		}
+	};
+
+	private static final McpStatelessServerTransport STATELESS_TRANSPORT = new McpStatelessServerTransport() {
+		@Override
+		public void setMcpHandler(McpStatelessServerHandler mcpHandler) {
+		}
+
+		@Override
+		public Mono<Void> closeGracefully() {
+			return Mono.empty();
+		}
+	};
+
+	@Test
+	void streamableProviderDoesNotAdvertiseVersionsPredatingStreamableHttp() {
+		assertThat(STREAMABLE_PROVIDER.protocolVersions()).doesNotContain(ProtocolVersions.MCP_2024_11_05)
+			.containsExactlyElementsOf(STREAMABLE_HTTP_VERSIONS);
+	}
+
+	@Test
+	void statelessTransportDoesNotAdvertiseVersionsPredatingStreamableHttp() {
+		assertThat(STATELESS_TRANSPORT.protocolVersions()).doesNotContain(ProtocolVersions.MCP_2024_11_05)
+			.containsExactlyElementsOf(STREAMABLE_HTTP_VERSIONS);
+	}
+
+	@Test
+	void transportsWithoutStreamableHttpConstraintKeepTheFullRange() {
+		McpServerTransportProviderBase base = new McpServerTransportProviderBase() {
+			@Override
+			public Mono<Void> notifyClients(String method, Object params) {
+				return Mono.empty();
+			}
+
+			@Override
+			public Mono<Void> closeGracefully() {
+				return Mono.empty();
+			}
+		};
+
+		assertThat(base.protocolVersions()).containsExactly(ProtocolVersions.MCP_2024_11_05,
+				ProtocolVersions.MCP_2025_03_26, ProtocolVersions.MCP_2025_06_18, ProtocolVersions.MCP_2025_11_25);
+	}
+
+}


### PR DESCRIPTION
Fixes #750

`McpStreamableServerTransportProvider` inherits the default `protocolVersions()` from `McpServerTransportProviderBase`, which includes `2024-11-05`. Streamable HTTP was introduced in `2025-03-26`, so a Streamable HTTP provider advertises a version whose transport it cannot serve — the symptom reported in #750 being `doGet` on `HttpServletStreamableServerTransportProvider` being unable to initialize a session without a prior POST.

Following the direction agreed in the issue, this overrides `protocolVersions()` on the `McpStreamableServerTransportProvider` interface rather than on the servlet implementation, so every current and future Streamable HTTP provider is covered. It mirrors the existing `McpStatelessServerTransport` default, which already excludes `2024-11-05` for the same reason.

```java
@Override
default List<String> protocolVersions() {
    return List.of(ProtocolVersions.MCP_2025_03_26, ProtocolVersions.MCP_2025_06_18,
            ProtocolVersions.MCP_2025_11_25);
}
```

`HttpServletSseServerTransportProvider` keeps its `2024-11-05`-only override, and transports without the Streamable HTTP constraint (stdio) keep the full range.

### Behavioural consequence

A client that requests `2024-11-05` against a Streamable HTTP server previously had that version echoed back, and then failed later in confusing ways. With this change `McpAsyncServer` takes the `else` branch and responds with the highest supported version (`2025-11-25`), logging the mismatch — which is what the spec comment in that method already prescribes. So the change turns a silent late failure into an explicit negotiation result at initialize time.

### Tests

Added `ServerTransportProtocolVersionsTests` asserting the Streamable HTTP and stateless defaults exclude `2024-11-05` while the base default keeps the full range, so a future transport can't silently regain the unsupported version.

`./mvnw test` results:
- `mcp-core`: 358 tests, all passing (including the 3 new ones)
- `mcp-test`: the 109 `HttpServletStreamable*` tests are unaffected

For transparency, the full `mcp-test` module currently has 1 failure and 12 errors (`ToolInputValidationIntegrationTests`, `HttpClientStreamableHttpTransportTest`) on my machine. I verified these are pre-existing by running the whole suite on a clean checkout with this change stashed — identical counts before and after, so they are unrelated to this PR.
