### PR TITLE
fix: validate MCP-Protocol-Version header in servlet transports

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStatelessServerTransport.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStatelessServerTransport.java
@@ -19,6 +19,7 @@ import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpStatelessServerHandler;
 import io.modelcontextprotocol.server.McpTransportContextExtractor;
+import io.modelcontextprotocol.spec.HttpHeaders;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpStatelessServerTransport;
@@ -133,6 +134,10 @@ public class HttpServletStatelessServerTransport extends HttpServlet implements 
 			return;
 		}
 
+		if (!validateProtocolVersion(request, response)) {
+			return;
+		}
+
 		try {
 			Map<String, List<String>> headers = HttpServletRequestUtils.extractHeaders(request);
 			this.securityValidator.validateHeaders(headers);
@@ -238,6 +243,31 @@ public class HttpServletStatelessServerTransport extends HttpServlet implements 
 		PrintWriter writer = response.getWriter();
 		writer.write(jsonError);
 		writer.flush();
+	}
+
+	/**
+	 * Validates the {@code MCP-Protocol-Version} header against the protocol versions
+	 * supported by this transport. A missing header is allowed and falls back to the
+	 * negotiated protocol version, while a header carrying an unsupported version is
+	 * rejected with a 400 Bad Request.
+	 * @param request the HTTP servlet request
+	 * @param response the HTTP servlet response
+	 * @return true if the header is missing or contains a supported version, false if a
+	 * 400 error response has been written
+	 * @throws IOException if an I/O error occurs
+	 */
+	private boolean validateProtocolVersion(HttpServletRequest request, HttpServletResponse response)
+			throws IOException {
+		String protocolVersion = request.getHeader(HttpHeaders.PROTOCOL_VERSION);
+		if (protocolVersion == null || this.protocolVersions().contains(protocolVersion)) {
+			return true;
+		}
+		this.responseError(response, HttpServletResponse.SC_BAD_REQUEST,
+				McpError.builder(McpSchema.ErrorCodes.METHOD_NOT_FOUND)
+					.message("Unsupported protocol version (supported versions: "
+							+ String.join(", ", this.protocolVersions()) + ")")
+					.build());
+		return false;
 	}
 
 	/**

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProvider.java
@@ -262,6 +262,10 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 			return;
 		}
 
+		if (!validateProtocolVersion(request, response)) {
+			return;
+		}
+
 		try {
 			Map<String, List<String>> headers = HttpServletRequestUtils.extractHeaders(request);
 			this.securityValidator.validateHeaders(headers);
@@ -395,6 +399,10 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 
 		if (this.isClosing) {
 			response.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE, "Server is shutting down");
+			return;
+		}
+
+		if (!validateProtocolVersion(request, response)) {
 			return;
 		}
 
@@ -579,6 +587,10 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 			return;
 		}
 
+		if (!validateProtocolVersion(request, response)) {
+			return;
+		}
+
 		try {
 			Map<String, List<String>> headers = HttpServletRequestUtils.extractHeaders(request);
 			this.securityValidator.validateHeaders(headers);
@@ -638,6 +650,31 @@ public class HttpServletStreamableServerTransportProvider extends HttpServlet
 		writer.write(jsonError);
 		writer.flush();
 		return;
+	}
+
+	/**
+	 * Validates the {@code MCP-Protocol-Version} header against the protocol versions
+	 * supported by this provider. A missing header is allowed and falls back to the
+	 * negotiated protocol version, while a header carrying an unsupported version is
+	 * rejected with a 400 Bad Request.
+	 * @param request the HTTP servlet request
+	 * @param response the HTTP servlet response
+	 * @return true if the header is missing or contains a supported version, false if a
+	 * 400 error response has been written
+	 * @throws IOException if an I/O error occurs
+	 */
+	private boolean validateProtocolVersion(HttpServletRequest request, HttpServletResponse response)
+			throws IOException {
+		String protocolVersion = request.getHeader(HttpHeaders.PROTOCOL_VERSION);
+		if (protocolVersion == null || this.protocolVersions().contains(protocolVersion)) {
+			return true;
+		}
+		this.responseError(response, HttpServletResponse.SC_BAD_REQUEST,
+				McpError.builder(McpSchema.ErrorCodes.METHOD_NOT_FOUND)
+					.message("Unsupported protocol version (supported versions: "
+							+ String.join(", ", this.protocolVersions()) + ")")
+					.build());
+		return false;
 	}
 
 	/**

--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/transport/HttpServletStatelessServerTransportTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/transport/HttpServletStatelessServerTransportTests.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server.transport;
+
+import java.io.BufferedReader;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.modelcontextprotocol.spec.HttpHeaders;
+import io.modelcontextprotocol.spec.ProtocolVersions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link HttpServletStatelessServerTransport} HTTP request header
+ * validation.
+ */
+class HttpServletStatelessServerTransportTests {
+
+	private final HttpServletStatelessServerTransport transport = HttpServletStatelessServerTransport.builder()
+		.build();
+
+	private final HttpServletRequest request = mock(HttpServletRequest.class);
+
+	private final HttpServletResponse response = mock(HttpServletResponse.class);
+
+	private final StringWriter responseBody = new StringWriter();
+
+	@BeforeEach
+	void setUp() throws Exception {
+		when(request.getRequestURI()).thenReturn("/mcp");
+		when(response.getWriter()).thenReturn(new PrintWriter(responseBody));
+	}
+
+	@Nested
+	class ProtocolVersionHeader {
+
+		@ParameterizedTest
+		@ValueSource(strings = { ProtocolVersions.MCP_2025_03_26, ProtocolVersions.MCP_2025_06_18,
+				ProtocolVersions.MCP_2025_11_25 })
+		void doPostWithSupportedProtocolVersionProceeds(String protocolVersion) throws Exception {
+			when(request.getHeader(HttpHeaders.PROTOCOL_VERSION)).thenReturn(protocolVersion);
+			when(request.getHeader(HttpServletStatelessServerTransport.ACCEPT))
+				.thenReturn("application/json, text/event-stream");
+			when(request.getReader()).thenReturn(new BufferedReader(new StringReader("")));
+
+			transport.doPost(request, response);
+
+			assertThat(responseBody.toString())
+				.as("a supported protocol version must not be rejected")
+				.doesNotContain("Unsupported protocol version")
+				.contains("Invalid message format");
+		}
+
+		@ParameterizedTest
+		@ValueSource(strings = { "banana", "1999-01-01" })
+		void doPostWithUnsupportedProtocolVersionRejected(String protocolVersion) throws Exception {
+			when(request.getHeader(HttpHeaders.PROTOCOL_VERSION)).thenReturn(protocolVersion);
+
+			transport.doPost(request, response);
+
+			verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			assertThat(responseBody.toString()).contains("Unsupported protocol version");
+		}
+
+		@Test
+		void doPostWithMissingProtocolVersionProceeds() throws Exception {
+			when(request.getHeader(HttpServletStatelessServerTransport.ACCEPT))
+				.thenReturn("application/json, text/event-stream");
+			when(request.getReader()).thenReturn(new BufferedReader(new StringReader("")));
+
+			transport.doPost(request, response);
+
+			assertThat(responseBody.toString())
+				.as("a missing protocol version must fall back to the negotiated version")
+				.doesNotContain("Unsupported protocol version")
+				.contains("Invalid message format");
+		}
+
+	}
+
+}

--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProviderTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/transport/HttpServletStreamableServerTransportProviderTests.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server.transport;
+
+import java.io.BufferedReader;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.modelcontextprotocol.spec.HttpHeaders;
+import io.modelcontextprotocol.spec.ProtocolVersions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link HttpServletStreamableServerTransportProvider} HTTP request header
+ * validation.
+ */
+class HttpServletStreamableServerTransportProviderTests {
+
+	private final HttpServletStreamableServerTransportProvider transport = HttpServletStreamableServerTransportProvider
+		.builder()
+		.build();
+
+	private final HttpServletRequest request = mock(HttpServletRequest.class);
+
+	private final HttpServletResponse response = mock(HttpServletResponse.class);
+
+	private final StringWriter responseBody = new StringWriter();
+
+	@BeforeEach
+	void setUp() throws Exception {
+		when(request.getRequestURI()).thenReturn("/mcp");
+		when(response.getWriter()).thenReturn(new PrintWriter(responseBody));
+	}
+
+	@Nested
+	class ProtocolVersionHeader {
+
+		@ParameterizedTest
+		@ValueSource(strings = { ProtocolVersions.MCP_2024_11_05, ProtocolVersions.MCP_2025_03_26,
+				ProtocolVersions.MCP_2025_06_18, ProtocolVersions.MCP_2025_11_25 })
+		void doGetWithSupportedProtocolVersionProceeds(String protocolVersion) throws Exception {
+			when(request.getHeader(HttpHeaders.PROTOCOL_VERSION)).thenReturn(protocolVersion);
+
+			transport.doGet(request, response);
+
+			assertThat(responseBody.toString())
+				.as("a supported protocol version must not be rejected")
+				.doesNotContain("Unsupported protocol version")
+				.contains("Session ID required in mcp-session-id header");
+		}
+
+		@ParameterizedTest
+		@ValueSource(strings = { "banana", "1999-01-01" })
+		void doGetWithUnsupportedProtocolVersionRejected(String protocolVersion) throws Exception {
+			when(request.getHeader(HttpHeaders.PROTOCOL_VERSION)).thenReturn(protocolVersion);
+
+			transport.doGet(request, response);
+
+			verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			assertThat(responseBody.toString()).contains("Unsupported protocol version");
+		}
+
+		@Test
+		void doGetWithMissingProtocolVersionProceeds() throws Exception {
+			transport.doGet(request, response);
+
+			assertThat(responseBody.toString())
+				.as("a missing protocol version must fall back to the negotiated version")
+				.doesNotContain("Unsupported protocol version")
+				.contains("Session ID required in mcp-session-id header");
+		}
+
+		@ParameterizedTest
+		@ValueSource(strings = { ProtocolVersions.MCP_2024_11_05, ProtocolVersions.MCP_2025_03_26,
+				ProtocolVersions.MCP_2025_06_18, ProtocolVersions.MCP_2025_11_25 })
+		void doPostWithSupportedProtocolVersionProceeds(String protocolVersion) throws Exception {
+			when(request.getHeader(HttpHeaders.PROTOCOL_VERSION)).thenReturn(protocolVersion);
+			when(request.getReader()).thenReturn(new BufferedReader(new StringReader("")));
+
+			transport.doPost(request, response);
+
+			assertThat(responseBody.toString())
+				.as("a supported protocol version must not be rejected")
+				.doesNotContain("Unsupported protocol version")
+				.contains("Invalid message format");
+		}
+
+		@ParameterizedTest
+		@ValueSource(strings = { "banana", "1999-01-01" })
+		void doPostWithUnsupportedProtocolVersionRejected(String protocolVersion) throws Exception {
+			when(request.getHeader(HttpHeaders.PROTOCOL_VERSION)).thenReturn(protocolVersion);
+
+			transport.doPost(request, response);
+
+			verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			assertThat(responseBody.toString()).contains("Unsupported protocol version");
+		}
+
+		@Test
+		void doPostWithMissingProtocolVersionProceeds() throws Exception {
+			when(request.getReader()).thenReturn(new BufferedReader(new StringReader("")));
+
+			transport.doPost(request, response);
+
+			assertThat(responseBody.toString())
+				.as("a missing protocol version must fall back to the negotiated version")
+				.doesNotContain("Unsupported protocol version")
+				.contains("Invalid message format");
+		}
+
+		@ParameterizedTest
+		@ValueSource(strings = { ProtocolVersions.MCP_2024_11_05, ProtocolVersions.MCP_2025_03_26,
+				ProtocolVersions.MCP_2025_06_18, ProtocolVersions.MCP_2025_11_25 })
+		void doDeleteWithSupportedProtocolVersionProceeds(String protocolVersion) throws Exception {
+			when(request.getHeader(HttpHeaders.PROTOCOL_VERSION)).thenReturn(protocolVersion);
+
+			transport.doDelete(request, response);
+
+			assertThat(responseBody.toString())
+				.as("a supported protocol version must not be rejected")
+				.doesNotContain("Unsupported protocol version")
+				.contains("Session ID required in mcp-session-id header");
+		}
+
+		@ParameterizedTest
+		@ValueSource(strings = { "banana", "1999-01-01" })
+		void doDeleteWithUnsupportedProtocolVersionRejected(String protocolVersion) throws Exception {
+			when(request.getHeader(HttpHeaders.PROTOCOL_VERSION)).thenReturn(protocolVersion);
+
+			transport.doDelete(request, response);
+
+			verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			assertThat(responseBody.toString()).contains("Unsupported protocol version");
+		}
+
+		@Test
+		void doDeleteWithMissingProtocolVersionProceeds() throws Exception {
+			transport.doDelete(request, response);
+
+			assertThat(responseBody.toString())
+				.as("a missing protocol version must fall back to the negotiated version")
+				.doesNotContain("Unsupported protocol version")
+				.contains("Session ID required in mcp-session-id header");
+		}
+
+	}
+
+}


### PR DESCRIPTION
The streamable HTTP spec requires the server to answer with 400 Bad Request when the client sends an unsupported MCP-Protocol-Version header, and to accept the request when the header is missing (falling back to the negotiated version). The Servlet-based providers never read this header.

This change validates the MCP-Protocol-Version header in doGet, doPost, and doDelete of `HttpServletStreamableServerTransportProvider` and in doPost of `HttpServletStatelessServerTransport`, rejecting unsupported versions with a 400 JSON error response consistent with the existing error style.

Tests cover the version-header matrix (supported version accepted, unsupported version rejected, missing header accepted) across both providers.