### PR TITLE
fix: validate resource URIs and cap subscriptions per session

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -92,6 +92,12 @@ public class McpAsyncServer {
 
 	private static final Logger logger = LoggerFactory.getLogger(McpAsyncServer.class);
 
+	/**
+	 * Maximum number of resource URIs a single session may subscribe to. Prevents a
+	 * client from growing the resource subscriptions map without bound.
+	 */
+	private static final int MAX_RESOURCE_SUBSCRIPTIONS_PER_SESSION = 1024;
+
 	private final McpServerTransportProviderBase mcpTransportProvider;
 
 	private final McpJsonMapper jsonMapper;
@@ -758,6 +764,25 @@ public class McpAsyncServer {
 					});
 			String uri = subscribeRequest.uri();
 			String sessionId = exchange.sessionId();
+
+			// Validate the URI against the registered resources and resource templates
+			// before accepting the subscription.
+			if (this.findResourceSpecification(uri).isEmpty() && this.findResourceTemplateSpecification(uri).isEmpty()) {
+				return Mono.error(RESOURCE_NOT_FOUND.apply(uri));
+			}
+
+			// Cap the number of resource subscriptions per session to prevent a client
+			// from growing the subscriptions map without bound.
+			long sessionSubscriptions = this.resourceSubscriptions.values()
+				.stream()
+				.filter(subscribedSessions -> subscribedSessions.contains(sessionId))
+				.count();
+			if (sessionSubscriptions >= MAX_RESOURCE_SUBSCRIPTIONS_PER_SESSION) {
+				return Mono.error(McpError.builder(McpSchema.ErrorCodes.INVALID_PARAMS)
+					.message("Resource subscription limit exceeded for session: " + sessionId)
+					.build());
+			}
+
 			this.resourceSubscriptions.computeIfAbsent(uri, k -> Collections.newSetFromMap(new ConcurrentHashMap<>()))
 				.add(sessionId);
 			logger.debug("Session {} subscribed to resource URI: {}", sessionId, uri);

--- a/mcp-test/src/test/java/io/modelcontextprotocol/server/ResourceSubscriptionTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/server/ResourceSubscriptionTests.java
@@ -4,6 +4,8 @@
 
 package io.modelcontextprotocol.server;
 
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import io.modelcontextprotocol.MockMcpServerTransport;
@@ -11,6 +13,7 @@ import io.modelcontextprotocol.MockMcpServerTransportProvider;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.ProtocolVersions;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,6 +60,31 @@ class ResourceSubscriptionTests {
 	private static McpSchema.JSONRPCRequest unsubscribeRequest(String uri) {
 		return new McpSchema.JSONRPCRequest(McpSchema.METHOD_RESOURCES_UNSUBSCRIBE, UUID.randomUUID().toString(),
 				McpSchema.UnsubscribeRequest.builder(uri).build());
+	}
+
+	private static McpAsyncServer buildServerWithResource(MockMcpServerTransportProvider transportProvider) {
+		McpSchema.Resource resource = McpSchema.Resource.builder(RESOURCE_URI, "Test Resource")
+			.mimeType("text/plain")
+			.build();
+		return McpServer.async(transportProvider)
+			.serverInfo(SERVER_INFO)
+			.capabilities(McpSchema.ServerCapabilities.builder().resources(true, false).build())
+			.resources(new McpServerFeatures.AsyncResourceSpecification(resource,
+					(exchange, request) -> Mono.just(new McpSchema.ReadResourceResult(List.of()))))
+			.build();
+	}
+
+	private static McpAsyncServer buildServerWithResourceTemplate(MockMcpServerTransportProvider transportProvider) {
+		McpSchema.ResourceTemplate resourceTemplate = McpSchema.ResourceTemplate
+			.builder("test://resource/{id}", "Test Resource Template")
+			.mimeType("text/plain")
+			.build();
+		return McpServer.async(transportProvider)
+			.serverInfo(SERVER_INFO)
+			.capabilities(McpSchema.ServerCapabilities.builder().resources(true, false).build())
+			.resourceTemplates(new McpServerFeatures.AsyncResourceTemplateSpecification(resourceTemplate,
+					(exchange, request) -> Mono.just(new McpSchema.ReadResourceResult(List.of()))))
+			.build();
 	}
 
 	@Test
@@ -162,6 +190,71 @@ class ResourceSubscriptionTests {
 
 		assertThat(transport.getAllSentMessages()).as("no notification should be sent after the session has closed")
 			.isEmpty();
+
+		server.closeGracefully().block();
+	}
+
+	@Test
+	void subscribeToRegisteredUri_succeeds() {
+		MockMcpServerTransport transport = new MockMcpServerTransport();
+		MockMcpServerTransportProvider transportProvider = new MockMcpServerTransportProvider(transport);
+		McpAsyncServer server = buildServerWithResource(transportProvider);
+
+		transportProvider.simulateIncomingMessage(initRequest());
+		transportProvider.simulateIncomingMessage(initializedNotification());
+		transport.clearSentMessages();
+		transportProvider.simulateIncomingMessage(subscribeRequest(RESOURCE_URI));
+
+		McpSchema.JSONRPCMessage sent = transport.getLastSentMessage();
+		assertThat(sent).isInstanceOf(McpSchema.JSONRPCResponse.class);
+		McpSchema.JSONRPCResponse response = (McpSchema.JSONRPCResponse) sent;
+		assertThat(response.error()).as("subscribing to a registered resource must succeed").isNull();
+		assertThat(response.result()).isEqualTo(Map.of());
+
+		server.closeGracefully().block();
+	}
+
+	@Test
+	void subscribeToUnregisteredUri_returnsResourceNotFound() {
+		MockMcpServerTransport transport = new MockMcpServerTransport();
+		MockMcpServerTransportProvider transportProvider = new MockMcpServerTransportProvider(transport);
+		McpAsyncServer server = buildServerWithResource(transportProvider);
+
+		transportProvider.simulateIncomingMessage(initRequest());
+		transportProvider.simulateIncomingMessage(initializedNotification());
+		transport.clearSentMessages();
+		transportProvider.simulateIncomingMessage(subscribeRequest("test://unknown/uri"));
+
+		McpSchema.JSONRPCMessage sent = transport.getLastSentMessage();
+		assertThat(sent).isInstanceOf(McpSchema.JSONRPCResponse.class);
+		McpSchema.JSONRPCResponse response = (McpSchema.JSONRPCResponse) sent;
+		assertThat(response.error()).isNotNull();
+		assertThat(response.error().code()).isEqualTo(McpSchema.ErrorCodes.RESOURCE_NOT_FOUND);
+
+		server.closeGracefully().block();
+	}
+
+	@Test
+	void subscribeBeyondPerSessionLimit_isRejected() {
+		MockMcpServerTransport transport = new MockMcpServerTransport();
+		MockMcpServerTransportProvider transportProvider = new MockMcpServerTransportProvider(transport);
+		McpAsyncServer server = buildServerWithResourceTemplate(transportProvider);
+
+		transportProvider.simulateIncomingMessage(initRequest());
+		transportProvider.simulateIncomingMessage(initializedNotification());
+		transport.clearSentMessages();
+
+		for (int i = 0; i < 1024; i++) {
+			transportProvider.simulateIncomingMessage(subscribeRequest("test://resource/" + i));
+		}
+
+		transportProvider.simulateIncomingMessage(subscribeRequest("test://resource/1024"));
+
+		McpSchema.JSONRPCMessage sent = transport.getLastSentMessage();
+		assertThat(sent).isInstanceOf(McpSchema.JSONRPCResponse.class);
+		McpSchema.JSONRPCResponse response = (McpSchema.JSONRPCResponse) sent;
+		assertThat(response.error()).isNotNull();
+		assertThat(response.error().code()).isEqualTo(McpSchema.ErrorCodes.INVALID_PARAMS);
 
 		server.closeGracefully().block();
 	}


### PR DESCRIPTION
The spec's server resources security guidance requires servers to validate all resource URIs. The read path validates URIs against the registered resources and resource templates, but resources/subscribe accepted any string URI into an unbounded map, so an authenticated client could grow memory without limit.

This change makes the subscribe handler resolve the URI through the same resource/template lookup as the read path and reject unknown URIs with the same Resource Not Found error (-32002). It also caps the number of resource subscriptions per session (1024); further subscribe requests are rejected with Invalid Params (-32602).

Tests cover subscribing to a registered URI (success), an unregistered URI (Resource Not Found), and exceeding the per-session cap (Invalid Params).