### PR TITLE
Fix typo in Javadoc of McpStreamableServerSession

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpStreamableServerSession.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpStreamableServerSession.java
@@ -243,7 +243,7 @@ public class McpStreamableServerSession implements McpLoggableSession {
 	/**
 	 * Handle the MCP notification.
 	 * @param notification MCP notification
-	 * @return Mono which completes upon succesful handling
+	 * @return Mono which completes upon successful handling
 	 */
 	public Mono<Void> accept(McpSchema.JSONRPCNotification notification) {
 		return Mono.deferContextual(ctx -> {


### PR DESCRIPTION
## What changed

Fixed a typo in the Javadoc of `McpStreamableServerSession#accept`:
`succesful` → `successful`.

## Why

The Javadoc comment `@return Mono which completes upon succesful handling` contains a misspelling. This is part of the public API documentation, so fixing it improves the generated Javadoc.

## How verified

Diff inspection of the single affected comment line. No code logic or API changed — only a Javadoc comment.