### PR TITLE
fix: respect caller-provided server capabilities

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServer.java
@@ -136,7 +136,7 @@ public class McpAsyncServer {
 		this.mcpTransportProvider = mcpTransportProvider;
 		this.jsonMapper = jsonMapper;
 		this.serverInfo = features.serverInfo();
-		this.serverCapabilities = features.serverCapabilities().mutate().logging().build();
+		this.serverCapabilities = features.serverCapabilities();
 		this.instructions = features.instructions();
 		this.tools.addAll(withStructuredOutputHandling(jsonSchemaValidator, features.tools()));
 		this.resources.putAll(features.resources());
@@ -167,7 +167,7 @@ public class McpAsyncServer {
 		this.mcpTransportProvider = mcpTransportProvider;
 		this.jsonMapper = jsonMapper;
 		this.serverInfo = features.serverInfo();
-		this.serverCapabilities = features.serverCapabilities().mutate().logging().build();
+		this.serverCapabilities = features.serverCapabilities();
 		this.instructions = features.instructions();
 		this.tools.addAll(withStructuredOutputHandling(jsonSchemaValidator, features.tools()));
 		this.resources.putAll(features.resources());

--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/McpAsyncServerCapabilitiesTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/McpAsyncServerCapabilitiesTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpServerTransportProvider;
+import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class McpAsyncServerCapabilitiesTests {
+
+	@Test
+	void standardTransportPreservesCallerProvidedCapabilities() {
+		McpServerTransportProvider transportProvider = mock(McpServerTransportProvider.class);
+		McpSchema.ServerCapabilities capabilities = McpSchema.ServerCapabilities.builder().tools(true).build();
+
+		McpAsyncServer server = McpServer.async(transportProvider)
+			.jsonMapper(mock(McpJsonMapper.class))
+			.jsonSchemaValidator(mock(JsonSchemaValidator.class))
+			.capabilities(capabilities)
+			.build();
+
+		assertThat(server.getServerCapabilities()).isEqualTo(capabilities);
+		assertThat(server.getServerCapabilities().logging()).isNull();
+	}
+
+	@Test
+	void streamableTransportPreservesCallerProvidedCapabilities() {
+		McpStreamableServerTransportProvider transportProvider = mock(McpStreamableServerTransportProvider.class);
+		McpSchema.ServerCapabilities capabilities = McpSchema.ServerCapabilities.builder().tools(true).build();
+
+		McpAsyncServer server = McpServer.async(transportProvider)
+			.jsonMapper(mock(McpJsonMapper.class))
+			.jsonSchemaValidator(mock(JsonSchemaValidator.class))
+			.capabilities(capabilities)
+			.build();
+
+		assertThat(server.getServerCapabilities()).isEqualTo(capabilities);
+		assertThat(server.getServerCapabilities().logging()).isNull();
+	}
+
+	@Test
+	void preservesExplicitLoggingCapability() {
+		McpServerTransportProvider transportProvider = mock(McpServerTransportProvider.class);
+		McpSchema.ServerCapabilities capabilities = McpSchema.ServerCapabilities.builder().logging().build();
+
+		McpAsyncServer server = McpServer.async(transportProvider)
+			.jsonMapper(mock(McpJsonMapper.class))
+			.jsonSchemaValidator(mock(JsonSchemaValidator.class))
+			.capabilities(capabilities)
+			.build();
+
+		assertThat(server.getServerCapabilities()).isEqualTo(capabilities);
+		assertThat(server.getServerCapabilities().logging()).isNotNull();
+	}
+
+}

--- a/mcp-test/src/main/java/io/modelcontextprotocol/AbstractMcpClientServerIntegrationTests.java
+++ b/mcp-test/src/main/java/io/modelcontextprotocol/AbstractMcpClientServerIntegrationTests.java
@@ -1493,7 +1493,7 @@ public abstract class AbstractMcpClientServerIntegrationTests {
 			.build();
 
 		var mcpServer = prepareAsyncServerBuilder().serverInfo("test-server", "1.0.0")
-			.capabilities(ServerCapabilities.builder().tools(true).build())
+			.capabilities(ServerCapabilities.builder().tools(true).logging().build())
 			.tools(tool)
 			.build();
 


### PR DESCRIPTION
Fixes #1086

## Problem

`McpAsyncServer` unconditionally advertises the logging capability,
even when the caller did not configure it.

## Changes

- Preserve the caller-provided server capabilities
- Stop implicitly advertising logging
- Cover both server transport construction paths
- Add regression tests
- Explicitly configure logging in the existing logging integration test

## Testing

Passed:

```bash
./mvnw -pl mcp-core -Dtest=McpAsyncServerCapabilitiesTests test
./mvnw -pl mcp-core test
./mvnw -pl mcp-test -am \
  -Dtest=HttpServletSseIntegrationTests#testLoggingNotification,HttpServletStreamableIntegrationTests#testLoggingNotification \
  -Dsurefire.failIfNoSpecifiedTests=false test