### PR TITLE
Reject listRoots when client lacks roots capability, without sending a request

### DIFF
--- a/0001-Reject-listRoots-when-client-lacks-roots-capability-.patch
+++ b/0001-Reject-listRoots-when-client-lacks-roots-capability-.patch
@@ -1,0 +1,104 @@
+From 9fd3a16c0306d5afbe35ff6d32cb2a84c34482ab Mon Sep 17 00:00:00 2001
+From: Rohit Kushwaha <subhamkushwahagd@gmail.com>
+Date: Thu, 20 Aug 2026 19:35:32 +0000
+Subject: [PATCH] Reject listRoots when client lacks roots capability, without
+ sending a request
+
+McpAsyncServerExchange#createMessage and #createElicitation both
+fail fast with an IllegalStateException when the client hasn't
+declared the relevant capability, avoiding an unnecessary round
+trip to the client. #listRoots(String) did not follow the same
+pattern and would send a roots/list request even when the client
+never advertised roots support.
+
+This aligns #listRoots(String) with the existing fail-fast
+convention: it now checks clientCapabilities for null (client not
+yet initialized) and for a missing roots capability before sending
+McpSchema.METHOD_ROOTS_LIST.
+
+Fixes #1067
+---
+ .../server/McpAsyncServerExchange.java        |  7 +++
+ .../server/McpAsyncServerExchangeTests.java   | 48 +++++++++++++++++++
+ 2 files changed, 55 insertions(+)
+
+diff --git a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
+index e27d612..d977ac9 100644
+--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
++++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
+@@ -225,6 +225,13 @@ public class McpAsyncServerExchange {
+ 	 * @return A Mono that emits the list of roots result containing
+ 	 */
+ 	public Mono<McpSchema.ListRootsResult> listRoots(String cursor) {
++		if (this.clientCapabilities == null) {
++			return Mono
++				.error(new IllegalStateException("Client must be initialized. Call the initialize method first!"));
++		}
++		if (this.clientCapabilities.roots() == null) {
++			return Mono.error(new IllegalStateException("Client must be configured with roots capabilities"));
++		}
+ 		return this.session.sendRequest(McpSchema.METHOD_ROOTS_LIST, new McpSchema.PaginatedRequest(cursor),
+ 				LIST_ROOTS_RESULT_TYPE_REF);
+ 	}
+diff --git a/mcp-core/src/test/java/io/modelcontextprotocol/server/McpAsyncServerExchangeTests.java b/mcp-core/src/test/java/io/modelcontextprotocol/server/McpAsyncServerExchangeTests.java
+index f4f76b1..b556a8a 100644
+--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/McpAsyncServerExchangeTests.java
++++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/McpAsyncServerExchangeTests.java
+@@ -157,6 +157,54 @@ class McpAsyncServerExchangeTests {
+ 		}).verifyComplete();
+ 	}
+ 
++	@Test
++	void testListRootsWithNullCapabilities() {
++
++		McpAsyncServerExchange exchangeWithNullCapabilities = new McpAsyncServerExchange("testSessionId",
++				mockSession, null, clientInfo, McpTransportContext.EMPTY);
++
++		StepVerifier.create(exchangeWithNullCapabilities.listRoots()).verifyErrorSatisfies(error -> {
++			assertThat(error).isInstanceOf(IllegalStateException.class)
++				.hasMessage("Client must be initialized. Call the initialize method first!");
++		});
++
++		// Verify that sendRequest was never called due to null capabilities
++		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(), any(TypeRef.class));
++	}
++
++	@Test
++	void testListRootsWithoutRootsCapabilities() {
++
++		McpSchema.ClientCapabilities capabilitiesWithoutRoots = McpSchema.ClientCapabilities.builder()
++			.sampling()
++			.build();
++
++		McpAsyncServerExchange exchangeWithoutRoots = new McpAsyncServerExchange("testSessionId", mockSession,
++				capabilitiesWithoutRoots, clientInfo, McpTransportContext.EMPTY);
++
++		StepVerifier.create(exchangeWithoutRoots.listRoots()).verifyErrorSatisfies(error -> {
++			assertThat(error).isInstanceOf(IllegalStateException.class)
++				.hasMessage("Client must be configured with roots capabilities");
++		});
++
++		// Verify that sendRequest was never called due to missing roots capabilities
++		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(), any(TypeRef.class));
++	}
++
++	@Test
++	void testListRootsWithSpecificCursorAndNullCapabilities() {
++
++		McpAsyncServerExchange exchangeWithNullCapabilities = new McpAsyncServerExchange("testSessionId",
++				mockSession, null, clientInfo, McpTransportContext.EMPTY);
++
++		StepVerifier.create(exchangeWithNullCapabilities.listRoots("someCursor")).verifyErrorSatisfies(error -> {
++			assertThat(error).isInstanceOf(IllegalStateException.class)
++				.hasMessage("Client must be initialized. Call the initialize method first!");
++		});
++
++		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(), any(TypeRef.class));
++	}
++
+ 	@Test
+ 	void testListRootsWithError() {
+ 
+-- 
+2.43.0
+

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,43 @@
+## Reject listRoots when client lacks roots capability, without sending a request
+
+Fixes #1067
+
+### What changed
+
+`McpAsyncServerExchange#createMessage` and `#createElicitation` both fail fast
+with an `IllegalStateException` when the client hasn't declared the relevant
+capability, avoiding an unnecessary round trip to the client.
+
+`#listRoots(String)` didn't follow the same pattern: it would send a
+`roots/list` request to the client even when the client never advertised
+`roots` support, only to fail later (or behave unexpectedly) depending on the
+client's own handling of an unsupported method.
+
+This PR aligns `#listRoots(String)` with the existing fail-fast convention
+already used by `createMessage`/`createElicitation`:
+
+- If `clientCapabilities` is `null` (client not yet initialized), fail with
+  `"Client must be initialized. Call the initialize method first!"`
+- If `clientCapabilities.roots()` is `null` (client didn't declare roots
+  support), fail with `"Client must be configured with roots capabilities"`
+- Otherwise, proceed with the request as before.
+
+`listRoots()` (no-arg, paginated variant) and `McpSyncServerExchange#listRoots`
+both delegate to `listRoots(String)`, so they're covered automatically.
+
+### Testing
+
+Added three unit tests to `McpAsyncServerExchangeTests` mirroring the existing
+capability-check tests for `createMessage`:
+
+- `testListRootsWithNullCapabilities`
+- `testListRootsWithoutRootsCapabilities`
+- `testListRootsWithSpecificCursorAndNullCapabilities`
+
+Each verifies the correct `IllegalStateException` is raised and that
+`session.sendRequest(...)` is never invoked in these cases.
+
+I audited all existing callers of `listRoots` in the repo (integration tests
+in `AbstractMcpClientServerIntegrationTests`, and the roots-changed handler in
+`McpAsyncServer`) — all already configure/assume roots capability, so this
+change shouldn't affect existing behavior anywhere else in the codebase.

--- a/listroots-fix.diff
+++ b/listroots-fix.diff
@@ -1,0 +1,77 @@
+diff --git a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
+index e27d612..d977ac9 100644
+--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
++++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
+@@ -225,6 +225,13 @@ public class McpAsyncServerExchange {
+ 	 * @return A Mono that emits the list of roots result containing
+ 	 */
+ 	public Mono<McpSchema.ListRootsResult> listRoots(String cursor) {
++		if (this.clientCapabilities == null) {
++			return Mono
++				.error(new IllegalStateException("Client must be initialized. Call the initialize method first!"));
++		}
++		if (this.clientCapabilities.roots() == null) {
++			return Mono.error(new IllegalStateException("Client must be configured with roots capabilities"));
++		}
+ 		return this.session.sendRequest(McpSchema.METHOD_ROOTS_LIST, new McpSchema.PaginatedRequest(cursor),
+ 				LIST_ROOTS_RESULT_TYPE_REF);
+ 	}
+diff --git a/mcp-core/src/test/java/io/modelcontextprotocol/server/McpAsyncServerExchangeTests.java b/mcp-core/src/test/java/io/modelcontextprotocol/server/McpAsyncServerExchangeTests.java
+index f4f76b1..b556a8a 100644
+--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/McpAsyncServerExchangeTests.java
++++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/McpAsyncServerExchangeTests.java
+@@ -157,6 +157,54 @@ class McpAsyncServerExchangeTests {
+ 		}).verifyComplete();
+ 	}
+ 
++	@Test
++	void testListRootsWithNullCapabilities() {
++
++		McpAsyncServerExchange exchangeWithNullCapabilities = new McpAsyncServerExchange("testSessionId",
++				mockSession, null, clientInfo, McpTransportContext.EMPTY);
++
++		StepVerifier.create(exchangeWithNullCapabilities.listRoots()).verifyErrorSatisfies(error -> {
++			assertThat(error).isInstanceOf(IllegalStateException.class)
++				.hasMessage("Client must be initialized. Call the initialize method first!");
++		});
++
++		// Verify that sendRequest was never called due to null capabilities
++		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(), any(TypeRef.class));
++	}
++
++	@Test
++	void testListRootsWithoutRootsCapabilities() {
++
++		McpSchema.ClientCapabilities capabilitiesWithoutRoots = McpSchema.ClientCapabilities.builder()
++			.sampling()
++			.build();
++
++		McpAsyncServerExchange exchangeWithoutRoots = new McpAsyncServerExchange("testSessionId", mockSession,
++				capabilitiesWithoutRoots, clientInfo, McpTransportContext.EMPTY);
++
++		StepVerifier.create(exchangeWithoutRoots.listRoots()).verifyErrorSatisfies(error -> {
++			assertThat(error).isInstanceOf(IllegalStateException.class)
++				.hasMessage("Client must be configured with roots capabilities");
++		});
++
++		// Verify that sendRequest was never called due to missing roots capabilities
++		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(), any(TypeRef.class));
++	}
++
++	@Test
++	void testListRootsWithSpecificCursorAndNullCapabilities() {
++
++		McpAsyncServerExchange exchangeWithNullCapabilities = new McpAsyncServerExchange("testSessionId",
++				mockSession, null, clientInfo, McpTransportContext.EMPTY);
++
++		StepVerifier.create(exchangeWithNullCapabilities.listRoots("someCursor")).verifyErrorSatisfies(error -> {
++			assertThat(error).isInstanceOf(IllegalStateException.class)
++				.hasMessage("Client must be initialized. Call the initialize method first!");
++		});
++
++		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(), any(TypeRef.class));
++	}
++
+ 	@Test
+ 	void testListRootsWithError() {
+ 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/McpAsyncServerExchange.java
@@ -225,6 +225,13 @@ public class McpAsyncServerExchange {
 	 * @return A Mono that emits the list of roots result containing
 	 */
 	public Mono<McpSchema.ListRootsResult> listRoots(String cursor) {
+		if (this.clientCapabilities == null) {
+			return Mono
+				.error(new IllegalStateException("Client must be initialized. Call the initialize method first!"));
+		}
+		if (this.clientCapabilities.roots() == null) {
+			return Mono.error(new IllegalStateException("Client must be configured with roots capabilities"));
+		}
 		return this.session.sendRequest(McpSchema.METHOD_ROOTS_LIST, new McpSchema.PaginatedRequest(cursor),
 				LIST_ROOTS_RESULT_TYPE_REF);
 	}

--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/McpAsyncServerExchangeTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/McpAsyncServerExchangeTests.java
@@ -158,6 +158,54 @@ class McpAsyncServerExchangeTests {
 	}
 
 	@Test
+	void testListRootsWithNullCapabilities() {
+
+		McpAsyncServerExchange exchangeWithNullCapabilities = new McpAsyncServerExchange("testSessionId",
+				mockSession, null, clientInfo, McpTransportContext.EMPTY);
+
+		StepVerifier.create(exchangeWithNullCapabilities.listRoots()).verifyErrorSatisfies(error -> {
+			assertThat(error).isInstanceOf(IllegalStateException.class)
+				.hasMessage("Client must be initialized. Call the initialize method first!");
+		});
+
+		// Verify that sendRequest was never called due to null capabilities
+		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(), any(TypeRef.class));
+	}
+
+	@Test
+	void testListRootsWithoutRootsCapabilities() {
+
+		McpSchema.ClientCapabilities capabilitiesWithoutRoots = McpSchema.ClientCapabilities.builder()
+			.sampling()
+			.build();
+
+		McpAsyncServerExchange exchangeWithoutRoots = new McpAsyncServerExchange("testSessionId", mockSession,
+				capabilitiesWithoutRoots, clientInfo, McpTransportContext.EMPTY);
+
+		StepVerifier.create(exchangeWithoutRoots.listRoots()).verifyErrorSatisfies(error -> {
+			assertThat(error).isInstanceOf(IllegalStateException.class)
+				.hasMessage("Client must be configured with roots capabilities");
+		});
+
+		// Verify that sendRequest was never called due to missing roots capabilities
+		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(), any(TypeRef.class));
+	}
+
+	@Test
+	void testListRootsWithSpecificCursorAndNullCapabilities() {
+
+		McpAsyncServerExchange exchangeWithNullCapabilities = new McpAsyncServerExchange("testSessionId",
+				mockSession, null, clientInfo, McpTransportContext.EMPTY);
+
+		StepVerifier.create(exchangeWithNullCapabilities.listRoots("someCursor")).verifyErrorSatisfies(error -> {
+			assertThat(error).isInstanceOf(IllegalStateException.class)
+				.hasMessage("Client must be initialized. Call the initialize method first!");
+		});
+
+		verify(mockSession, never()).sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(), any(TypeRef.class));
+	}
+
+	@Test
 	void testListRootsWithError() {
 
 		when(mockSession.sendRequest(eq(McpSchema.METHOD_ROOTS_LIST), any(McpSchema.PaginatedRequest.class),


### PR DESCRIPTION
## Reject listRoots when client lacks roots capability, without sending a request

Fixes #1067

### What changed

`McpAsyncServerExchange#createMessage` and `#createElicitation` both fail fast
with an `IllegalStateException` when the client hasn't declared the relevant
capability, avoiding an unnecessary round trip to the client.

`#listRoots(String)` didn't follow the same pattern: it would send a
`roots/list` request to the client even when the client never advertised
`roots` support, only to fail later (or behave unexpectedly) depending on the
client's own handling of an unsupported method.

This PR aligns `#listRoots(String)` with the existing fail-fast convention
already used by `createMessage`/`createElicitation`:

- If `clientCapabilities` is `null` (client not yet initialized), fail with
  `"Client must be initialized. Call the initialize method first!"`
- If `clientCapabilities.roots()` is `null` (client didn't declare roots
  support), fail with `"Client must be configured with roots capabilities"`
- Otherwise, proceed with the request as before.

`listRoots()` (no-arg, paginated variant) and `McpSyncServerExchange#listRoots`
both delegate to `listRoots(String)`, so they're covered automatically.

### Testing

Added three unit tests to `McpAsyncServerExchangeTests` mirroring the existing
capability-check tests for `createMessage`:

- `testListRootsWithNullCapabilities`
- `testListRootsWithoutRootsCapabilities`
- `testListRootsWithSpecificCursorAndNullCapabilities`

Each verifies the correct `IllegalStateException` is raised and that
`session.sendRequest(...)` is never invoked in these cases.

I audited all existing callers of `listRoots` in the repo (integration tests
in `AbstractMcpClientServerIntegrationTests`, and the roots-changed handler in
`McpAsyncServer`) — all already configure/assume roots capability, so this
change shouldn't affect existing behavior anywhere else in the codebase.
