### PR TITLE
Fix error behavior on unregistered handlers in stateless server handler

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/server/DefaultMcpStatelessServerHandler.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/server/DefaultMcpStatelessServerHandler.java
@@ -32,9 +32,9 @@ class DefaultMcpStatelessServerHandler implements McpStatelessServerHandler {
 			McpSchema.JSONRPCRequest request) {
 		McpStatelessRequestHandler<?> requestHandler = this.requestHandlers.get(request.method());
 		if (requestHandler == null) {
-			return Mono.error(McpError.builder(McpSchema.ErrorCodes.METHOD_NOT_FOUND)
-				.message("Missing handler for request type: " + request.method())
-				.build());
+			return Mono.just(new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), null,
+					new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.METHOD_NOT_FOUND,
+							"Method not found: " + request.method(), null)));
 		}
 		return requestHandler.handle(transportContext, request.params())
 			.map(result -> new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(), result, null))

--- a/mcp-core/src/test/java/io/modelcontextprotocol/server/DefaultMcpStatelessServerHandlerTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/server/DefaultMcpStatelessServerHandlerTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ */
+
+package io.modelcontextprotocol.server;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultMcpStatelessServerHandlerTests {
+
+	@Test
+	void testHandleRequestWithUnregisteredMethod() {
+		// no request/initialization handlers
+		DefaultMcpStatelessServerHandler handler = new DefaultMcpStatelessServerHandler(Collections.emptyMap(),
+				Collections.emptyMap());
+
+		// unregistered method
+		McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, "resources/list",
+				"test-id-123", null);
+
+		StepVerifier.create(handler.handleRequest(McpTransportContext.EMPTY, request)).assertNext(response -> {
+			assertThat(response).isNotNull();
+			assertThat(response.jsonrpc()).isEqualTo(McpSchema.JSONRPC_VERSION);
+			assertThat(response.id()).isEqualTo("test-id-123");
+			assertThat(response.result()).isNull();
+
+			assertThat(response.error()).isNotNull();
+			assertThat(response.error().code()).isEqualTo(McpSchema.ErrorCodes.METHOD_NOT_FOUND);
+			assertThat(response.error().message()).isEqualTo("Method not found: resources/list");
+		}).verifyComplete();
+	}
+
+}

--- a/mcp-test/src/test/java/io/modelcontextprotocol/server/HttpServletStatelessIntegrationTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/server/HttpServletStatelessIntegrationTests.java
@@ -650,6 +650,46 @@ class HttpServletStatelessIntegrationTests {
 		mcpServer.close();
 	}
 
+	@Test
+	void testMissingHandlerReturnsMethodNotFoundError() throws Exception {
+		var mcpServer = McpServer.sync(mcpStatelessServerTransport)
+			.serverInfo("test-server", "1.0.0")
+			.capabilities(ServerCapabilities.builder().tools(true).build())
+			.build();
+
+		// "server/discover" has no registered handler, and neither do the capabilities
+		// this server does not advertise
+		McpSchema.JSONRPCRequest jsonrpcRequest = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION,
+				"server/discover", "test", null);
+
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", CUSTOM_MESSAGE_ENDPOINT);
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		byte[] content = JSON_MAPPER.writeValueAsBytes(jsonrpcRequest);
+		request.setContent(content);
+		request.addHeader("Content-Length", Integer.toString(content.length));
+		request.addHeader("Accept", APPLICATION_JSON + ", " + TEXT_EVENT_STREAM);
+		request.addHeader("Content-Type", APPLICATION_JSON);
+		request.addHeader("Cache-Control", "no-cache");
+		request.addHeader(HttpHeaders.PROTOCOL_VERSION, ProtocolVersions.MCP_2025_03_26);
+
+		mcpStatelessServerTransport.service(request, response);
+
+		assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+
+		McpSchema.JSONRPCResponse jsonrpcResponse = JSON_MAPPER.readValue(response.getContentAsByteArray(),
+				McpSchema.JSONRPCResponse.class);
+
+		assertThat(jsonrpcResponse).isNotNull();
+		assertThat(jsonrpcResponse.id()).isEqualTo("test");
+		assertThat(jsonrpcResponse.result()).isNull();
+		assertThat(jsonrpcResponse.error()).isNotNull();
+		assertThat(jsonrpcResponse.error().code()).isEqualTo(ErrorCodes.METHOD_NOT_FOUND);
+		assertThat(jsonrpcResponse.error().message()).isEqualTo("Method not found: server/discover");
+
+		mcpServer.close();
+	}
+
 	// ---------------------------------------
 	// Bounded read
 	// ---------------------------------------


### PR DESCRIPTION
Forward-port of #1104 to the 1.1.x line.