### PR TITLE
docs(core): document String structuredContent parsing in JsonSchemaValidator

### DIFF
--- a/mcp-core/src/main/java/io/modelcontextprotocol/json/schema/JsonSchemaValidator.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/json/schema/JsonSchemaValidator.java
@@ -57,6 +57,11 @@ public interface JsonSchemaValidator {
 
 	/**
 	 * Validates the structured content against the provided JSON schema.
+	 * <p>
+	 * If {@code structuredContent} is a {@link String}, it is treated as a serialized
+	 * JSON document and parsed before validation; quote embedded strings accordingly (for
+	 * example {@code "\"red\""} for the JSON string value {@code red}). Any other type is
+	 * converted to its JSON representation directly.
 	 * @param schema The JSON schema to validate against.
 	 * @param structuredContent The structured content to validate.
 	 * @return A ValidationResponse indicating whether the validation was successful or


### PR DESCRIPTION
## What this change does

Adds the input-conversion contract of the `validate` method to the
`JsonSchemaValidator` interface Javadoc.

The method treats a `String` argument as a serialized JSON document and parses
it with `readTree` before validation. It converts any other type directly with
`valueToTree`. Both consequences follow for callers:

- To validate a root-level string, pass quoted JSON text: `"\"red\""`
  represents the value `red`.
- A bare string such as `red` reaches the parser as an unquoted token, and
  parsing fails with a message that mentions the tool JSON Schema, even though
  the schema is valid.

This contract exists identically in both implementations
(`mcp-json-jackson2` at line 70, `mcp-json-jackson3` at line 69). The interface
Javadoc did not state it before this change.

## Why

During output-schema validation testing, a root-level `enum` check failed in a
way that pointed at the schema parser rather than at caller-side string
handling. Tracing both default validators revealed the undocumented branch.
Documentation-only changes to a shared SPI carry no migration risk, and the
wording mirrors what the code does so future refactors can update one place.

## Testing

No production code changed. Before opening this pull request, I verified:

- `mcp-json-jackson3`: `DefaultJsonSchemaValidatorTests` passes, 40 of 40 tests
- `mcp-json-jackson2`: `DefaultJsonSchemaValidatorTests` passes, 40 of 40 tests
- `spring-javaformat:validate` passes for the touched module

## Notes for reviewers

If you prefer stronger ergonomics over pure documentation (for example, a
dedicated overload or a clearer parse-failure message), this wording still
stands on its own. Follow-up issues can adjust either message or API without
conflict. Known sharp edge, intentionally out of scope here: the
"Error parsing tool JSON Schema" prefix also appears when the *content* fails
to parse; existing test assertions pin that string in both modules.
