### PR TITLE
ci: add workflow_dispatch trigger to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request: {}
+  workflow_dispatch: {}
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch: {}` to `ci.yml` so contributors can manually run CI against a branch on their own fork before opening a PR.

## Context
Currently `ci.yml` only triggers on `pull_request`, so a fork branch can't be built by Actions until a PR already exists against this repo. `publish-snapshot.yml` (push-to-`main`) already provides post-merge signal and is a superset of `ci.yml`'s checks, so no change is needed there — this PR only addresses the pre-PR, contributor-facing gap.

Fixes #1116

## Test plan
- [x] YAML is valid (single-line addition to existing `on:` block)
- [ ] Confirm the "Run workflow" button appears for `CI` in Actions once this merges to `main`