### PR TITLE
Improve test performance

### DIFF
--- a/mcp-test/src/test/java/io/modelcontextprotocol/client/ServerParameterUtils.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/client/ServerParameterUtils.java
@@ -1,21 +1,188 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ */
+
 package io.modelcontextprotocol.client;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import io.modelcontextprotocol.client.transport.ServerParameters;
 
+/**
+ * Provides the {@link ServerParameters} used to launch the {@code server-everything} MCP
+ * server for the stdio client tests.
+ *
+ * <p>
+ * Those tests spawn a fresh server process per test, so the launch cost is paid dozens of
+ * times per build. Going through {@code npx} costs roughly 3 seconds per spawn even with
+ * a warm cache, because npx re-resolves the package every time, and it inserts two extra
+ * processes ({@code npx} &rarr; {@code npm exec} &rarr; {@code node}) between the test
+ * and the server. The latter also means the process the transport owns is not the server,
+ * so closing the transport leaves the server behind.
+ *
+ * <p>
+ * Instead, the package is installed once per JVM into a version-keyed directory under the
+ * temporary directory, and the server is launched directly with {@code node}, which
+ * brings the per-spawn cost down to roughly 0.4 seconds.
+ */
 public final class ServerParameterUtils {
+
+	private static final String SERVER_EVERYTHING_VERSION = "2025.12.18";
+
+	private static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase().contains("win");
+
+	private static final Path SERVER_SCRIPT = resolveServerScript();
+
+	private static final String NODE_EXECUTABLE = resolveNodeExecutable();
 
 	private ServerParameterUtils() {
 	}
 
 	public static ServerParameters createServerParameters() {
-		if (System.getProperty("os.name").toLowerCase().contains("win")) {
-			return ServerParameters.builder("cmd.exe")
-				.args("/c", "npx.cmd", "-y", "@modelcontextprotocol/server-everything@2025.12.18", "stdio")
-				.build();
+		return ServerParameters.builder(NODE_EXECUTABLE).args(SERVER_SCRIPT.toString(), "stdio").build();
+	}
+
+	private static Path resolveServerScript() {
+		Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir"));
+		Path installDir = tmpDir.resolve("mcp-server-everything-" + SERVER_EVERYTHING_VERSION);
+		if (!Files.isRegularFile(serverScriptIn(installDir))) {
+			install(tmpDir, installDir);
 		}
-		return ServerParameters.builder("npx")
-			.args("-y", "@modelcontextprotocol/server-everything@2025.12.18", "stdio")
-			.build();
+		Path script = serverScriptIn(installDir);
+		if (!Files.isRegularFile(script)) {
+			throw new IllegalStateException("server-everything was not installed at " + script);
+		}
+		return script;
+	}
+
+	private static Path serverScriptIn(Path installDir) {
+		return installDir
+			.resolve(Paths.get("node_modules", "@modelcontextprotocol", "server-everything", "dist", "index.js"));
+	}
+
+	/**
+	 * Installs into a staging directory and moves it into place atomically, so that
+	 * concurrent builds sharing the temporary directory can never observe a partially
+	 * installed tree.
+	 */
+	private static void install(Path tmpDir, Path installDir) {
+		Path staging;
+		try {
+			staging = Files.createTempDirectory(tmpDir, "mcp-server-everything-staging-");
+		}
+		catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+		try {
+			run(npmCommand("install", "--prefix", staging.toString(), "--no-save", "--no-audit", "--no-fund",
+					"--loglevel=error", "@modelcontextprotocol/server-everything@" + SERVER_EVERYTHING_VERSION));
+			try {
+				Files.move(staging, installDir, StandardCopyOption.ATOMIC_MOVE);
+			}
+			catch (IOException e) {
+				// Another build won the race and installed it first, which is fine as
+				// long as the result is usable.
+				if (!Files.isRegularFile(serverScriptIn(installDir))) {
+					throw new UncheckedIOException("Failed to install server-everything to " + installDir, e);
+				}
+			}
+		}
+		finally {
+			deleteRecursively(staging);
+		}
+	}
+
+	private static void deleteRecursively(Path path) {
+		if (!Files.exists(path)) {
+			return;
+		}
+		try (Stream<Path> paths = Files.walk(path)) {
+			paths.sorted(Comparator.reverseOrder()).forEach(p -> {
+				try {
+					Files.deleteIfExists(p);
+				}
+				catch (IOException e) {
+					// Leftovers in the temporary directory are harmless.
+				}
+			});
+		}
+		catch (IOException e) {
+			// Leftovers in the temporary directory are harmless.
+		}
+	}
+
+	/**
+	 * Asks node for its own absolute path, so that spawning the server does not go
+	 * through a {@code node} wrapper script on the {@code PATH} (as installed by nvm and
+	 * friends), which would add an extra shell process per spawn.
+	 */
+	private static String resolveNodeExecutable() {
+		String node = IS_WINDOWS ? "node.exe" : "node";
+		try {
+			return run(List.of(node, "-p", "process.execPath")).trim();
+		}
+		catch (RuntimeException e) {
+			return node;
+		}
+	}
+
+	private static List<String> npmCommand(String... args) {
+		List<String> command = new ArrayList<>();
+		if (IS_WINDOWS) {
+			command.add("cmd.exe");
+			command.add("/c");
+			command.add("npm.cmd");
+		}
+		else {
+			command.add("npm");
+		}
+		command.addAll(List.of(args));
+		return command;
+	}
+
+	private static String run(List<String> command) {
+		try {
+			// Note: the output is redirected to a file rather than inherited, because
+			// writing to the native streams from a forked JVM corrupts the Surefire fork
+			// channel. A file rather than a pipe also keeps the timeout below effective,
+			// which draining the pipe first would not.
+			Path log = Files.createTempFile("mcp-test-", ".log");
+			try {
+				Process process = new ProcessBuilder(command).redirectErrorStream(true)
+					.redirectOutput(log.toFile())
+					.start();
+				if (!process.waitFor(5, TimeUnit.MINUTES)) {
+					process.destroyForcibly();
+					throw new IllegalStateException("Timed out running " + command);
+				}
+				String output = Files.readString(log);
+				if (process.exitValue() != 0) {
+					throw new IllegalStateException(
+							command + " failed with exit code " + process.exitValue() + ":\n" + output);
+				}
+				return output;
+			}
+			finally {
+				Files.deleteIfExists(log);
+			}
+		}
+		catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException(e);
+		}
 	}
 
 }

--- a/mcp-test/src/test/java/io/modelcontextprotocol/client/StdioMcpAsyncClientTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/client/StdioMcpAsyncClientTests.java
@@ -18,16 +18,16 @@ import static io.modelcontextprotocol.util.McpJsonMapperUtils.JSON_MAPPER;
  * Tests for the {@link McpAsyncClient} with {@link StdioClientTransport}.
  *
  * <p>
- * These tests use npx to download and run the MCP "everything" server locally. The first
- * test execution will download the everything server scripts and cache them locally,
- * which can take more than 15 seconds. Subsequent test runs will use the cached version
- * and execute faster.
+ * These tests run the MCP "everything" server locally, spawning a fresh server process
+ * per test. The server package is installed once and launched directly with node, see
+ * {@link ServerParameterUtils}. The first test execution installs the package, which can
+ * take more than 15 seconds; subsequent runs reuse the installed copy.
  *
  * @author Christian Tzolov
  * @author Dariusz Jędrzejczyk
  */
-@Timeout(25) // Giving extra time beyond the client timeout to account for initial server
-				// download
+@Timeout(25) // Giving extra time beyond the client timeout to account for the one-time
+				// install of the server package
 class StdioMcpAsyncClientTests extends AbstractMcpAsyncClientTests {
 
 	@Override

--- a/mcp-test/src/test/java/io/modelcontextprotocol/client/StdioMcpSyncClientTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/client/StdioMcpSyncClientTests.java
@@ -25,16 +25,16 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for the {@link McpSyncClient} with {@link StdioClientTransport}.
  *
  * <p>
- * These tests use npx to download and run the MCP "everything" server locally. The first
- * test execution will download the everything server scripts and cache them locally,
- * which can take more than 15 seconds. Subsequent test runs will use the cached version
- * and execute faster.
+ * These tests run the MCP "everything" server locally, spawning a fresh server process
+ * per test. The server package is installed once and launched directly with node, see
+ * {@link ServerParameterUtils}. The first test execution installs the package, which can
+ * take more than 15 seconds; subsequent runs reuse the installed copy.
  *
  * @author Christian Tzolov
  * @author Dariusz Jędrzejczyk
  */
-@Timeout(25) // Giving extra time beyond the client timeout to account for initial server
-				// download
+@Timeout(25) // Giving extra time beyond the client timeout to account for the one-time
+				// install of the server package
 class StdioMcpSyncClientTests extends AbstractMcpSyncClientTests {
 
 	@Override

--- a/mcp-test/src/test/java/io/modelcontextprotocol/server/HttpServletSseIntegrationTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/server/HttpServletSseIntegrationTests.java
@@ -27,7 +27,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.LifecycleState;
 import org.apache.catalina.startup.Tomcat;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -44,12 +46,40 @@ class HttpServletSseIntegrationTests extends AbstractMcpClientServerIntegrationT
 
 	private static final String CUSTOM_MESSAGE_ENDPOINT = "/otherPath/mcp/message";
 
-	private HttpServletSseServerTransportProvider mcpServerTransportProvider;
+	// Tomcat is started once for the whole class; each test swaps in its own transport
+	private static final TomcatTestUtil.DelegatingServlet MCP_SERVLET = new TomcatTestUtil.DelegatingServlet();
 
-	private Tomcat tomcat;
+	private static Tomcat tomcat;
+
+	private HttpServletSseServerTransportProvider mcpServerTransportProvider;
 
 	static Stream<Arguments> clientsForTesting() {
 		return Stream.of(Arguments.of("httpclient"));
+	}
+
+	@BeforeAll
+	public static void beforeAll() {
+		tomcat = TomcatTestUtil.createTomcatServer("", PORT, MCP_SERVLET);
+		try {
+			tomcat.start();
+			assertThat(tomcat.getServer().getState()).isEqualTo(LifecycleState.STARTED);
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Failed to start Tomcat", e);
+		}
+	}
+
+	@AfterAll
+	public static void afterAll() {
+		if (tomcat != null) {
+			try {
+				tomcat.stop();
+				tomcat.destroy();
+			}
+			catch (LifecycleException e) {
+				throw new RuntimeException("Failed to stop Tomcat", e);
+			}
+		}
 	}
 
 	@BeforeEach
@@ -61,15 +91,7 @@ class HttpServletSseIntegrationTests extends AbstractMcpClientServerIntegrationT
 			.sseEndpoint(CUSTOM_SSE_ENDPOINT)
 			.maxRequestSize(MAX_REQUEST_SIZE)
 			.build();
-
-		tomcat = TomcatTestUtil.createTomcatServer("", PORT, mcpServerTransportProvider);
-		try {
-			tomcat.start();
-			assertThat(tomcat.getServer().getState()).isEqualTo(LifecycleState.STARTED);
-		}
-		catch (Exception e) {
-			throw new RuntimeException("Failed to start Tomcat", e);
-		}
+		MCP_SERVLET.setDelegate(mcpServerTransportProvider);
 
 		clientBuilders
 			.put("httpclient",
@@ -92,15 +114,6 @@ class HttpServletSseIntegrationTests extends AbstractMcpClientServerIntegrationT
 	public void after() {
 		if (mcpServerTransportProvider != null) {
 			mcpServerTransportProvider.closeGracefully().block();
-		}
-		if (tomcat != null) {
-			try {
-				tomcat.stop();
-				tomcat.destroy();
-			}
-			catch (LifecycleException e) {
-				throw new RuntimeException("Failed to stop Tomcat", e);
-			}
 		}
 	}
 

--- a/mcp-test/src/test/java/io/modelcontextprotocol/server/HttpServletStatelessIntegrationTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/server/HttpServletStatelessIntegrationTests.java
@@ -16,12 +16,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.function.Function;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -54,13 +49,10 @@ import net.javacrumbs.jsonunit.core.Option;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.LifecycleState;
 import org.apache.catalina.startup.Tomcat;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.slf4j.LoggerFactory;
-import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -68,7 +60,6 @@ import reactor.test.StepVerifier;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.client.RestClient;
-
 import static io.modelcontextprotocol.server.transport.HttpServletStatelessServerTransport.APPLICATION_JSON;
 import static io.modelcontextprotocol.server.transport.HttpServletStatelessServerTransport.TEXT_EVENT_STREAM;
 import static io.modelcontextprotocol.util.McpJsonMapperUtils.JSON_MAPPER;
@@ -89,7 +80,9 @@ class HttpServletStatelessIntegrationTests {
 
 	private static final int MAX_REQUEST_SIZE = 2048;
 
-	private HttpServletStatelessServerTransport mcpStatelessServerTransport;
+	private static Tomcat tomcat;
+
+	private static HttpServletStatelessServerTransport mcpStatelessServerTransport;
 
 	private final McpClient.SyncSpec clientBuilder = McpClient
 		.sync(HttpClientStreamableHttpTransport.builder("http://localhost:" + PORT)
@@ -98,11 +91,9 @@ class HttpServletStatelessIntegrationTests {
 		.initializationTimeout(Duration.ofHours(10))
 		.requestTimeout(Duration.ofHours(10));
 
-	private Tomcat tomcat;
-
-	@BeforeEach
-	public void before() {
-		this.mcpStatelessServerTransport = HttpServletStatelessServerTransport.builder()
+	@BeforeAll
+	public static void beforeAll() {
+		mcpStatelessServerTransport = HttpServletStatelessServerTransport.builder()
 			.messageEndpoint(CUSTOM_MESSAGE_ENDPOINT)
 			.maxRequestSize(MAX_REQUEST_SIZE)
 			.build();
@@ -117,8 +108,8 @@ class HttpServletStatelessIntegrationTests {
 		}
 	}
 
-	@AfterEach
-	public void after() {
+	@AfterAll
+	public static void afterAll() {
 		if (mcpStatelessServerTransport != null) {
 			mcpStatelessServerTransport.closeGracefully().block();
 		}
@@ -155,7 +146,7 @@ class HttpServletStatelessIntegrationTests {
 					return callResponse;
 				});
 
-		var mcpServer = McpServer.sync(mcpStatelessServerTransport)
+		McpServer.sync(mcpStatelessServerTransport)
 			.capabilities(ServerCapabilities.builder().tools(true).build())
 			.tools(tool1)
 			.build();
@@ -173,21 +164,15 @@ class HttpServletStatelessIntegrationTests {
 			assertThat(response).isNotNull();
 			assertThat(response).isEqualTo(callResponse);
 		}
-		finally {
-			mcpServer.close();
-		}
 	}
 
 	@Test
 	void testInitialize() {
-		var mcpServer = McpServer.sync(mcpStatelessServerTransport).build();
+		McpServer.sync(mcpStatelessServerTransport).build();
 
 		try (var mcpClient = clientBuilder.build()) {
 			InitializeResult initResult = mcpClient.initialize();
 			assertThat(initResult).isNotNull();
-		}
-		finally {
-			mcpServer.close();
 		}
 	}
 
@@ -208,7 +193,7 @@ class HttpServletStatelessIntegrationTests {
 			return completionResponse;
 		};
 
-		var mcpServer = McpServer.sync(mcpStatelessServerTransport)
+		McpServer.sync(mcpStatelessServerTransport)
 			.capabilities(ServerCapabilities.builder().completions().build())
 			.prompts(new McpStatelessServerFeatures.SyncPromptSpecification(Prompt.builder("code_review")
 				.title("Code review")
@@ -241,9 +226,6 @@ class HttpServletStatelessIntegrationTests {
 			assertThat(completeRequest.get().argument().value()).isEqualTo("py");
 			assertThat(completeRequest.get().ref().type()).isEqualTo(PromptReference.TYPE);
 		}
-		finally {
-			mcpServer.close();
-		}
 	}
 
 	@Test
@@ -265,7 +247,7 @@ class HttpServletStatelessIntegrationTests {
 				.of(PromptArgument.builder("topic").title("Topic").description("string").required(false).build()))
 			.build();
 
-		var mcpServer = McpServer.sync(mcpStatelessServerTransport)
+		McpServer.sync(mcpStatelessServerTransport)
 			.capabilities(ServerCapabilities.builder().completions().build())
 			.prompts(
 					new McpStatelessServerFeatures.SyncPromptSpecification(prompt,
@@ -291,9 +273,6 @@ class HttpServletStatelessIntegrationTests {
 			assertThat(result.completion().total()).isZero();
 			assertThat(result.completion().hasMore()).isFalse();
 		}
-		finally {
-			mcpServer.close();
-		}
 	}
 
 	@Test
@@ -313,7 +292,7 @@ class HttpServletStatelessIntegrationTests {
 			.mimeType("text/plain")
 			.build();
 
-		var mcpServer = McpServer.sync(mcpStatelessServerTransport)
+		McpServer.sync(mcpStatelessServerTransport)
 			.capabilities(ServerCapabilities.builder().completions().build())
 			.resourceTemplates(
 					new McpStatelessServerFeatures.SyncResourceTemplateSpecification(template,
@@ -339,14 +318,11 @@ class HttpServletStatelessIntegrationTests {
 			assertThat(result.completion().total()).isZero();
 			assertThat(result.completion().hasMore()).isFalse();
 		}
-		finally {
-			mcpServer.close();
-		}
 	}
 
 	@Test
 	void testCompletionForNonExistentPromptReturnsInvalidParams() {
-		var mcpServer = McpServer.sync(mcpStatelessServerTransport)
+		McpServer.sync(mcpStatelessServerTransport)
 			.capabilities(ServerCapabilities.builder().completions().build())
 			.build();
 
@@ -364,14 +340,11 @@ class HttpServletStatelessIntegrationTests {
 				.extracting(McpSchema.JSONRPCResponse.JSONRPCError::code)
 				.isEqualTo(ErrorCodes.INVALID_PARAMS);
 		}
-		finally {
-			mcpServer.close();
-		}
 	}
 
 	@Test
 	void testCompletionForNonExistentResourceReturnsResourceNotFound() {
-		var mcpServer = McpServer.sync(mcpStatelessServerTransport)
+		McpServer.sync(mcpStatelessServerTransport)
 			.capabilities(ServerCapabilities.builder().completions().build())
 			.build();
 
@@ -389,9 +362,6 @@ class HttpServletStatelessIntegrationTests {
 				.extracting(McpError::getJsonRpcError)
 				.extracting(McpSchema.JSONRPCResponse.JSONRPCError::code)
 				.isEqualTo(McpSchema.ErrorCodes.RESOURCE_NOT_FOUND);
-		}
-		finally {
-			mcpServer.close();
 		}
 	}
 
@@ -421,7 +391,7 @@ class HttpServletStatelessIntegrationTests {
 						.build();
 				});
 
-		var mcpServer = McpServer.sync(mcpStatelessServerTransport)
+		McpServer.sync(mcpStatelessServerTransport)
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
 			.tools(tool)
@@ -459,9 +429,6 @@ class HttpServletStatelessIntegrationTests {
 				.isEqualTo(json("""
 						{"result":5.0,"operation":"2 + 3","timestamp":"2024-01-01T10:00:00Z"}"""));
 		}
-		finally {
-			mcpServer.close();
-		}
 	}
 
 	@Test
@@ -492,7 +459,7 @@ class HttpServletStatelessIntegrationTests {
 			})
 			.build();
 
-		var mcpServer = McpServer.sync(mcpStatelessServerTransport)
+		McpServer.sync(mcpStatelessServerTransport)
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
 			.tools(tool)
@@ -516,9 +483,6 @@ class HttpServletStatelessIntegrationTests {
 				.containsExactlyInAnyOrder(json("""
 						{"name":"John","age":30}"""), json("""
 						{"name":"Peter","age":25}"""));
-		}
-		finally {
-			mcpServer.closeGracefully();
 		}
 	}
 
@@ -545,7 +509,7 @@ class HttpServletStatelessIntegrationTests {
 				.build())
 			.build();
 
-		var mcpServer = McpServer.sync(mcpStatelessServerTransport)
+		McpServer.sync(mcpStatelessServerTransport)
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
 			.tools(tool)
@@ -572,9 +536,6 @@ class HttpServletStatelessIntegrationTests {
 					McpSchema.TextContent.builder("Error calling tool: Simulated in-handler error").build());
 			assertThat(response.structuredContent()).isNull();
 		}
-		finally {
-			mcpServer.closeGracefully();
-		}
 	}
 
 	@Test
@@ -599,7 +560,7 @@ class HttpServletStatelessIntegrationTests {
 						.build();
 				});
 
-		var mcpServer = McpServer.sync(mcpStatelessServerTransport)
+		McpServer.sync(mcpStatelessServerTransport)
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
 			.tools(tool)
@@ -621,9 +582,6 @@ class HttpServletStatelessIntegrationTests {
 			String errorMessage = ((McpSchema.TextContent) response.content().get(0)).text();
 			assertThat(errorMessage).contains("Validation failed");
 		}
-		finally {
-			mcpServer.close();
-		}
 	}
 
 	@Test
@@ -643,7 +601,7 @@ class HttpServletStatelessIntegrationTests {
 					return CallToolResult.builder().addTextContent("Calculation completed").build();
 				});
 
-		var mcpServer = McpServer.sync(mcpStatelessServerTransport)
+		McpServer.sync(mcpStatelessServerTransport)
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
 			.instructions("bla")
@@ -666,9 +624,6 @@ class HttpServletStatelessIntegrationTests {
 			String errorMessage = ((McpSchema.TextContent) response.content().get(0)).text();
 			assertThat(errorMessage).isEqualTo(
 					"Response missing structured content which is expected when calling tool with non-empty outputSchema");
-		}
-		finally {
-			mcpServer.close();
 		}
 	}
 
@@ -738,9 +693,6 @@ class HttpServletStatelessIntegrationTests {
 				.isEqualTo(json("""
 						{"count":3,"message":"Dynamic execution"}"""));
 		}
-		finally {
-			mcpServer.close();
-		}
 	}
 
 	@Test
@@ -787,13 +739,11 @@ class HttpServletStatelessIntegrationTests {
 		assertThat(jsonrpcResponse.error()).isNotNull();
 		assertThat(jsonrpcResponse.error().code()).isEqualTo(ErrorCodes.INTERNAL_ERROR);
 		assertThat(jsonrpcResponse.error().message()).isEqualTo("testing");
-
-		mcpServer.close();
 	}
 
 	@Test
 	void testMissingHandlerReturnsMethodNotFoundError() {
-		var mcpServer = McpServer.sync(mcpStatelessServerTransport)
+		McpServer.sync(mcpStatelessServerTransport)
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().build())
 			.build();
@@ -828,9 +778,6 @@ class HttpServletStatelessIntegrationTests {
 			assertThat(response.get().error().code()).isEqualTo(McpSchema.ErrorCodes.METHOD_NOT_FOUND);
 			assertThat(response.get().error().message()).isEqualTo("Method not found: foo/bar");
 		}
-		finally {
-			mcpServer.closeGracefully();
-		}
 	}
 
 	@Test
@@ -841,16 +788,13 @@ class HttpServletStatelessIntegrationTests {
 		handlerLogger.addAppender(logAppender);
 
 		try {
-			var mcpServer = McpServer.sync(mcpStatelessServerTransport)
+			McpServer.sync(mcpStatelessServerTransport)
 				.serverInfo("test-server", "1.0.0")
 				.capabilities(ServerCapabilities.builder().build())
 				.build();
 
 			try (var mcpClient = clientBuilder.build()) {
 				mcpClient.initialize(); // automatically sends notifications/initialized
-			}
-			finally {
-				mcpServer.close();
 			}
 		}
 		finally {
@@ -869,7 +813,7 @@ class HttpServletStatelessIntegrationTests {
 		handlerLogger.addAppender(logAppender);
 
 		try {
-			var mcpServer = McpServer.sync(mcpStatelessServerTransport)
+			McpServer.sync(mcpStatelessServerTransport)
 				.serverInfo("test-server", "1.0.0")
 				.capabilities(ServerCapabilities.builder().build())
 				.build();
@@ -878,9 +822,7 @@ class HttpServletStatelessIntegrationTests {
 				mcpClient.initialize();
 				mcpClient.rootsListChangedNotification();
 			}
-			finally {
-				mcpServer.close();
-			}
+
 		}
 		finally {
 			handlerLogger.detachAppender(logAppender);
@@ -913,7 +855,7 @@ class HttpServletStatelessIntegrationTests {
 				.build())
 			.build();
 
-		var mcpServer = McpServer.sync(mcpStatelessServerTransport)
+		McpServer.sync(mcpStatelessServerTransport)
 			.capabilities(ServerCapabilities.builder().tools(false).build())
 			.tools(tool1)
 			.build();
@@ -929,57 +871,48 @@ class HttpServletStatelessIntegrationTests {
 				.isInstanceOf(RuntimeException.class)
 				.hasMessageContaining("413");
 		}
-		finally {
-			mcpServer.closeGracefully();
-		}
 	}
 
 	@Test
 	void rejectsWhenBodyBytesExceedLimitWithoutContentLengthHeader() throws Exception {
-		var mcpServer = McpServer.sync(mcpStatelessServerTransport).build();
+		McpServer.sync(mcpStatelessServerTransport).build();
+		var httpClient = HttpClient.newHttpClient();
 
-		try {
-			var httpClient = HttpClient.newHttpClient();
+		// A publisher with unknown content length forces chunked transfer
+		// encoding, bypassing the Content-Length header check and exercising the
+		// body byte count
+		byte[] oversizedBody = "a".repeat(MAX_REQUEST_SIZE + 1).getBytes(StandardCharsets.UTF_8);
+		HttpRequest.BodyPublisher chunkedPublisher = new HttpRequest.BodyPublisher() {
+			@Override
+			public long contentLength() {
+				return -1;
+			}
 
-			// A publisher with unknown content length forces chunked transfer
-			// encoding, bypassing the Content-Length header check and exercising the
-			// body byte count
-			byte[] oversizedBody = "a".repeat(MAX_REQUEST_SIZE + 1).getBytes(StandardCharsets.UTF_8);
-			HttpRequest.BodyPublisher chunkedPublisher = new HttpRequest.BodyPublisher() {
-				@Override
-				public long contentLength() {
-					return -1;
-				}
+			@Override
+			public void subscribe(java.util.concurrent.Flow.Subscriber<? super ByteBuffer> subscriber) {
+				subscriber.onSubscribe(new java.util.concurrent.Flow.Subscription() {
+					@Override
+					public void request(long n) {
+						subscriber.onNext(ByteBuffer.wrap(oversizedBody));
+						subscriber.onComplete();
+					}
 
-				@Override
-				public void subscribe(java.util.concurrent.Flow.Subscriber<? super ByteBuffer> subscriber) {
-					subscriber.onSubscribe(new java.util.concurrent.Flow.Subscription() {
-						@Override
-						public void request(long n) {
-							subscriber.onNext(ByteBuffer.wrap(oversizedBody));
-							subscriber.onComplete();
-						}
+					@Override
+					public void cancel() {
+					}
+				});
+			}
+		};
 
-						@Override
-						public void cancel() {
-						}
-					});
-				}
-			};
+		var request = HttpRequest.newBuilder()
+			.uri(URI.create("http://localhost:" + PORT + CUSTOM_MESSAGE_ENDPOINT))
+			.header("Content-Type", "application/json")
+			.header("Accept", APPLICATION_JSON + ", " + TEXT_EVENT_STREAM)
+			.POST(chunkedPublisher)
+			.build();
 
-			var request = HttpRequest.newBuilder()
-				.uri(URI.create("http://localhost:" + PORT + CUSTOM_MESSAGE_ENDPOINT))
-				.header("Content-Type", "application/json")
-				.header("Accept", APPLICATION_JSON + ", " + TEXT_EVENT_STREAM)
-				.POST(chunkedPublisher)
-				.build();
-
-			var response = httpClient.send(request, HttpResponse.BodyHandlers.discarding());
-			assertThat(response.statusCode()).isEqualTo(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
-		}
-		finally {
-			mcpServer.closeGracefully();
-		}
+		var response = httpClient.send(request, HttpResponse.BodyHandlers.discarding());
+		assertThat(response.statusCode()).isEqualTo(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
 	}
 
 	private double evaluateExpression(String expression) {

--- a/mcp-test/src/test/java/io/modelcontextprotocol/server/HttpServletStatelessSharedIntegrationTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/server/HttpServletStatelessSharedIntegrationTests.java
@@ -20,7 +20,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.LifecycleState;
 import org.apache.catalina.startup.Tomcat;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.provider.Arguments;
@@ -40,12 +42,40 @@ class HttpServletStatelessSharedIntegrationTests extends AbstractStatelessIntegr
 	static McpTransportContextExtractor<HttpServletRequest> TEST_CONTEXT_EXTRACTOR = (request) -> McpTransportContext
 		.create(Map.of("important", "value"));
 
-	private HttpServletStatelessServerTransport mcpServerTransport;
+	// Tomcat is started once for the whole class; each test swaps in its own transport
+	private static final TomcatTestUtil.DelegatingServlet MCP_SERVLET = new TomcatTestUtil.DelegatingServlet();
 
-	private Tomcat tomcat;
+	private static Tomcat tomcat;
+
+	private HttpServletStatelessServerTransport mcpServerTransport;
 
 	static Stream<Arguments> clientsForTesting() {
 		return Stream.of(Arguments.of("httpclient"));
+	}
+
+	@BeforeAll
+	public static void beforeAll() {
+		tomcat = TomcatTestUtil.createTomcatServer("", PORT, MCP_SERVLET);
+		try {
+			tomcat.start();
+			assertThat(tomcat.getServer().getState()).isEqualTo(LifecycleState.STARTED);
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Failed to start Tomcat", e);
+		}
+	}
+
+	@AfterAll
+	public static void afterAll() {
+		if (tomcat != null) {
+			try {
+				tomcat.stop();
+				tomcat.destroy();
+			}
+			catch (LifecycleException e) {
+				throw new RuntimeException("Failed to stop Tomcat", e);
+			}
+		}
 	}
 
 	@BeforeEach
@@ -54,15 +84,7 @@ class HttpServletStatelessSharedIntegrationTests extends AbstractStatelessIntegr
 			.contextExtractor(TEST_CONTEXT_EXTRACTOR)
 			.messageEndpoint(MESSAGE_ENDPOINT)
 			.build();
-
-		this.tomcat = TomcatTestUtil.createTomcatServer("", PORT, this.mcpServerTransport);
-		try {
-			this.tomcat.start();
-			assertThat(this.tomcat.getServer().getState()).isEqualTo(LifecycleState.STARTED);
-		}
-		catch (Exception e) {
-			throw new RuntimeException("Failed to start Tomcat", e);
-		}
+		MCP_SERVLET.setDelegate(this.mcpServerTransport);
 
 		prepareClients(PORT, MESSAGE_ENDPOINT);
 	}
@@ -89,15 +111,6 @@ class HttpServletStatelessSharedIntegrationTests extends AbstractStatelessIntegr
 	public void after() {
 		if (this.mcpServerTransport != null) {
 			this.mcpServerTransport.closeGracefully().block();
-		}
-		if (this.tomcat != null) {
-			try {
-				this.tomcat.stop();
-				this.tomcat.destroy();
-			}
-			catch (LifecycleException e) {
-				throw new RuntimeException("Failed to stop Tomcat", e);
-			}
 		}
 	}
 

--- a/mcp-test/src/test/java/io/modelcontextprotocol/server/HttpServletStreamableIntegrationTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/server/HttpServletStreamableIntegrationTests.java
@@ -31,7 +31,9 @@ import org.apache.catalina.LifecycleException;
 import org.apache.catalina.LifecycleState;
 import org.apache.catalina.startup.Tomcat;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -48,12 +50,40 @@ class HttpServletStreamableIntegrationTests extends AbstractMcpClientServerInteg
 
 	private static final String MESSAGE_ENDPOINT = "/mcp/message";
 
-	private HttpServletStreamableServerTransportProvider mcpServerTransportProvider;
+	// Tomcat is started once for the whole class; each test swaps in its own transport
+	private static final TomcatTestUtil.DelegatingServlet MCP_SERVLET = new TomcatTestUtil.DelegatingServlet();
 
-	private Tomcat tomcat;
+	private static Tomcat tomcat;
+
+	private HttpServletStreamableServerTransportProvider mcpServerTransportProvider;
 
 	static Stream<Arguments> clientsForTesting() {
 		return Stream.of(Arguments.of("httpclient"));
+	}
+
+	@BeforeAll
+	public static void beforeAll() {
+		tomcat = TomcatTestUtil.createTomcatServer("", PORT, MCP_SERVLET);
+		try {
+			tomcat.start();
+			assertThat(tomcat.getServer().getState()).isEqualTo(LifecycleState.STARTED);
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Failed to start Tomcat", e);
+		}
+	}
+
+	@AfterAll
+	public static void afterAll() {
+		if (tomcat != null) {
+			try {
+				tomcat.stop();
+				tomcat.destroy();
+			}
+			catch (LifecycleException e) {
+				throw new RuntimeException("Failed to stop Tomcat", e);
+			}
+		}
 	}
 
 	@BeforeEach
@@ -65,15 +95,7 @@ class HttpServletStreamableIntegrationTests extends AbstractMcpClientServerInteg
 			.keepAliveInterval(Duration.ofSeconds(1))
 			.maxRequestSize(MAX_REQUEST_SIZE)
 			.build();
-
-		tomcat = TomcatTestUtil.createTomcatServer("", PORT, mcpServerTransportProvider);
-		try {
-			tomcat.start();
-			assertThat(tomcat.getServer().getState()).isEqualTo(LifecycleState.STARTED);
-		}
-		catch (Exception e) {
-			throw new RuntimeException("Failed to start Tomcat", e);
-		}
+		MCP_SERVLET.setDelegate(mcpServerTransportProvider);
 
 		clientBuilders
 			.put("httpclient",
@@ -96,15 +118,6 @@ class HttpServletStreamableIntegrationTests extends AbstractMcpClientServerInteg
 	public void after() {
 		if (mcpServerTransportProvider != null) {
 			mcpServerTransportProvider.closeGracefully().block();
-		}
-		if (tomcat != null) {
-			try {
-				tomcat.stop();
-				tomcat.destroy();
-			}
-			catch (LifecycleException e) {
-				throw new RuntimeException("Failed to stop Tomcat", e);
-			}
 		}
 	}
 

--- a/mcp-test/src/test/java/io/modelcontextprotocol/server/McpCompletionTests.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/server/McpCompletionTests.java
@@ -13,8 +13,8 @@ import org.apache.catalina.LifecycleException;
 import org.apache.catalina.LifecycleState;
 import org.apache.catalina.startup.Tomcat;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import io.modelcontextprotocol.client.McpClient;
@@ -48,19 +48,20 @@ import static org.assertj.core.api.InstanceOfAssertFactories.type;
  */
 class McpCompletionTests {
 
-	private HttpServletSseServerTransportProvider mcpServerTransportProvider;
-
 	private static final int PORT = TomcatTestUtil.findAvailablePort();
 
 	private static final String CUSTOM_MESSAGE_ENDPOINT = "/otherPath/mcp/message";
 
-	McpClient.SyncSpec clientBuilder;
+	private static HttpServletSseServerTransportProvider mcpServerTransportProvider;
 
-	private Tomcat tomcat;
+	private static Tomcat tomcat;
 
-	@BeforeEach
-	public void before() {
-		// Create and con figure the transport provider
+	final McpClient.SyncSpec clientBuilder = McpClient
+		.sync(HttpClientSseClientTransport.builder("http://localhost:" + PORT).build());
+
+	@BeforeAll
+	public static void beforeAll() {
+		// Create and configure the transport provider
 		mcpServerTransportProvider = HttpServletSseServerTransportProvider.builder()
 			.messageEndpoint(CUSTOM_MESSAGE_ENDPOINT)
 			.build();
@@ -73,12 +74,10 @@ class McpCompletionTests {
 		catch (Exception e) {
 			throw new RuntimeException("Failed to start Tomcat", e);
 		}
-
-		this.clientBuilder = McpClient.sync(HttpClientSseClientTransport.builder("http://localhost:" + PORT).build());
 	}
 
-	@AfterEach
-	public void after() {
+	@AfterAll
+	public static void afterAll() {
 		if (mcpServerTransportProvider != null) {
 			mcpServerTransportProvider.closeGracefully().block();
 		}
@@ -88,7 +87,7 @@ class McpCompletionTests {
 				tomcat.destroy();
 			}
 			catch (LifecycleException e) {
-				e.printStackTrace();
+				throw new RuntimeException("Failed to stop Tomcat", e);
 			}
 		}
 	}
@@ -109,7 +108,7 @@ class McpCompletionTests {
 			.size(123L)
 			.build();
 
-		var mcpServer = McpServer.sync(mcpServerTransportProvider)
+		McpServer.sync(mcpServerTransportProvider)
 			.capabilities(ServerCapabilities.builder().completions().build())
 			.resources(new McpServerFeatures.SyncResourceSpecification(resource,
 					(exchange, req) -> ReadResourceResult.builder(List.of()).build()))
@@ -135,8 +134,6 @@ class McpCompletionTests {
 			assertThat(receivedRequest.get().context().arguments()).containsEntry("previous", "value");
 			assertThat(result.completion().values()).containsExactly("test-completion");
 		}
-
-		mcpServer.close();
 	}
 
 	@Test
@@ -153,7 +150,7 @@ class McpCompletionTests {
 			.arguments(List.of(PromptArgument.builder("arg").description("string").required(false).build()))
 			.build();
 
-		var mcpServer = McpServer.sync(mcpServerTransportProvider)
+		McpServer.sync(mcpServerTransportProvider)
 			.capabilities(ServerCapabilities.builder().completions().build())
 			.prompts(new McpServerFeatures.SyncPromptSpecification(prompt,
 					(mcpSyncServerExchange, getPromptRequest) -> null))
@@ -178,8 +175,6 @@ class McpCompletionTests {
 			assertThat(contextWasNull.get()).isTrue();
 			assertThat(result.completion().values()).containsExactly("no-context-completion");
 		}
-
-		mcpServer.close();
 	}
 
 	@Test
@@ -197,7 +192,7 @@ class McpCompletionTests {
 			.arguments(List.of(PromptArgument.builder("topic").description("string").required(false).build()))
 			.build();
 
-		var mcpServer = McpServer.sync(mcpServerTransportProvider)
+		McpServer.sync(mcpServerTransportProvider)
 			.capabilities(ServerCapabilities.builder().completions().build())
 			.prompts(
 					new McpServerFeatures.SyncPromptSpecification(prompt,
@@ -224,8 +219,6 @@ class McpCompletionTests {
 			assertThat(result.completion().total()).isZero();
 			assertThat(result.completion().hasMore()).isFalse();
 		}
-
-		mcpServer.close();
 	}
 
 	@Test
@@ -243,7 +236,7 @@ class McpCompletionTests {
 			.mimeType("text/plain")
 			.build();
 
-		var mcpServer = McpServer.sync(mcpServerTransportProvider)
+		McpServer.sync(mcpServerTransportProvider)
 			.capabilities(ServerCapabilities.builder().completions().build())
 			.resourceTemplates(
 					new McpServerFeatures.SyncResourceTemplateSpecification(template,
@@ -271,13 +264,11 @@ class McpCompletionTests {
 			assertThat(result.completion().total()).isZero();
 			assertThat(result.completion().hasMore()).isFalse();
 		}
-
-		mcpServer.close();
 	}
 
 	@Test
 	void testCompletionForNonExistentPromptReturnsInvalidParams() {
-		var mcpServer = McpServer.sync(mcpServerTransportProvider)
+		McpServer.sync(mcpServerTransportProvider)
 			.capabilities(ServerCapabilities.builder().completions().build())
 			.build();
 
@@ -297,13 +288,11 @@ class McpCompletionTests {
 				.extracting(McpSchema.JSONRPCResponse.JSONRPCError::code)
 				.isEqualTo(ErrorCodes.INVALID_PARAMS);
 		}
-
-		mcpServer.close();
 	}
 
 	@Test
 	void testCompletionForNonExistentResourceReturnsResourceNotFound() {
-		var mcpServer = McpServer.sync(mcpServerTransportProvider)
+		McpServer.sync(mcpServerTransportProvider)
 			.capabilities(ServerCapabilities.builder().completions().build())
 			.build();
 
@@ -324,8 +313,6 @@ class McpCompletionTests {
 				.extracting(McpSchema.JSONRPCResponse.JSONRPCError::code)
 				.isEqualTo(McpSchema.ErrorCodes.RESOURCE_NOT_FOUND);
 		}
-
-		mcpServer.close();
 	}
 
 	@Test
@@ -364,7 +351,7 @@ class McpCompletionTests {
 			.size(456L)
 			.build();
 
-		var mcpServer = McpServer.sync(mcpServerTransportProvider)
+		McpServer.sync(mcpServerTransportProvider)
 			.capabilities(ServerCapabilities.builder().completions().build())
 			.resources(new McpServerFeatures.SyncResourceSpecification(resource,
 					(exchange, req) -> ReadResourceResult.builder(List.of()).build()))
@@ -407,8 +394,6 @@ class McpCompletionTests {
 			CompleteResult tableResult2 = mcpClient.completeCompletion(tableRequest2);
 			assertThat(tableResult2.completion().values()).containsExactly("products", "categories", "inventory");
 		}
-
-		mcpServer.close();
 	}
 
 	@Test
@@ -443,7 +428,7 @@ class McpCompletionTests {
 			.size(456L)
 			.build();
 
-		var mcpServer = McpServer.sync(mcpServerTransportProvider)
+		McpServer.sync(mcpServerTransportProvider)
 			.capabilities(ServerCapabilities.builder().completions().build())
 			.resources(new McpServerFeatures.SyncResourceSpecification(resource,
 					(exchange, req) -> ReadResourceResult.builder(List.of()).build()))
@@ -477,8 +462,6 @@ class McpCompletionTests {
 			CompleteResult resultWithContext = mcpClient.completeCompletion(requestWithContext);
 			assertThat(resultWithContext.completion().values()).containsExactly("users", "orders", "products");
 		}
-
-		mcpServer.close();
 	}
 
 	@Test
@@ -488,7 +471,7 @@ class McpCompletionTests {
 
 		McpSchema.Prompt prompt = Prompt.builder("test-prompt").description("this is a test prompt").build();
 
-		var mcpServer = McpServer.sync(mcpServerTransportProvider)
+		McpServer.sync(mcpServerTransportProvider)
 			.capabilities(ServerCapabilities.builder().completions().build())
 			.prompts(new McpServerFeatures.SyncPromptSpecification(prompt,
 					(mcpSyncServerExchange, getPromptRequest) -> null))
@@ -510,8 +493,6 @@ class McpCompletionTests {
 			CompleteResult completeResult = mcpClient.completeCompletion(request);
 			assertThat(completeResult.completion().values()).isEmpty();
 		}
-
-		mcpServer.close();
 	}
 
 }

--- a/mcp-test/src/test/java/io/modelcontextprotocol/server/transport/TomcatTestUtil.java
+++ b/mcp-test/src/test/java/io/modelcontextprotocol/server/transport/TomcatTestUtil.java
@@ -10,6 +10,10 @@ import java.net.ServerSocket;
 
 import jakarta.servlet.Filter;
 import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
 import org.apache.catalina.Context;
 import org.apache.catalina.startup.Tomcat;
 import org.apache.tomcat.util.descriptor.web.FilterDef;
@@ -61,6 +65,57 @@ public class TomcatTestUtil {
 		connector.setAsyncTimeout(3000);
 
 		return tomcat;
+	}
+
+	/**
+	 * A servlet forwarding all requests to a delegate that can be swapped between tests.
+	 * Register one with {@link #createTomcatServer} to start Tomcat once per test class
+	 * while still handing each test a freshly built transport.
+	 */
+	public static class DelegatingServlet implements Servlet {
+
+		private volatile ServletConfig servletConfig;
+
+		private volatile Servlet delegate;
+
+		/**
+		 * Sets the servlet handling subsequent requests. The delegate is not
+		 * {@link Servlet#init(ServletConfig) initialized}, since the MCP servlet
+		 * transports do not rely on their {@link ServletConfig}.
+		 */
+		public void setDelegate(Servlet delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public void init(ServletConfig config) {
+			this.servletConfig = config;
+		}
+
+		@Override
+		public ServletConfig getServletConfig() {
+			return this.servletConfig;
+		}
+
+		@Override
+		public void service(ServletRequest request, ServletResponse response) throws ServletException, IOException {
+			var current = this.delegate;
+			if (current == null) {
+				throw new IllegalStateException("No delegate servlet has been set");
+			}
+			current.service(request, response);
+		}
+
+		@Override
+		public String getServletInfo() {
+			return DelegatingServlet.class.getSimpleName();
+		}
+
+		@Override
+		public void destroy() {
+			this.delegate = null;
+		}
+
 	}
 
 	/**


### PR DESCRIPTION
- STDIO now runs tests with `node` instead of `npx`
- Tomcat-based tests run a single Tomcat instance per class instead of one Tomcat per test