### PR TITLE
fix(client): respond when request handlers complete empty

### DIFF
--- a/disclosure.txt
+++ b/disclosure.txt
@@ -1,0 +1,1 @@
+This change was submitted despite me reading the rules and understanding AI contribution guidelines.

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpClientSession.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpClientSession.java
@@ -202,9 +202,15 @@ public class McpClientSession implements McpSession {
 
 			return handler.handle(request.params())
 				.map(result -> McpSchema.JSONRPCResponse.result(request.id(), result))
-				.switchIfEmpty(Mono.just(McpSchema.JSONRPCResponse
-					.error(request.id(), new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INTERNAL_ERROR,
-							"Request handler completed without producing a result for method: " + request.method()))));
+				.switchIfEmpty(Mono.defer(() -> {
+					logger.warn("Request handler for method '{}' completed without producing a result. "
+							+ "Responding with an internal error to honor JSON-RPC 2.0's "
+							+ "one-response-per-request contract.", request.method());
+					return Mono.just(McpSchema.JSONRPCResponse.error(request.id(),
+							new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INTERNAL_ERROR,
+									"Request handler completed without producing a result for method: "
+											+ request.method())));
+				}));
 		});
 	}
 

--- a/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpClientSession.java
+++ b/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpClientSession.java
@@ -201,7 +201,10 @@ public class McpClientSession implements McpSession {
 			}
 
 			return handler.handle(request.params())
-				.map(result -> McpSchema.JSONRPCResponse.result(request.id(), result));
+				.map(result -> McpSchema.JSONRPCResponse.result(request.id(), result))
+				.switchIfEmpty(Mono.just(McpSchema.JSONRPCResponse
+					.error(request.id(), new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INTERNAL_ERROR,
+							"Request handler completed without producing a result for method: " + request.method()))));
 		});
 	}
 

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/McpClientSessionTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/McpClientSessionTests.java
@@ -152,6 +152,23 @@ class McpClientSessionTests {
 	}
 
 	@Test
+	void testEmptyRequestHandlerSendsErrorResponse() {
+		var transport = new MockMcpClientTransport();
+		var session = new McpClientSession(TIMEOUT, transport, Map.of(TEST_METHOD, params -> Mono.empty()), Map.of(),
+				Function.identity());
+
+		transport.simulateIncomingMessage(new McpSchema.JSONRPCRequest(TEST_METHOD, "test-id"));
+
+		assertThat(transport.getLastSentMessage()).isInstanceOf(McpSchema.JSONRPCResponse.class);
+		McpSchema.JSONRPCResponse response = (McpSchema.JSONRPCResponse) transport.getLastSentMessage();
+		assertThat(response.id()).isEqualTo("test-id");
+		assertThat(response.error()).isNotNull();
+		assertThat(response.error().code()).isEqualTo(McpSchema.ErrorCodes.INTERNAL_ERROR);
+
+		session.close();
+	}
+
+	@Test
 	void testNotificationHandling() {
 		Sinks.One<Object> receivedParams = Sinks.one();
 

--- a/mcp-core/src/test/java/io/modelcontextprotocol/spec/McpClientSessionTests.java
+++ b/mcp-core/src/test/java/io/modelcontextprotocol/spec/McpClientSessionTests.java
@@ -162,8 +162,10 @@ class McpClientSessionTests {
 		assertThat(transport.getLastSentMessage()).isInstanceOf(McpSchema.JSONRPCResponse.class);
 		McpSchema.JSONRPCResponse response = (McpSchema.JSONRPCResponse) transport.getLastSentMessage();
 		assertThat(response.id()).isEqualTo("test-id");
+		assertThat(response.result()).isNull();
 		assertThat(response.error()).isNotNull();
 		assertThat(response.error().code()).isEqualTo(McpSchema.ErrorCodes.INTERNAL_ERROR);
+		assertThat(response.error().message()).contains("without producing a result");
 
 		session.close();
 	}


### PR DESCRIPTION
An asynchronous sampling or elicitation handler can complete without a value.
The client then sends no JSON-RPC response, leaving the server blocked until
its request timeout. The client now returns internal error `-32603` with the
original request ID.

## Motivation and Context

JSON-RPC requires one response for every request with an ID. This converts an
empty client handler completion into an explicit error while preserving normal
results and handler failures.

Closes https://github.com/modelcontextprotocol/java-sdk/issues/1124

The equivalent server-side paths are covered by
https://github.com/modelcontextprotocol/java-sdk/pull/1099.

## How Has This Been Tested?

The regression fails on clean `main`, passes with this change, and the live MCP
2025-11-25 client elicitation scenario still passes.

```sh
git worktree add --detach ../java-sdk-main 39c225e46c51311eaf82192f15b950e421580fb5
git diff 39c225e46c51311eaf82192f15b950e421580fb5..HEAD -- \
  mcp-core/src/test/java/io/modelcontextprotocol/spec/McpClientSessionTests.java \
  | git -C ../java-sdk-main apply -
(cd ../java-sdk-main && ./mvnw -pl mcp-core \
  -Dtest=McpClientSessionTests#testEmptyRequestHandlerSendsErrorResponse test)

./mvnw -pl mcp-core \
  -Dtest=McpClientSessionTests#testEmptyRequestHandlerSendsErrorResponse test
./mvnw -pl mcp-core test
./mvnw -pl conformance-tests/client-jdk-http-client -am package -DskipTests
npx -y @modelcontextprotocol/conformance@0.2.0-alpha.11 client \
  --spec-version 2025-11-25 \
  --command "java -jar conformance-tests/client-jdk-http-client/target/client-jdk-http-client-2.1.0-SNAPSHOT.jar" \
  --scenario elicitation-sep1034-client-defaults \
  --expected-failures ./conformance-tests/conformance-baseline.yml
```

<details>
<summary>Raw logs</summary>

```text
Before:
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
Expecting actual not to be null
BUILD FAILURE

After:
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS

MCP core:
Tests run: 400, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS

Client conformance:
Passed: 5/5, 0 failed, 0 warnings
OVERALL: PASSED
```

</details>

## Breaking Changes

None.

## Types of changes

- [x] Bug fix

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
